### PR TITLE
fix: add auth.users trigger to fix Supabase registration error

### DIFF
--- a/supabase-schema.sql
+++ b/supabase-schema.sql
@@ -95,7 +95,47 @@ COMMENT ON TABLE feedbacks IS 'Tabla de feedback de la comunidad sobre temas de 
 COMMENT ON TABLE comments IS 'Tabla de comentarios de la comunidad';
 
 -- Datos de ejemplo (opcional)
-INSERT INTO usuarios (nombre, email, rol) VALUES 
+INSERT INTO usuarios (nombre, email, rol) VALUES
   ('Steven Ayala', 'steven@aiquaa.com', 'admin'),
   ('Usuario Ejemplo', 'usuario@ejemplo.com', 'comunidad')
-ON CONFLICT (email) DO NOTHING; 
+ON CONFLICT (email) DO NOTHING;
+
+-- =====================================================
+-- TRIGGER: Sincronizar auth.users → public.usuarios
+-- =====================================================
+-- Este trigger es NECESARIO para que el registro con Supabase Auth funcione.
+-- Sin este trigger, si existe cualquier otro trigger roto en auth.users,
+-- Supabase retorna "Database error saving new user".
+--
+-- PASOS PARA APLICAR EN EL SQL EDITOR DE SUPABASE:
+-- 1. Primero verificar si existe un trigger roto:
+--    SELECT * FROM information_schema.triggers
+--    WHERE event_object_schema = 'auth' AND event_object_table = 'users';
+--
+-- 2. Si existe un trigger con errores, eliminarlo:
+--    DROP TRIGGER IF EXISTS on_auth_user_created ON auth.users;
+--    DROP FUNCTION IF EXISTS public.handle_new_user();
+--
+-- 3. Ejecutar el bloque de abajo para crear el trigger correcto.
+-- =====================================================
+
+-- Función que se ejecuta cuando un usuario se registra en Supabase Auth
+CREATE OR REPLACE FUNCTION public.handle_new_user()
+RETURNS TRIGGER AS $$
+BEGIN
+  INSERT INTO public.usuarios (email, nombre, rol)
+  VALUES (
+    NEW.email,
+    COALESCE(NEW.raw_user_meta_data->>'full_name', split_part(NEW.email, '@', 1)),
+    COALESCE(NEW.raw_user_meta_data->>'role', 'comunidad')
+  )
+  ON CONFLICT (email) DO NOTHING;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- Trigger que dispara la función después de cada nuevo usuario en auth.users
+DROP TRIGGER IF EXISTS on_auth_user_created ON auth.users;
+CREATE TRIGGER on_auth_user_created
+  AFTER INSERT ON auth.users
+  FOR EACH ROW EXECUTE FUNCTION public.handle_new_user(); 


### PR DESCRIPTION
Add handle_new_user trigger function that syncs newly created auth.users
rows into public.usuarios table. Without a working trigger, Supabase Auth
returns "Database error saving new user" when any trigger on auth.users fails.

Includes diagnostic steps to check/remove existing broken triggers before
applying the fix via Supabase SQL Editor.

https://claude.ai/code/session_01Gapg4nQCo2XuRYHHi7UELq