### PR TITLE
fix(auth): harden Supabase signup trigger and add diagnostic script

### DIFF
--- a/apps/frontend/scripts/diagnose-supabase-signup.mjs
+++ b/apps/frontend/scripts/diagnose-supabase-signup.mjs
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+import { createClient } from '@supabase/supabase-js';
+
+const SUPABASE_URL = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+const SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+if (!SUPABASE_URL || !SERVICE_ROLE_KEY) {
+  console.error('Faltan variables requeridas: SUPABASE_URL/NEXT_PUBLIC_SUPABASE_URL y SUPABASE_SERVICE_ROLE_KEY');
+  process.exit(1);
+}
+
+const supabase = createClient(SUPABASE_URL, SERVICE_ROLE_KEY, {
+  auth: { autoRefreshToken: false, persistSession: false },
+});
+
+const email = `signup_diagnostic_${Date.now()}@example.com`;
+const password = `Diag${Date.now()}Aa!`;
+
+console.log('🔎 Probando creación de usuario en Supabase Auth...');
+console.log(`Proyecto: ${SUPABASE_URL}`);
+console.log(`Email de prueba: ${email}`);
+
+const { data, error } = await supabase.auth.admin.createUser({
+  email,
+  password,
+  email_confirm: false,
+  user_metadata: {
+    full_name: 'Signup Diagnostic',
+    role: 'comunidad',
+  },
+});
+
+if (error) {
+  console.error('\n❌ Error al crear usuario');
+  console.error(`Mensaje: ${error.message}`);
+  console.error(`Status: ${error.status ?? 'N/A'}`);
+  if (error.message?.toLowerCase().includes('database error saving new user')) {
+    console.error('\n💡 Diagnóstico: hay un trigger/función en auth.users o una dependencia en public que está rompiendo el signup.');
+    console.error('   Ejecuta el bloque de reparación de supabase-schema.sql (handle_new_user + trigger on_auth_user_created).');
+  }
+  process.exit(2);
+}
+
+console.log(`\n✅ Usuario creado: ${data.user?.id}`);
+
+if (data.user?.id) {
+  const { error: deleteError } = await supabase.auth.admin.deleteUser(data.user.id);
+  if (deleteError) {
+    console.warn(`⚠️ No se pudo borrar el usuario de prueba ${data.user.id}: ${deleteError.message}`);
+  } else {
+    console.log('🧹 Usuario de prueba eliminado.');
+  }
+}
+
+console.log('\n✅ Diagnóstico completado.');

--- a/docs/SUPABASE_SIGNUP_DATABASE_ERROR_FIX.md
+++ b/docs/SUPABASE_SIGNUP_DATABASE_ERROR_FIX.md
@@ -1,0 +1,30 @@
+# Fix para "Database error saving new user" en Supabase Auth
+
+Este error suele aparecer cuando un trigger en `auth.users` falla al intentar sincronizar datos hacia tablas de `public`.
+
+## 1) Aplicar SQL de reparación
+
+En el SQL Editor de Supabase, ejecutá el bloque final de `supabase-schema.sql` (función `public.handle_new_user` y trigger `on_auth_user_created`).
+
+La versión actual está endurecida para **no romper el signup** si falla la sincronización de perfil:
+- ignora `email` nulo,
+- normaliza metadata vacía (`full_name`, `role`),
+- captura excepciones (`undefined_table` y `others`) y retorna `NEW`.
+
+## 2) Diagnosticar con script
+
+Desde `apps/frontend`:
+
+```bash
+SUPABASE_URL="https://TU-PROYECTO.supabase.co" \
+SUPABASE_SERVICE_ROLE_KEY="TU_SERVICE_ROLE_KEY" \
+node scripts/diagnose-supabase-signup.mjs
+```
+
+Si devuelve `Database error saving new user`, el script te indica revisar trigger/función.
+
+## 3) Verificación manual mínima
+
+- Intentá registro desde `/register`.
+- Confirmá que no aparece el error.
+- Revisá si el perfil quedó en `public.usuarios`.

--- a/supabase-schema.sql
+++ b/supabase-schema.sql
@@ -123,14 +123,27 @@ ON CONFLICT (email) DO NOTHING;
 CREATE OR REPLACE FUNCTION public.handle_new_user()
 RETURNS TRIGGER AS $$
 BEGIN
+  -- Nunca bloquear el alta en auth.users por fallas en la tabla de perfil.
+  IF NEW.email IS NULL THEN
+    RETURN NEW;
+  END IF;
+
   INSERT INTO public.usuarios (email, nombre, rol)
   VALUES (
     NEW.email,
-    COALESCE(NEW.raw_user_meta_data->>'full_name', split_part(NEW.email, '@', 1)),
-    COALESCE(NEW.raw_user_meta_data->>'role', 'comunidad')
+    COALESCE(NULLIF(NEW.raw_user_meta_data->>'full_name', ''), split_part(NEW.email, '@', 1)),
+    COALESCE(NULLIF(NEW.raw_user_meta_data->>'role', ''), 'comunidad')
   )
   ON CONFLICT (email) DO NOTHING;
+
   RETURN NEW;
+EXCEPTION
+  WHEN undefined_table THEN
+    RAISE WARNING 'public.handle_new_user: tabla public.usuarios no existe. auth.users continuará. id=%', NEW.id;
+    RETURN NEW;
+  WHEN others THEN
+    RAISE WARNING 'public.handle_new_user: error sincronizando perfil para auth.users.id=%: %', NEW.id, SQLERRM;
+    RETURN NEW;
 END;
 $$ LANGUAGE plpgsql SECURITY DEFINER;
 


### PR DESCRIPTION
### Motivation
- Evitar que fallas en triggers o dependencias de `auth.users` bloqueen el alta de usuarios con el error "Database error saving new user".
- Proveer una forma sencilla de diagnosticar y validar el problema usando credenciales de service role.

### Description
- Endurecí la función de sincronización `public.handle_new_user()` en `supabase-schema.sql` para no bloquear `auth.users` al manejar `NULL`/vacíos y capturar excepciones, siempre retornando `NEW`.
- Normalicé metadata vacía usando `NULLIF(..., '')` y añadí `EXCEPTION` handlers (`undefined_table` y `others`) que emiten warnings y permiten continuar el signup.
- Añadí el script de diagnóstico `apps/frontend/scripts/diagnose-supabase-signup.mjs` que usa la Admin API (`auth.admin.createUser`) para reproducir y detectar el error y limpiar el usuario de prueba.
- Documenté el runbook en `docs/SUPABASE_SIGNUP_DATABASE_ERROR_FIX.md` con pasos para aplicar el SQL y ejecutar el diagnóstico (`SUPABASE_URL` + `SUPABASE_SERVICE_ROLE_KEY`).

### Testing
- Ejecuté la verificación sintáctica del script con `node --check apps/frontend/scripts/diagnose-supabase-signup.mjs` y pasó correctamente.
- Intenté ejecutar el diagnóstico real con `SUPABASE_URL=... SUPABASE_SERVICE_ROLE_KEY=... node apps/frontend/scripts/diagnose-supabase-signup.mjs`, pero falló por limitaciones de red en este entorno (`ENETUNREACH` / `fetch failed`).
- Verifiqué la presencia de los cambios relevantes mediante `rg`/búsquedas en los archivos modificados y confirmé que el bloque SQL y los archivos nuevos están presentes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df7ccd36f883299de171b95c5f0783)