### PR TITLE
feat(employer): dashboard de selección QA + portal admin

### DIFF
--- a/apps/frontend/src/actions/admin.ts
+++ b/apps/frontend/src/actions/admin.ts
@@ -1,0 +1,91 @@
+'use server';
+
+import { createClient } from '@/lib/supabase/server';
+
+async function requireAdmin() {
+  const supabase = createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return { error: 'No autenticado', supabase: null };
+
+  const { data: profile } = await supabase
+    .from('profiles')
+    .select('role')
+    .eq('id', user.id)
+    .single();
+
+  if (profile?.role !== 'admin') return { error: 'Acceso denegado', supabase: null };
+  return { error: null, supabase };
+}
+
+export async function getAdminUsersAction() {
+  const { error, supabase } = await requireAdmin();
+  if (error || !supabase) return { error, data: null };
+
+  const { data, error: dbError } = await supabase
+    .from('profiles')
+    .select('id, display_name, email, role, created_at')
+    .order('created_at', { ascending: false });
+
+  if (dbError) return { error: dbError.message, data: null };
+  return { data };
+}
+
+export async function changeUserRoleAction(targetUserId: string, newRole: 'comunidad' | 'employer' | 'admin') {
+  const { error, supabase } = await requireAdmin();
+  if (error || !supabase) return { error };
+
+  const { error: fnError } = await supabase.rpc('change_user_role', {
+    target_user_id: targetUserId,
+    new_role: newRole,
+  });
+
+  if (fnError) return { error: fnError.message };
+  return { success: true };
+}
+
+export async function getAdminProcessesAction() {
+  const { error, supabase } = await requireAdmin();
+  if (error || !supabase) return { error, data: null };
+
+  const { data, error: dbError } = await supabase
+    .from('hiring_processes')
+    .select(`
+      id, code, company_name, position_name, status, created_at, expires_at,
+      profiles!hiring_processes_created_by_fkey(display_name, email)
+    `)
+    .order('created_at', { ascending: false });
+
+  if (dbError) return { error: dbError.message, data: null };
+  return { data };
+}
+
+export async function getAdminStatsAction() {
+  const { error, supabase } = await requireAdmin();
+  if (error || !supabase) return { error, data: null };
+
+  const [users, processes, results] = await Promise.all([
+    supabase.from('profiles').select('role'),
+    supabase.from('hiring_processes').select('status'),
+    supabase.from('exam_results').select('passed'),
+  ]);
+
+  const userCounts = {
+    total: users.data?.length ?? 0,
+    admins: users.data?.filter(u => u.role === 'admin').length ?? 0,
+    employers: users.data?.filter(u => u.role === 'employer').length ?? 0,
+    comunidad: users.data?.filter(u => u.role === 'comunidad').length ?? 0,
+  };
+
+  const processCounts = {
+    total: processes.data?.length ?? 0,
+    active: processes.data?.filter(p => p.status === 'active').length ?? 0,
+    closed: processes.data?.filter(p => p.status === 'closed').length ?? 0,
+  };
+
+  const resultCounts = {
+    total: results.data?.length ?? 0,
+    passed: results.data?.filter(r => r.passed).length ?? 0,
+  };
+
+  return { data: { userCounts, processCounts, resultCounts } };
+}

--- a/apps/frontend/src/actions/employer.ts
+++ b/apps/frontend/src/actions/employer.ts
@@ -1,0 +1,126 @@
+'use server';
+
+import { createClient } from '@/lib/supabase/server';
+
+export interface HiringProcess {
+  id: string;
+  code: string;
+  created_by: string;
+  company_name: string;
+  position_name: string;
+  description?: string;
+  exam_types: string[];
+  status: 'draft' | 'active' | 'closed';
+  expires_at?: string;
+  created_at: string;
+}
+
+export interface ProcessCandidate {
+  id: string;
+  user_id: string;
+  participant_name?: string;
+  exam_type: string;
+  score: number;
+  percentage: number;
+  passed: boolean;
+  time_spent: number;
+  created_at: string;
+  profiles?: { display_name?: string; email?: string };
+}
+
+function generateCode(company: string): string {
+  const slug = company.toUpperCase().replace(/[^A-Z0-9]/g, '').slice(0, 6);
+  const year = new Date().getFullYear();
+  const rand = Math.random().toString(36).substring(2, 5).toUpperCase();
+  return `${slug}-${year}-${rand}`;
+}
+
+export async function createHiringProcessAction(payload: {
+  company_name: string;
+  position_name: string;
+  description?: string;
+  exam_types: string[];
+  expires_at?: string;
+}) {
+  const supabase = createClient();
+  const { data: { user }, error: userError } = await supabase.auth.getUser();
+  if (userError || !user) return { error: 'No autenticado' };
+
+  const code = generateCode(payload.company_name);
+
+  const { data, error } = await supabase
+    .from('hiring_processes')
+    .insert({ ...payload, code, created_by: user.id, status: 'active' })
+    .select()
+    .single();
+
+  if (error) return { error: error.message };
+  return { data };
+}
+
+export async function getMyProcessesAction() {
+  const supabase = createClient();
+  const { data: { user }, error: userError } = await supabase.auth.getUser();
+  if (userError || !user) return { error: 'No autenticado', data: null };
+
+  const { data, error } = await supabase
+    .from('hiring_processes')
+    .select('*')
+    .eq('created_by', user.id)
+    .order('created_at', { ascending: false });
+
+  if (error) return { error: error.message, data: null };
+  return { data };
+}
+
+export async function getProcessCandidatesAction(code: string) {
+  const supabase = createClient();
+  const { data: { user }, error: userError } = await supabase.auth.getUser();
+  if (userError || !user) return { error: 'No autenticado', data: null, process: null };
+
+  const { data: process, error: procError } = await supabase
+    .from('hiring_processes')
+    .select('*')
+    .eq('code', code)
+    .eq('created_by', user.id)
+    .single();
+
+  if (procError || !process) return { error: 'Proceso no encontrado', data: null, process: null };
+
+  const { data, error } = await supabase
+    .from('exam_results')
+    .select('id, user_id, participant_name, exam_type, score, percentage, passed, time_spent, created_at')
+    .eq('process_code', code)
+    .order('percentage', { ascending: false });
+
+  if (error) return { error: error.message, data: null, process };
+  return { data, process };
+}
+
+export async function validateProcessCodeAction(code: string) {
+  const supabase = createClient();
+  const { data, error } = await supabase
+    .from('hiring_processes')
+    .select('code, company_name, position_name, status')
+    .eq('code', code.trim().toUpperCase())
+    .eq('status', 'active')
+    .single();
+
+  if (error || !data) return { valid: false, process: null };
+  return { valid: true, process: data };
+}
+
+export async function updateProcessStatusAction(code: string, status: 'active' | 'closed') {
+  const supabase = createClient();
+  const { data: { user }, error: userError } = await supabase.auth.getUser();
+  if (userError || !user) return { error: 'No autenticado' };
+
+  const { error } = await supabase
+    .from('hiring_processes')
+    .update({ status })
+    .eq('code', code)
+    .eq('created_by', user.id);
+
+  if (error) return { error: error.message };
+  return { success: true };
+}

--- a/apps/frontend/src/actions/exams.ts
+++ b/apps/frontend/src/actions/exams.ts
@@ -24,6 +24,8 @@ interface SaveExamResultPayload {
   language?: string;
   // Analysis
   learning_objectives?: object;
+  // Hiring process
+  process_code?: string;
 }
 
 export async function saveExamResultAction(payload: SaveExamResultPayload) {

--- a/apps/frontend/src/actions/exams.ts
+++ b/apps/frontend/src/actions/exams.ts
@@ -3,9 +3,11 @@
 import { createClient } from '@/lib/supabase/server';
 
 interface SaveExamResultPayload {
-  exam_type: 'git' | 'istqb' | 'performance';
+  exam_type: 'git' | 'istqb' | 'performance' | 'test-app';
   exam_mode: 'exam' | 'training';
   participant_name?: string;
+  participant_email?: string;
+  candidate_id?: string;
   score: number;
   total_questions: number;
   correct_answers: number;
@@ -26,6 +28,8 @@ interface SaveExamResultPayload {
   learning_objectives?: object;
   // Hiring process
   process_code?: string;
+  // Extra structured data (bugs, sections, etc.)
+  metadata?: object;
 }
 
 export async function saveExamResultAction(payload: SaveExamResultPayload) {

--- a/apps/frontend/src/app/admin/page.tsx
+++ b/apps/frontend/src/app/admin/page.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+export const dynamic = 'force-dynamic';
+
 import { useEffect, useState, useTransition } from 'react';
 import { useRouter } from 'next/navigation';
 import { useSupabaseAuth } from '@/contexts/SupabaseAuthContext';

--- a/apps/frontend/src/app/admin/page.tsx
+++ b/apps/frontend/src/app/admin/page.tsx
@@ -1,0 +1,320 @@
+'use client';
+
+import { useEffect, useState, useTransition } from 'react';
+import { useRouter } from 'next/navigation';
+import { useSupabaseAuth } from '@/contexts/SupabaseAuthContext';
+import { useTheme } from '@/contexts/ThemeContext';
+import {
+  getAdminUsersAction,
+  getAdminProcessesAction,
+  getAdminStatsAction,
+  changeUserRoleAction,
+} from '@/actions/admin';
+
+type Role = 'comunidad' | 'employer' | 'admin';
+type Tab = 'overview' | 'users' | 'processes';
+
+interface UserRow {
+  id: string;
+  display_name?: string;
+  email?: string;
+  role: Role;
+  created_at: string;
+}
+
+interface ProcessRow {
+  id: string;
+  code: string;
+  company_name: string;
+  position_name: string;
+  status: string;
+  created_at: string;
+  expires_at?: string;
+  profiles?: { display_name?: string; email?: string };
+}
+
+interface Stats {
+  userCounts: { total: number; admins: number; employers: number; comunidad: number };
+  processCounts: { total: number; active: number; closed: number };
+  resultCounts: { total: number; passed: number };
+}
+
+const ROLE_COLORS: Record<Role, string> = {
+  admin: 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400',
+  employer: 'bg-indigo-100 text-indigo-700 dark:bg-indigo-900/30 dark:text-indigo-400',
+  comunidad: 'bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-400',
+};
+
+const STATUS_COLORS: Record<string, string> = {
+  active: 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400',
+  closed: 'bg-gray-100 text-gray-500 dark:bg-gray-700 dark:text-gray-400',
+  draft: 'bg-yellow-100 text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-400',
+};
+
+function formatDate(iso: string) {
+  return new Date(iso).toLocaleDateString('es-PY', { day: '2-digit', month: 'short', year: 'numeric' });
+}
+
+export default function AdminPage() {
+  const { user, isLoading } = useSupabaseAuth();
+  const { isDarkMode } = useTheme();
+  const router = useRouter();
+
+  const [tab, setTab] = useState<Tab>('overview');
+  const [stats, setStats] = useState<Stats | null>(null);
+  const [users, setUsers] = useState<UserRow[]>([]);
+  const [processes, setProcesses] = useState<ProcessRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [accessError, setAccessError] = useState('');
+  const [isPending, startTransition] = useTransition();
+  const [roleAlert, setRoleAlert] = useState<{ userId: string; msg: string; ok: boolean } | null>(null);
+
+  useEffect(() => {
+    if (!isLoading && !user) { router.push('/login'); return; }
+    if (!user) return;
+
+    Promise.all([
+      getAdminStatsAction(),
+      getAdminUsersAction(),
+      getAdminProcessesAction(),
+    ]).then(([s, u, p]) => {
+      if (s.error || u.error || p.error) {
+        setAccessError(s.error ?? u.error ?? p.error ?? 'Acceso denegado');
+      } else {
+        setStats(s.data as Stats);
+        setUsers((u.data ?? []) as UserRow[]);
+        setProcesses((p.data ?? []) as ProcessRow[]);
+      }
+      setLoading(false);
+    });
+  }, [user, isLoading, router]);
+
+  function handleRoleChange(userId: string, newRole: Role) {
+    startTransition(async () => {
+      const { error } = await changeUserRoleAction(userId, newRole);
+      if (error) {
+        setRoleAlert({ userId, msg: error, ok: false });
+      } else {
+        setUsers(prev => prev.map(u => u.id === userId ? { ...u, role: newRole } : u));
+        setRoleAlert({ userId, msg: 'Rol actualizado', ok: true });
+      }
+      setTimeout(() => setRoleAlert(null), 3000);
+    });
+  }
+
+  const base = isDarkMode ? 'bg-gray-900 text-white' : 'bg-gray-50 text-gray-900';
+  const card = isDarkMode ? 'bg-gray-800 border-gray-700' : 'bg-white border-gray-200';
+  const th = isDarkMode ? 'text-gray-400 border-gray-700 bg-gray-800/50' : 'text-gray-500 border-gray-200 bg-gray-50';
+  const td = isDarkMode ? 'border-gray-700' : 'border-gray-100';
+
+  if (isLoading || loading) {
+    return (
+      <div className={`min-h-screen ${base} flex items-center justify-center`}>
+        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-indigo-500" />
+      </div>
+    );
+  }
+
+  if (accessError) {
+    return (
+      <div className={`min-h-screen ${base} flex items-center justify-center`}>
+        <div className="text-center">
+          <p className="text-red-500 font-medium text-lg">{accessError}</p>
+          <button onClick={() => router.push('/')} className="mt-4 text-sm text-indigo-500 hover:underline">
+            Volver al inicio
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  const employers = users.filter(u => u.role === 'employer');
+
+  return (
+    <div className={`min-h-screen ${base} py-10 px-4`}>
+      <div className="max-w-6xl mx-auto">
+
+        <div className="mb-8">
+          <h1 className="text-2xl font-bold">Panel de Administración</h1>
+          <p className={`text-sm mt-1 ${isDarkMode ? 'text-gray-400' : 'text-gray-500'}`}>
+            Gestión de usuarios, roles y procesos de selección
+          </p>
+        </div>
+
+        {/* Tabs */}
+        <div className={`flex gap-1 p-1 rounded-lg mb-6 w-fit ${isDarkMode ? 'bg-gray-800' : 'bg-gray-200'}`}>
+          {([
+            { key: 'overview', label: 'Resumen' },
+            { key: 'users', label: `Usuarios (${users.length})` },
+            { key: 'processes', label: `Procesos (${processes.length})` },
+          ] as { key: Tab; label: string }[]).map(t => (
+            <button
+              key={t.key}
+              onClick={() => setTab(t.key)}
+              className={`px-4 py-1.5 rounded-md text-sm font-medium transition-colors ${
+                tab === t.key
+                  ? 'bg-indigo-600 text-white'
+                  : isDarkMode ? 'text-gray-400 hover:text-white' : 'text-gray-600 hover:text-gray-900'
+              }`}
+            >
+              {t.label}
+            </button>
+          ))}
+        </div>
+
+        {/* OVERVIEW */}
+        {tab === 'overview' && stats && (
+          <div className="space-y-6">
+            <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+              {[
+                { label: 'Usuarios totales', value: stats.userCounts.total, color: 'text-indigo-500' },
+                { label: 'Employers', value: stats.userCounts.employers, color: 'text-blue-500' },
+                { label: 'Procesos activos', value: stats.processCounts.active, color: 'text-green-500' },
+                { label: 'Exámenes rendidos', value: stats.resultCounts.total, color: 'text-amber-500' },
+              ].map(s => (
+                <div key={s.label} className={`${card} border rounded-xl p-5`}>
+                  <p className={`text-3xl font-bold ${s.color}`}>{s.value}</p>
+                  <p className={`text-sm mt-1 ${isDarkMode ? 'text-gray-400' : 'text-gray-500'}`}>{s.label}</p>
+                </div>
+              ))}
+            </div>
+
+            {/* Employers registrados */}
+            <div className={`${card} border rounded-xl`}>
+              <div className="px-5 py-4 border-b border-gray-200 dark:border-gray-700">
+                <h2 className="font-semibold">Empresas registradas</h2>
+                <p className={`text-xs mt-0.5 ${isDarkMode ? 'text-gray-400' : 'text-gray-500'}`}>
+                  Usuarios con rol employer habilitados para crear procesos
+                </p>
+              </div>
+              {employers.length === 0 ? (
+                <p className={`px-5 py-6 text-sm ${isDarkMode ? 'text-gray-500' : 'text-gray-400'}`}>
+                  No hay employers registrados todavía
+                </p>
+              ) : (
+                <div className="divide-y divide-gray-100 dark:divide-gray-700">
+                  {employers.map(e => {
+                    const empProcesses = processes.filter(p => p.profiles?.email === e.email);
+                    const active = empProcesses.filter(p => p.status === 'active').length;
+                    return (
+                      <div key={e.id} className="px-5 py-3 flex items-center justify-between">
+                        <div>
+                          <p className="font-medium text-sm">{e.display_name ?? '—'}</p>
+                          <p className={`text-xs ${isDarkMode ? 'text-gray-400' : 'text-gray-500'}`}>{e.email}</p>
+                        </div>
+                        <div className="text-right">
+                          <p className="text-sm font-medium">{empProcesses.length} procesos</p>
+                          <p className={`text-xs ${active > 0 ? 'text-green-500' : isDarkMode ? 'text-gray-500' : 'text-gray-400'}`}>
+                            {active} activos
+                          </p>
+                        </div>
+                      </div>
+                    );
+                  })}
+                </div>
+              )}
+            </div>
+          </div>
+        )}
+
+        {/* USERS */}
+        {tab === 'users' && (
+          <div className={`${card} border rounded-xl overflow-hidden`}>
+            <table className="w-full text-sm">
+              <thead>
+                <tr className={`border-b ${th} text-xs uppercase tracking-wider`}>
+                  <th className="px-4 py-3 text-left">Usuario</th>
+                  <th className="px-4 py-3 text-left">Email</th>
+                  <th className="px-4 py-3 text-left">Registro</th>
+                  <th className="px-4 py-3 text-left">Rol actual</th>
+                  <th className="px-4 py-3 text-left">Cambiar rol</th>
+                </tr>
+              </thead>
+              <tbody>
+                {users.map(u => (
+                  <tr key={u.id} className={`border-b ${td} last:border-0`}>
+                    <td className="px-4 py-3 font-medium">{u.display_name ?? '—'}</td>
+                    <td className={`px-4 py-3 ${isDarkMode ? 'text-gray-400' : 'text-gray-500'}`}>{u.email ?? '—'}</td>
+                    <td className={`px-4 py-3 text-xs ${isDarkMode ? 'text-gray-500' : 'text-gray-400'}`}>
+                      {formatDate(u.created_at)}
+                    </td>
+                    <td className="px-4 py-3">
+                      <span className={`text-xs px-2 py-0.5 rounded-full font-medium ${ROLE_COLORS[u.role]}`}>
+                        {u.role}
+                      </span>
+                    </td>
+                    <td className="px-4 py-3">
+                      <div className="flex items-center gap-2">
+                        <select
+                          value={u.role}
+                          onChange={e => handleRoleChange(u.id, e.target.value as Role)}
+                          disabled={isPending}
+                          className={`text-xs px-2 py-1 rounded-lg border outline-none transition-colors ${
+                            isDarkMode
+                              ? 'bg-gray-700 border-gray-600 text-white'
+                              : 'bg-white border-gray-300 text-gray-900'
+                          }`}
+                        >
+                          <option value="comunidad">comunidad</option>
+                          <option value="employer">employer</option>
+                          <option value="admin">admin</option>
+                        </select>
+                        {roleAlert?.userId === u.id && (
+                          <span className={`text-xs ${roleAlert.ok ? 'text-green-500' : 'text-red-500'}`}>
+                            {roleAlert.msg}
+                          </span>
+                        )}
+                      </div>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+
+        {/* PROCESSES */}
+        {tab === 'processes' && (
+          <div className={`${card} border rounded-xl overflow-hidden`}>
+            <table className="w-full text-sm">
+              <thead>
+                <tr className={`border-b ${th} text-xs uppercase tracking-wider`}>
+                  <th className="px-4 py-3 text-left">Empresa</th>
+                  <th className="px-4 py-3 text-left">Posición</th>
+                  <th className="px-4 py-3 text-left">Código</th>
+                  <th className="px-4 py-3 text-left">Employer</th>
+                  <th className="px-4 py-3 text-center">Estado</th>
+                  <th className="px-4 py-3 text-right">Creado</th>
+                </tr>
+              </thead>
+              <tbody>
+                {processes.map(p => (
+                  <tr key={p.id} className={`border-b ${td} last:border-0`}>
+                    <td className="px-4 py-3 font-medium">{p.company_name}</td>
+                    <td className={`px-4 py-3 ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}>{p.position_name}</td>
+                    <td className="px-4 py-3">
+                      <code className={`text-xs px-2 py-0.5 rounded font-mono ${isDarkMode ? 'bg-gray-700' : 'bg-gray-100'}`}>
+                        {p.code}
+                      </code>
+                    </td>
+                    <td className={`px-4 py-3 text-xs ${isDarkMode ? 'text-gray-400' : 'text-gray-500'}`}>
+                      {p.profiles?.display_name ?? p.profiles?.email ?? '—'}
+                    </td>
+                    <td className="px-4 py-3 text-center">
+                      <span className={`text-xs px-2 py-0.5 rounded-full font-medium ${STATUS_COLORS[p.status]}`}>
+                        {p.status}
+                      </span>
+                    </td>
+                    <td className={`px-4 py-3 text-right text-xs ${isDarkMode ? 'text-gray-500' : 'text-gray-400'}`}>
+                      {formatDate(p.created_at)}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/src/app/employer/[code]/page.tsx
+++ b/apps/frontend/src/app/employer/[code]/page.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+export const dynamic = 'force-dynamic';
+
 import { useEffect, useState } from 'react';
 import { useParams, useRouter } from 'next/navigation';
 import { useSupabaseAuth } from '@/contexts/SupabaseAuthContext';

--- a/apps/frontend/src/app/employer/[code]/page.tsx
+++ b/apps/frontend/src/app/employer/[code]/page.tsx
@@ -1,0 +1,215 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useParams, useRouter } from 'next/navigation';
+import { useSupabaseAuth } from '@/contexts/SupabaseAuthContext';
+import { useTheme } from '@/contexts/ThemeContext';
+import { getProcessCandidatesAction, type HiringProcess, type ProcessCandidate } from '@/actions/employer';
+
+const EXAM_LABELS: Record<string, string> = {
+  istqb: 'ISTQB',
+  git: 'Git',
+  performance: 'Rendimiento',
+};
+
+function formatTime(seconds: number) {
+  const m = Math.floor(seconds / 60);
+  const s = seconds % 60;
+  return `${m}:${s.toString().padStart(2, '0')}`;
+}
+
+function formatDate(iso: string) {
+  return new Date(iso).toLocaleDateString('es-PY', { day: '2-digit', month: 'short', year: 'numeric' });
+}
+
+export default function ProcessDashboardPage() {
+  const { code } = useParams<{ code: string }>();
+  const { user, isLoading } = useSupabaseAuth();
+  const { isDarkMode } = useTheme();
+  const router = useRouter();
+
+  const [process, setProcess] = useState<HiringProcess | null>(null);
+  const [candidates, setCandidates] = useState<ProcessCandidate[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+  const [copied, setCopied] = useState(false);
+
+  useEffect(() => {
+    if (!isLoading && !user) router.push('/login');
+  }, [user, isLoading, router]);
+
+  useEffect(() => {
+    if (!user || !code) return;
+    getProcessCandidatesAction(code).then(({ data, process: proc, error: err }) => {
+      if (err || !proc) { setError(err ?? 'Proceso no encontrado'); setLoading(false); return; }
+      setProcess(proc as HiringProcess);
+      setCandidates((data ?? []) as ProcessCandidate[]);
+      setLoading(false);
+    });
+  }, [user, code]);
+
+  function copyCode() {
+    navigator.clipboard.writeText(code);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  }
+
+  const base = isDarkMode ? 'bg-gray-900 text-white' : 'bg-gray-50 text-gray-900';
+  const card = isDarkMode ? 'bg-gray-800 border-gray-700' : 'bg-white border-gray-200';
+  const th = isDarkMode ? 'text-gray-400 border-gray-700' : 'text-gray-500 border-gray-200';
+  const td = isDarkMode ? 'border-gray-700' : 'border-gray-100';
+
+  if (isLoading || loading) {
+    return (
+      <div className={`min-h-screen ${base} flex items-center justify-center`}>
+        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-indigo-500" />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className={`min-h-screen ${base} flex items-center justify-center`}>
+        <div className="text-center">
+          <p className="text-red-500 font-medium">{error}</p>
+          <button onClick={() => router.push('/employer')} className="mt-4 text-sm text-indigo-500 hover:underline">
+            Volver a procesos
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  const passed = candidates.filter(c => c.passed).length;
+
+  return (
+    <div className={`min-h-screen ${base} py-10 px-4`}>
+      <div className="max-w-5xl mx-auto">
+        <button
+          onClick={() => router.push('/employer')}
+          className={`text-sm mb-6 ${isDarkMode ? 'text-gray-400 hover:text-white' : 'text-gray-500 hover:text-gray-900'} transition-colors`}
+        >
+          ← Volver a procesos
+        </button>
+
+        <div className={`${card} border rounded-xl p-5 mb-6`}>
+          <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
+            <div>
+              <h1 className="text-xl font-bold">{process?.position_name}</h1>
+              <p className={`text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-500'}`}>{process?.company_name}</p>
+              {process?.description && (
+                <p className={`text-sm mt-1 ${isDarkMode ? 'text-gray-400' : 'text-gray-500'}`}>{process.description}</p>
+              )}
+            </div>
+            <div className="flex items-center gap-2 shrink-0">
+              <span className={`text-sm font-medium ${isDarkMode ? 'text-gray-300' : 'text-gray-600'}`}>Código:</span>
+              <code className={`text-sm font-mono px-3 py-1.5 rounded-lg ${isDarkMode ? 'bg-gray-700' : 'bg-gray-100'}`}>
+                {code}
+              </code>
+              <button
+                onClick={copyCode}
+                className={`text-xs px-2 py-1.5 rounded-lg border transition-colors ${
+                  copied
+                    ? 'border-green-400 text-green-600'
+                    : isDarkMode ? 'border-gray-600 text-gray-400 hover:text-white' : 'border-gray-300 text-gray-500 hover:text-gray-900'
+                }`}
+              >
+                {copied ? '¡Copiado!' : 'Copiar'}
+              </button>
+            </div>
+          </div>
+
+          <div className="flex gap-6 mt-5 pt-4 border-t border-gray-700/30">
+            <div className="text-center">
+              <p className="text-2xl font-bold">{candidates.length}</p>
+              <p className={`text-xs ${isDarkMode ? 'text-gray-400' : 'text-gray-500'}`}>Candidatos</p>
+            </div>
+            <div className="text-center">
+              <p className="text-2xl font-bold text-green-500">{passed}</p>
+              <p className={`text-xs ${isDarkMode ? 'text-gray-400' : 'text-gray-500'}`}>Aprobaron</p>
+            </div>
+            <div className="text-center">
+              <p className="text-2xl font-bold text-red-400">{candidates.length - passed}</p>
+              <p className={`text-xs ${isDarkMode ? 'text-gray-400' : 'text-gray-500'}`}>No aprobaron</p>
+            </div>
+            {candidates.length > 0 && (
+              <div className="text-center">
+                <p className="text-2xl font-bold text-indigo-400">
+                  {Math.round(candidates.reduce((acc, c) => acc + c.percentage, 0) / candidates.length)}%
+                </p>
+                <p className={`text-xs ${isDarkMode ? 'text-gray-400' : 'text-gray-500'}`}>Promedio</p>
+              </div>
+            )}
+          </div>
+        </div>
+
+        {candidates.length === 0 ? (
+          <div className={`${card} border rounded-xl p-12 text-center`}>
+            <p className={`text-lg font-medium ${isDarkMode ? 'text-gray-300' : 'text-gray-600'}`}>
+              Todavía no hay candidatos
+            </p>
+            <p className={`text-sm mt-1 ${isDarkMode ? 'text-gray-500' : 'text-gray-400'}`}>
+              Compartí el código <strong>{code}</strong> con los candidatos para que rindan el examen
+            </p>
+          </div>
+        ) : (
+          <div className={`${card} border rounded-xl overflow-hidden`}>
+            <table className="w-full text-sm">
+              <thead>
+                <tr className={`border-b ${th} text-xs uppercase tracking-wider`}>
+                  <th className="px-4 py-3 text-left">#</th>
+                  <th className="px-4 py-3 text-left">Candidato</th>
+                  <th className="px-4 py-3 text-left">Examen</th>
+                  <th className="px-4 py-3 text-right">Score</th>
+                  <th className="px-4 py-3 text-center">Resultado</th>
+                  <th className="px-4 py-3 text-right">Tiempo</th>
+                  <th className="px-4 py-3 text-right">Fecha</th>
+                </tr>
+              </thead>
+              <tbody>
+                {candidates.map((c, i) => (
+                  <tr key={c.id} className={`border-b ${td} last:border-0`}>
+                    <td className={`px-4 py-3 font-mono font-bold ${i === 0 ? 'text-yellow-500' : i === 1 ? 'text-gray-400' : i === 2 ? 'text-orange-400' : isDarkMode ? 'text-gray-500' : 'text-gray-400'}`}>
+                      {i + 1}
+                    </td>
+                    <td className="px-4 py-3 font-medium">
+                      {c.participant_name ?? 'Sin nombre'}
+                    </td>
+                    <td className="px-4 py-3">
+                      <span className={`text-xs px-2 py-0.5 rounded-full ${isDarkMode ? 'bg-gray-700 text-gray-300' : 'bg-gray-100 text-gray-600'}`}>
+                        {EXAM_LABELS[c.exam_type] ?? c.exam_type}
+                      </span>
+                    </td>
+                    <td className="px-4 py-3 text-right">
+                      <span className={`font-bold ${c.percentage >= 70 ? 'text-green-500' : 'text-red-400'}`}>
+                        {c.percentage}%
+                      </span>
+                      <span className={`text-xs ml-1 ${isDarkMode ? 'text-gray-500' : 'text-gray-400'}`}>
+                        ({c.score}pts)
+                      </span>
+                    </td>
+                    <td className="px-4 py-3 text-center">
+                      <span className={`text-xs px-2 py-0.5 rounded-full font-medium ${
+                        c.passed
+                          ? 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400'
+                          : 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400'
+                      }`}>
+                        {c.passed ? 'Aprobó' : 'No aprobó'}
+                      </span>
+                    </td>
+                    <td className={`px-4 py-3 text-right font-mono text-xs ${isDarkMode ? 'text-gray-400' : 'text-gray-500'}`}>
+                      {formatTime(c.time_spent)}
+                    </td>
+                    <td className={`px-4 py-3 text-right text-xs ${isDarkMode ? 'text-gray-500' : 'text-gray-400'}`}>
+                      {formatDate(c.created_at)}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/src/app/employer/nuevo/page.tsx
+++ b/apps/frontend/src/app/employer/nuevo/page.tsx
@@ -2,7 +2,7 @@
 
 export const dynamic = 'force-dynamic';
 
-import { useState, useTransition } from 'react';
+import { useState, useTransition, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import { useSupabaseAuth } from '@/contexts/SupabaseAuthContext';
 import { useTheme } from '@/contexts/ThemeContext';
@@ -15,7 +15,7 @@ const EXAM_OPTIONS = [
 ];
 
 export default function NuevoProcesoPage() {
-  const { user } = useSupabaseAuth();
+  const { user, isLoading } = useSupabaseAuth();
   const { isDarkMode } = useTheme();
   const router = useRouter();
   const [isPending, startTransition] = useTransition();
@@ -29,10 +29,11 @@ export default function NuevoProcesoPage() {
     expires_at: '',
   });
 
-  if (!user) {
-    router.push('/login');
-    return null;
-  }
+  useEffect(() => {
+    if (!isLoading && !user) router.push('/login');
+  }, [user, isLoading, router]);
+
+  if (isLoading || !user) return null;
 
   function toggleExam(value: string) {
     setForm(prev => ({

--- a/apps/frontend/src/app/employer/nuevo/page.tsx
+++ b/apps/frontend/src/app/employer/nuevo/page.tsx
@@ -1,0 +1,168 @@
+'use client';
+
+import { useState, useTransition } from 'react';
+import { useRouter } from 'next/navigation';
+import { useSupabaseAuth } from '@/contexts/SupabaseAuthContext';
+import { useTheme } from '@/contexts/ThemeContext';
+import { createHiringProcessAction } from '@/actions/employer';
+
+const EXAM_OPTIONS = [
+  { value: 'istqb', label: 'ISTQB Foundation Level' },
+  { value: 'git', label: 'Git' },
+  { value: 'performance', label: 'Rendimiento / Performance' },
+];
+
+export default function NuevoProcesoPage() {
+  const { user } = useSupabaseAuth();
+  const { isDarkMode } = useTheme();
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+  const [error, setError] = useState('');
+
+  const [form, setForm] = useState({
+    company_name: '',
+    position_name: '',
+    description: '',
+    exam_types: ['istqb', 'git', 'performance'],
+    expires_at: '',
+  });
+
+  if (!user) {
+    router.push('/login');
+    return null;
+  }
+
+  function toggleExam(value: string) {
+    setForm(prev => ({
+      ...prev,
+      exam_types: prev.exam_types.includes(value)
+        ? prev.exam_types.filter(e => e !== value)
+        : [...prev.exam_types, value],
+    }));
+  }
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!form.company_name.trim() || !form.position_name.trim()) {
+      setError('Empresa y posición son obligatorios');
+      return;
+    }
+    if (form.exam_types.length === 0) {
+      setError('Seleccioná al menos un tipo de examen');
+      return;
+    }
+
+    startTransition(async () => {
+      const { data, error: err } = await createHiringProcessAction({
+        company_name: form.company_name.trim(),
+        position_name: form.position_name.trim(),
+        description: form.description.trim() || undefined,
+        exam_types: form.exam_types,
+        expires_at: form.expires_at || undefined,
+      });
+
+      if (err) { setError(err); return; }
+      router.push(`/employer/${data.code}`);
+    });
+  }
+
+  const base = isDarkMode ? 'bg-gray-900 text-white' : 'bg-gray-50 text-gray-900';
+  const card = isDarkMode ? 'bg-gray-800 border-gray-700' : 'bg-white border-gray-200';
+  const input = isDarkMode
+    ? 'bg-gray-700 border-gray-600 text-white placeholder-gray-400 focus:border-indigo-500'
+    : 'bg-white border-gray-300 text-gray-900 placeholder-gray-400 focus:border-indigo-500';
+
+  return (
+    <div className={`min-h-screen ${base} py-10 px-4`}>
+      <div className="max-w-xl mx-auto">
+        <button
+          onClick={() => router.push('/employer')}
+          className={`text-sm mb-6 ${isDarkMode ? 'text-gray-400 hover:text-white' : 'text-gray-500 hover:text-gray-900'} transition-colors`}
+        >
+          ← Volver a procesos
+        </button>
+
+        <h1 className="text-2xl font-bold mb-1">Nuevo proceso de selección</h1>
+        <p className={`text-sm mb-8 ${isDarkMode ? 'text-gray-400' : 'text-gray-500'}`}>
+          Se generará un código único que compartís con los candidatos
+        </p>
+
+        <form onSubmit={handleSubmit} className={`${card} border rounded-xl p-6 space-y-5`}>
+          <div>
+            <label className="block text-sm font-medium mb-1">Empresa *</label>
+            <input
+              type="text"
+              value={form.company_name}
+              onChange={e => setForm(prev => ({ ...prev, company_name: e.target.value }))}
+              placeholder="Ej: CLT, Banco XYZ"
+              className={`w-full px-3 py-2 rounded-lg border text-sm outline-none transition-colors ${input}`}
+            />
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium mb-1">Posición *</label>
+            <input
+              type="text"
+              value={form.position_name}
+              onChange={e => setForm(prev => ({ ...prev, position_name: e.target.value }))}
+              placeholder="Ej: QA Analyst Junior"
+              className={`w-full px-3 py-2 rounded-lg border text-sm outline-none transition-colors ${input}`}
+            />
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium mb-1">Descripción (opcional)</label>
+            <textarea
+              value={form.description}
+              onChange={e => setForm(prev => ({ ...prev, description: e.target.value }))}
+              placeholder="Información adicional para los candidatos..."
+              rows={3}
+              className={`w-full px-3 py-2 rounded-lg border text-sm outline-none transition-colors resize-none ${input}`}
+            />
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium mb-2">Exámenes incluidos *</label>
+            <div className="space-y-2">
+              {EXAM_OPTIONS.map(opt => (
+                <label key={opt.value} className="flex items-center gap-2 cursor-pointer">
+                  <input
+                    type="checkbox"
+                    checked={form.exam_types.includes(opt.value)}
+                    onChange={() => toggleExam(opt.value)}
+                    className="rounded border-gray-300 text-indigo-600 focus:ring-indigo-500"
+                  />
+                  <span className="text-sm">{opt.label}</span>
+                </label>
+              ))}
+            </div>
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium mb-1">Fecha de vencimiento (opcional)</label>
+            <input
+              type="date"
+              value={form.expires_at}
+              onChange={e => setForm(prev => ({ ...prev, expires_at: e.target.value }))}
+              className={`w-full px-3 py-2 rounded-lg border text-sm outline-none transition-colors ${input}`}
+            />
+          </div>
+
+          {error && (
+            <p className="text-sm text-red-500 bg-red-50 dark:bg-red-900/20 px-3 py-2 rounded-lg">
+              {error}
+            </p>
+          )}
+
+          <button
+            type="submit"
+            disabled={isPending}
+            className="w-full bg-indigo-600 hover:bg-indigo-700 disabled:opacity-60 text-white py-2.5 rounded-lg text-sm font-medium transition-colors"
+          >
+            {isPending ? 'Creando proceso...' : 'Crear proceso'}
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/src/app/employer/nuevo/page.tsx
+++ b/apps/frontend/src/app/employer/nuevo/page.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+export const dynamic = 'force-dynamic';
+
 import { useState, useTransition } from 'react';
 import { useRouter } from 'next/navigation';
 import { useSupabaseAuth } from '@/contexts/SupabaseAuthContext';

--- a/apps/frontend/src/app/employer/page.tsx
+++ b/apps/frontend/src/app/employer/page.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+export const dynamic = 'force-dynamic';
+
 import { useEffect, useState, useTransition } from 'react';
 import { useRouter } from 'next/navigation';
 import { useSupabaseAuth } from '@/contexts/SupabaseAuthContext';

--- a/apps/frontend/src/app/employer/page.tsx
+++ b/apps/frontend/src/app/employer/page.tsx
@@ -1,0 +1,184 @@
+'use client';
+
+import { useEffect, useState, useTransition } from 'react';
+import { useRouter } from 'next/navigation';
+import { useSupabaseAuth } from '@/contexts/SupabaseAuthContext';
+import { useTheme } from '@/contexts/ThemeContext';
+import { getMyProcessesAction, updateProcessStatusAction, type HiringProcess } from '@/actions/employer';
+import Link from 'next/link';
+
+const STATUS_LABEL: Record<string, string> = {
+  active: 'Activo',
+  closed: 'Cerrado',
+  draft: 'Borrador',
+};
+
+const STATUS_COLOR: Record<string, string> = {
+  active: 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400',
+  closed: 'bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-400',
+  draft: 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-400',
+};
+
+const EXAM_LABELS: Record<string, string> = {
+  istqb: 'ISTQB',
+  git: 'Git',
+  performance: 'Rendimiento',
+};
+
+function formatDate(iso: string) {
+  return new Date(iso).toLocaleDateString('es-PY', { day: '2-digit', month: 'short', year: 'numeric' });
+}
+
+export default function EmployerPage() {
+  const { user, isLoading } = useSupabaseAuth();
+  const { isDarkMode } = useTheme();
+  const router = useRouter();
+  const [processes, setProcesses] = useState<HiringProcess[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [isPending, startTransition] = useTransition();
+  const [copied, setCopied] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!isLoading && !user) router.push('/login');
+  }, [user, isLoading, router]);
+
+  useEffect(() => {
+    if (!user) return;
+    getMyProcessesAction().then(({ data }) => {
+      if (data) setProcesses(data as HiringProcess[]);
+      setLoading(false);
+    });
+  }, [user]);
+
+  function copyCode(code: string) {
+    navigator.clipboard.writeText(code);
+    setCopied(code);
+    setTimeout(() => setCopied(null), 2000);
+  }
+
+  function toggleStatus(code: string, current: string) {
+    const next = current === 'active' ? 'closed' : 'active';
+    startTransition(async () => {
+      await updateProcessStatusAction(code, next as 'active' | 'closed');
+      setProcesses(prev => prev.map(p => p.code === code ? { ...p, status: next as HiringProcess['status'] } : p));
+    });
+  }
+
+  const base = isDarkMode ? 'bg-gray-900 text-white' : 'bg-gray-50 text-gray-900';
+  const card = isDarkMode ? 'bg-gray-800 border-gray-700' : 'bg-white border-gray-200';
+
+  if (isLoading || loading) {
+    return (
+      <div className={`min-h-screen ${base} flex items-center justify-center`}>
+        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-indigo-500" />
+      </div>
+    );
+  }
+
+  return (
+    <div className={`min-h-screen ${base} py-10 px-4`}>
+      <div className="max-w-4xl mx-auto">
+        <div className="flex items-center justify-between mb-8">
+          <div>
+            <h1 className="text-2xl font-bold">Procesos de selección</h1>
+            <p className={`text-sm mt-1 ${isDarkMode ? 'text-gray-400' : 'text-gray-500'}`}>
+              Gestioná tus evaluaciones técnicas para candidatos QA
+            </p>
+          </div>
+          <Link
+            href="/employer/nuevo"
+            className="bg-indigo-600 hover:bg-indigo-700 text-white px-4 py-2 rounded-lg text-sm font-medium transition-colors"
+          >
+            + Nuevo proceso
+          </Link>
+        </div>
+
+        {processes.length === 0 ? (
+          <div className={`${card} border rounded-xl p-12 text-center`}>
+            <p className={`text-lg font-medium ${isDarkMode ? 'text-gray-300' : 'text-gray-600'}`}>
+              No tenés procesos creados todavía
+            </p>
+            <p className={`text-sm mt-1 ${isDarkMode ? 'text-gray-500' : 'text-gray-400'}`}>
+              Creá tu primer proceso para empezar a evaluar candidatos
+            </p>
+            <Link
+              href="/employer/nuevo"
+              className="inline-block mt-4 bg-indigo-600 hover:bg-indigo-700 text-white px-5 py-2 rounded-lg text-sm font-medium transition-colors"
+            >
+              Crear proceso
+            </Link>
+          </div>
+        ) : (
+          <div className="space-y-4">
+            {processes.map(p => (
+              <div key={p.id} className={`${card} border rounded-xl p-5`}>
+                <div className="flex items-start justify-between gap-4">
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center gap-2 flex-wrap">
+                      <h2 className="font-semibold text-base">{p.position_name}</h2>
+                      <span className={`text-xs px-2 py-0.5 rounded-full font-medium ${STATUS_COLOR[p.status]}`}>
+                        {STATUS_LABEL[p.status]}
+                      </span>
+                    </div>
+                    <p className={`text-sm mt-0.5 ${isDarkMode ? 'text-gray-400' : 'text-gray-500'}`}>
+                      {p.company_name}
+                    </p>
+
+                    <div className="flex items-center gap-2 mt-3">
+                      <code className={`text-sm font-mono px-2 py-1 rounded ${isDarkMode ? 'bg-gray-700' : 'bg-gray-100'}`}>
+                        {p.code}
+                      </code>
+                      <button
+                        onClick={() => copyCode(p.code)}
+                        className={`text-xs px-2 py-1 rounded transition-colors ${
+                          copied === p.code
+                            ? 'text-green-600 bg-green-50 dark:bg-green-900/20'
+                            : isDarkMode ? 'text-gray-400 hover:text-white' : 'text-gray-500 hover:text-gray-900'
+                        }`}
+                      >
+                        {copied === p.code ? 'Copiado!' : 'Copiar'}
+                      </button>
+                    </div>
+
+                    <div className="flex flex-wrap gap-1 mt-3">
+                      {p.exam_types.map(t => (
+                        <span key={t} className={`text-xs px-2 py-0.5 rounded-full ${isDarkMode ? 'bg-gray-700 text-gray-300' : 'bg-gray-100 text-gray-600'}`}>
+                          {EXAM_LABELS[t] ?? t}
+                        </span>
+                      ))}
+                    </div>
+
+                    <p className={`text-xs mt-3 ${isDarkMode ? 'text-gray-500' : 'text-gray-400'}`}>
+                      Creado {formatDate(p.created_at)}
+                      {p.expires_at && ` · Vence ${formatDate(p.expires_at)}`}
+                    </p>
+                  </div>
+
+                  <div className="flex flex-col gap-2 items-end shrink-0">
+                    <Link
+                      href={`/employer/${p.code}`}
+                      className="text-sm text-indigo-500 hover:text-indigo-400 font-medium"
+                    >
+                      Ver candidatos →
+                    </Link>
+                    <button
+                      onClick={() => toggleStatus(p.code, p.status)}
+                      disabled={isPending}
+                      className={`text-xs px-2 py-1 rounded border transition-colors ${
+                        p.status === 'active'
+                          ? 'border-red-300 text-red-500 hover:bg-red-50 dark:hover:bg-red-900/20'
+                          : 'border-green-300 text-green-600 hover:bg-green-50 dark:hover:bg-green-900/20'
+                      }`}
+                    >
+                      {p.status === 'active' ? 'Cerrar proceso' : 'Reabrir proceso'}
+                    </button>
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/src/app/labs/git/page.tsx
+++ b/apps/frontend/src/app/labs/git/page.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+export const dynamic = 'force-dynamic';
+
 import { useState, useEffect } from 'react';
 import { useSearchParams } from 'next/navigation';
 import { useTheme } from '@/contexts/ThemeContext';

--- a/apps/frontend/src/app/labs/git/page.tsx
+++ b/apps/frontend/src/app/labs/git/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useEffect } from 'react';
+import { useSearchParams } from 'next/navigation';
 import { useTheme } from '@/contexts/ThemeContext';
 import { Alert } from '@/components/common';
 import ExamSimulator from './components/ExamSimulator';
@@ -8,11 +9,13 @@ import { loadExamData } from './utils';
 import ExamAuthGate from '@/components/labs/ExamAuthGate';
 import { useSupabaseAuth } from '@/contexts/SupabaseAuthContext';
 import { saveExamResultAction } from '@/actions/exams';
+import ProcessCodeInput from '@/components/labs/ProcessCodeInput';
 import type { ExamResult } from './types';
 
 export default function GitExamPage() {
   const { isDarkMode } = useTheme();
   const { user } = useSupabaseAuth();
+  const searchParams = useSearchParams();
   const [participantName, setParticipantName] = useState('');
   const [githubProfile, setGithubProfile] = useState('');
   const [examPurpose, setExamPurpose] = useState<'capacitacion' | 'postulacion' | 'practica' | 'otro'>('capacitacion');
@@ -20,6 +23,7 @@ export default function GitExamPage() {
   const [examMode, setExamMode] = useState<'exam' | 'training' | null>(null);
   const [hasStarted, setHasStarted] = useState(false);
   const [error, setError] = useState('');
+  const [processCode, setProcessCode] = useState(searchParams.get('process')?.toUpperCase() ?? '');
 
   // Pre-fill name from user profile
   useEffect(() => {
@@ -44,6 +48,7 @@ export default function GitExamPage() {
       exam_purpose: result.examPurpose,
       company_name: result.companyName,
       learning_objectives: result.learningObjectiveAnalysis,
+      process_code: processCode.trim() || undefined,
     });
   };
 
@@ -275,6 +280,12 @@ export default function GitExamPage() {
                 </p>
               </div>
             )}
+
+            <ProcessCodeInput
+              value={processCode}
+              onChange={setProcessCode}
+              autoValidate={!!searchParams.get('process')}
+            />
 
             {error && (
               <Alert type="error" message={error} onClose={() => setError('')} />

--- a/apps/frontend/src/app/labs/istqb/page.tsx
+++ b/apps/frontend/src/app/labs/istqb/page.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+export const dynamic = 'force-dynamic';
+
 import { useState, useEffect } from 'react';
 import { useSearchParams } from 'next/navigation';
 import { useTheme } from '@/contexts/ThemeContext';

--- a/apps/frontend/src/app/labs/istqb/page.tsx
+++ b/apps/frontend/src/app/labs/istqb/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useEffect } from 'react';
+import { useSearchParams } from 'next/navigation';
 import { useTheme } from '@/contexts/ThemeContext';
 import { Alert } from '@/components/common';
 import ExamSimulator from './components/ExamSimulator';
@@ -9,17 +10,20 @@ import { SuruFloating } from '@/components/Suru';
 import ExamAuthGate from '@/components/labs/ExamAuthGate';
 import { useSupabaseAuth } from '@/contexts/SupabaseAuthContext';
 import { saveExamResultAction } from '@/actions/exams';
+import ProcessCodeInput from '@/components/labs/ProcessCodeInput';
 import type { ExamResult } from './types';
 
 export default function ISTQBSimulatorPage() {
   const { isDarkMode } = useTheme();
   const { user } = useSupabaseAuth();
+  const searchParams = useSearchParams();
   const [participantName, setParticipantName] = useState('');
   const [examMode, setExamMode] = useState<'exam' | 'training' | null>(null);
   const [hasStarted, setHasStarted] = useState(false);
   const [error, setError] = useState('');
   const [language, setLanguage] = useState<'es' | 'en'>('es');
   const [model, setModel] = useState<'A' | 'B' | 'C'>('A');
+  const [processCode, setProcessCode] = useState(searchParams.get('process')?.toUpperCase() ?? '');
 
   useEffect(() => {
     if (user?.user_metadata?.full_name && !participantName) {
@@ -42,6 +46,7 @@ export default function ISTQBSimulatorPage() {
       model,
       language,
       learning_objectives: result.learningObjectiveAnalysis,
+      process_code: processCode.trim() || undefined,
     });
   };
 
@@ -337,6 +342,12 @@ export default function ISTQBSimulatorPage() {
                   } focus:outline-none focus:ring-2 focus:ring-amber-500`}
               />
             </div>
+
+            <ProcessCodeInput
+              value={processCode}
+              onChange={setProcessCode}
+              autoValidate={!!searchParams.get('process')}
+            />
 
             {error && (
               <Alert type="error" message={error} onClose={() => setError('')} />

--- a/apps/frontend/src/app/labs/performance/components/ExamSimulator.tsx
+++ b/apps/frontend/src/app/labs/performance/components/ExamSimulator.tsx
@@ -14,6 +14,7 @@ interface ExamSimulatorProps {
   companyName?: string;
   mode: 'exam' | 'training';
   examData: ExamData;
+  onExamComplete?: (result: ExamResult) => void;
 }
 
 export default function ExamSimulator({
@@ -23,6 +24,7 @@ export default function ExamSimulator({
   companyName,
   mode,
   examData,
+  onExamComplete,
 }: ExamSimulatorProps) {
   const onReset = () => {
     window.location.reload();
@@ -202,6 +204,8 @@ export default function ExamSimulator({
       timeSpent,
       examData.examInfo.passingScore,
     );
+
+    onExamComplete?.(result);
 
     return (
       <ResultsScreen

--- a/apps/frontend/src/app/labs/performance/components/ExamSimulator.tsx
+++ b/apps/frontend/src/app/labs/performance/components/ExamSimulator.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useCallback } from 'react';
 import { useTheme } from '@/contexts/ThemeContext';
-import type { ExamData, ExamQuestion } from '../types';
+import type { ExamData, ExamQuestion, ExamResult } from '../types';
 import { prepareExamQuestions, formatTime, generateExamResult } from '../utils';
 import QuestionCard from './QuestionCard';
 import ResultsScreen from './ResultsScreen';

--- a/apps/frontend/src/app/labs/performance/page.tsx
+++ b/apps/frontend/src/app/labs/performance/page.tsx
@@ -9,14 +9,12 @@ import { Alert } from '@/components/common';
 import ExamSimulator from './components/ExamSimulator';
 import { loadExamData } from './utils';
 import { SuruFloating } from '@/components/Suru';
-import { useSupabaseAuth } from '@/contexts/SupabaseAuthContext';
 import { saveExamResultAction } from '@/actions/exams';
 import ProcessCodeInput from '@/components/labs/ProcessCodeInput';
 import type { ExamResult } from './types';
 
 export default function PerformanceExamPage() {
   const { isDarkMode } = useTheme();
-  const { user } = useSupabaseAuth();
   const searchParams = useSearchParams();
   const [participantName, setParticipantName] = useState('');
   const [githubProfile, setGithubProfile] = useState('');

--- a/apps/frontend/src/app/labs/performance/page.tsx
+++ b/apps/frontend/src/app/labs/performance/page.tsx
@@ -11,6 +11,7 @@ import { loadExamData } from './utils';
 import { SuruFloating } from '@/components/Suru';
 import { saveExamResultAction } from '@/actions/exams';
 import ProcessCodeInput from '@/components/labs/ProcessCodeInput';
+import ExamAuthGate from '@/components/labs/ExamAuthGate';
 import type { ExamResult } from './types';
 
 export default function PerformanceExamPage() {
@@ -133,6 +134,7 @@ export default function PerformanceExamPage() {
   ];
 
   return (
+    <ExamAuthGate examName="Examen de Rendimiento / Performance" examEmoji="⚡">
     <div className={`min-h-screen py-12 md:py-16 transition-colors duration-300 ${
       isDarkMode ? 'bg-slate-900' : 'bg-brand-light'
     }`}>
@@ -508,5 +510,6 @@ export default function PerformanceExamPage() {
         </div>
       </div>
     </div>
+    </ExamAuthGate>
   );
 }

--- a/apps/frontend/src/app/labs/performance/page.tsx
+++ b/apps/frontend/src/app/labs/performance/page.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+export const dynamic = 'force-dynamic';
+
 import { useState } from 'react';
 import { useSearchParams } from 'next/navigation';
 import { useTheme } from '@/contexts/ThemeContext';

--- a/apps/frontend/src/app/labs/performance/page.tsx
+++ b/apps/frontend/src/app/labs/performance/page.tsx
@@ -1,14 +1,21 @@
 'use client';
 
 import { useState } from 'react';
+import { useSearchParams } from 'next/navigation';
 import { useTheme } from '@/contexts/ThemeContext';
 import { Alert } from '@/components/common';
 import ExamSimulator from './components/ExamSimulator';
 import { loadExamData } from './utils';
 import { SuruFloating } from '@/components/Suru';
+import { useSupabaseAuth } from '@/contexts/SupabaseAuthContext';
+import { saveExamResultAction } from '@/actions/exams';
+import ProcessCodeInput from '@/components/labs/ProcessCodeInput';
+import type { ExamResult } from './types';
 
 export default function PerformanceExamPage() {
   const { isDarkMode } = useTheme();
+  const { user } = useSupabaseAuth();
+  const searchParams = useSearchParams();
   const [participantName, setParticipantName] = useState('');
   const [githubProfile, setGithubProfile] = useState('');
   const [examPurpose, setExamPurpose] = useState<'capacitacion' | 'postulacion' | 'practica' | 'otro'>('practica');
@@ -16,6 +23,7 @@ export default function PerformanceExamPage() {
   const [examMode, setExamMode] = useState<'exam' | 'training' | null>(null);
   const [hasStarted, setHasStarted] = useState(false);
   const [error, setError] = useState('');
+  const [processCode, setProcessCode] = useState(searchParams.get('process')?.toUpperCase() ?? '');
 
   const handleStartExam = (mode: 'exam' | 'training') => {
     if (!participantName.trim()) {
@@ -36,6 +44,26 @@ export default function PerformanceExamPage() {
     setHasStarted(true);
   };
 
+  const handleExamComplete = async (result: ExamResult) => {
+    await saveExamResultAction({
+      exam_type: 'performance',
+      exam_mode: examMode as 'exam' | 'training',
+      participant_name: participantName,
+      score: result.score,
+      total_questions: result.totalQuestions,
+      correct_answers: result.correctAnswers,
+      incorrect_answers: result.incorrectAnswers,
+      passing_score: Math.round(result.totalQuestions * 0.7),
+      passed: result.passed,
+      percentage: result.percentage,
+      time_spent: result.timeSpent,
+      github_profile: githubProfile,
+      exam_purpose: examPurpose,
+      company_name: companyName || undefined,
+      process_code: processCode.trim() || undefined,
+    });
+  };
+
   // Si el examen ha iniciado, mostrar el simulador
   if (hasStarted && examMode) {
     return (
@@ -46,6 +74,7 @@ export default function PerformanceExamPage() {
         companyName={companyName}
         mode={examMode}
         examData={loadExamData()}
+        onExamComplete={handleExamComplete}
       />
     );
   }
@@ -307,6 +336,11 @@ export default function PerformanceExamPage() {
           )}
 
           <div className="space-y-4">
+            <ProcessCodeInput
+              value={processCode}
+              onChange={setProcessCode}
+              autoValidate={!!searchParams.get('process')}
+            />
             <div>
               <label className={`block text-sm font-semibold mb-2 ${
                 isDarkMode ? 'text-slate-300' : 'text-gray-700'

--- a/apps/frontend/src/app/labs/test-app/report/page.tsx
+++ b/apps/frontend/src/app/labs/test-app/report/page.tsx
@@ -1,7 +1,11 @@
 'use client';
 
+export const dynamic = 'force-dynamic';
+
 import { useState, useEffect } from 'react';
+import { useRouter } from 'next/navigation';
 import { useTheme } from '@/contexts/ThemeContext';
+import { useSupabaseAuth } from '@/contexts/SupabaseAuthContext';
 import type { TechnicalReport, BugReport, CandidateInfo, TestSession, ImageEvidence } from './types';
 import {
   calculateScore,
@@ -19,8 +23,14 @@ import { saveExamResultAction } from '@/actions/exams';
 
 export default function TechnicalReportPage() {
   const { isDarkMode } = useTheme();
+  const { user, isLoading } = useSupabaseAuth();
+  const router = useRouter();
 
-  // Candidate Info
+  useEffect(() => {
+    if (!isLoading && !user) router.push('/login');
+  }, [user, isLoading, router]);
+
+  // Candidate Info — pre-filled from session, github editable
   const [candidateInfo, setCandidateInfo] = useState<CandidateInfo>({
     fullName: '',
     email: '',
@@ -29,6 +39,19 @@ export default function TechnicalReportPage() {
     candidateId: '',
     testDate: new Date(),
   });
+
+  // Sync session data into candidateInfo once user loads
+  useEffect(() => {
+    if (user) {
+      const name = user.user_metadata?.full_name || user.user_metadata?.name || '';
+      const email = user.email || '';
+      setCandidateInfo(prev => ({
+        ...prev,
+        fullName: prev.fullName || name,
+        email: prev.email || email,
+      }));
+    }
+  }, [user]);
 
   // Test Session
   const [testSession, setTestSession] = useState<TestSession>({
@@ -364,18 +387,16 @@ export default function TechnicalReportPage() {
   });
 
   const handleSaveToDb = async () => {
-    if (!candidateInfo.fullName) {
-      setSaveError('Ingresá tu nombre completo antes de guardar');
-      return;
-    }
     setIsSaving(true);
     setSaveError('');
+    const participantName = candidateInfo.fullName || user?.user_metadata?.full_name || user?.email || '';
+    const participantEmail = candidateInfo.email || user?.email || '';
     const bugsWithoutImages = bugs.map(({ images: _images, ...rest }) => rest);
     const { error } = await saveExamResultAction({
       exam_type: 'test-app',
       exam_mode: 'exam',
-      participant_name: candidateInfo.fullName,
-      participant_email: candidateInfo.email || undefined,
+      participant_name: participantName,
+      participant_email: participantEmail || undefined,
       candidate_id: candidateInfo.candidateId || undefined,
       score: score.totalPoints,
       total_questions: score.maxPoints,
@@ -406,6 +427,14 @@ export default function TechnicalReportPage() {
       setSavedOk(true);
     }
   };
+
+  if (isLoading || !user) {
+    return (
+      <div className={`min-h-screen ${isDarkMode ? 'bg-slate-900' : 'bg-gray-50'} flex items-center justify-center`}>
+        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-amber-500" />
+      </div>
+    );
+  }
 
   return (
     <div className={`min-h-screen py-8 ${isDarkMode ? 'bg-slate-900' : 'bg-gray-50'}`}>
@@ -480,70 +509,37 @@ export default function TechnicalReportPage() {
           </div>
         </div>
 
-        {/* Candidate Info */}
+        {/* Candidate Info — read-only from session */}
         <div className={`rounded-lg shadow-lg mb-6 p-6 ${isDarkMode ? 'bg-slate-800' : 'bg-white'}`}>
           <h2 className={`text-2xl font-bold mb-4 ${isDarkMode ? 'text-white' : 'text-gray-900'}`}>
             👤 Información del Candidato
           </h2>
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
             <div>
-              <label className={`block text-sm font-medium mb-2 ${isDarkMode ? 'text-white' : 'text-gray-900'}`}>
-                Nombre Completo *
-              </label>
-              <input
-                type="text"
-                value={candidateInfo.fullName}
-                onChange={(e) => setCandidateInfo((prev) => ({ ...prev, fullName: e.target.value }))}
-                className={`w-full px-4 py-2 rounded-lg border ${isDarkMode
-                  ? 'bg-slate-700 border-slate-600 text-white'
-                  : 'bg-white border-gray-300 text-gray-900'
-                  } focus:outline-none focus:ring-2 focus:ring-amber-500`}
-                placeholder="Ej: Juan Pérez"
-              />
+              <p className={`text-xs font-medium mb-1 uppercase tracking-wider ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}>Nombre</p>
+              <p className={`text-base font-medium ${isDarkMode ? 'text-white' : 'text-gray-900'}`}>
+                {candidateInfo.fullName || user?.email || '—'}
+              </p>
             </div>
             <div>
-              <label className={`block text-sm font-medium mb-2 ${isDarkMode ? 'text-white' : 'text-gray-900'}`}>
-                Email *
-              </label>
-              <input
-                type="email"
-                value={candidateInfo.email}
-                onChange={(e) => setCandidateInfo((prev) => ({ ...prev, email: e.target.value }))}
-                className={`w-full px-4 py-2 rounded-lg border ${isDarkMode
-                  ? 'bg-slate-700 border-slate-600 text-white'
-                  : 'bg-white border-gray-300 text-gray-900'
-                  } focus:outline-none focus:ring-2 focus:ring-amber-500`}
-                placeholder="juan@example.com"
-              />
+              <p className={`text-xs font-medium mb-1 uppercase tracking-wider ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}>Email</p>
+              <p className={`text-base ${isDarkMode ? 'text-slate-300' : 'text-gray-700'}`}>
+                {candidateInfo.email || user?.email || '—'}
+              </p>
             </div>
-            <div>
+            <div className="md:col-span-2">
               <label className={`block text-sm font-medium mb-2 ${isDarkMode ? 'text-white' : 'text-gray-900'}`}>
-                GitHub Profile
+                GitHub Profile <span className={`font-normal ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}>(opcional)</span>
               </label>
               <input
                 type="text"
                 value={candidateInfo.githubProfile}
                 onChange={(e) => setCandidateInfo((prev) => ({ ...prev, githubProfile: e.target.value }))}
-                className={`w-full px-4 py-2 rounded-lg border ${isDarkMode
-                  ? 'bg-slate-700 border-slate-600 text-white'
-                  : 'bg-white border-gray-300 text-gray-900'
+                className={`w-full max-w-sm px-4 py-2 rounded-lg border ${isDarkMode
+                  ? 'bg-slate-700 border-slate-600 text-white placeholder-slate-400'
+                  : 'bg-white border-gray-300 text-gray-900 placeholder-gray-400'
                   } focus:outline-none focus:ring-2 focus:ring-amber-500`}
                 placeholder="https://github.com/username"
-              />
-            </div>
-            <div>
-              <label className={`block text-sm font-medium mb-2 ${isDarkMode ? 'text-white' : 'text-gray-900'}`}>
-                Candidate ID *
-              </label>
-              <input
-                type="text"
-                value={candidateInfo.candidateId}
-                onChange={(e) => setCandidateInfo((prev) => ({ ...prev, candidateId: e.target.value }))}
-                className={`w-full px-4 py-2 rounded-lg border ${isDarkMode
-                  ? 'bg-slate-700 border-slate-600 text-white'
-                  : 'bg-white border-gray-300 text-gray-900'
-                  } focus:outline-none focus:ring-2 focus:ring-amber-500`}
-                placeholder="candidate-123"
               />
             </div>
           </div>

--- a/apps/frontend/src/app/labs/test-app/report/page.tsx
+++ b/apps/frontend/src/app/labs/test-app/report/page.tsx
@@ -15,6 +15,7 @@ import {
   clearReportCache,
   formatLastSaved,
 } from './utils';
+import { saveExamResultAction } from '@/actions/exams';
 
 export default function TechnicalReportPage() {
   const { isDarkMode } = useTheme();
@@ -63,6 +64,10 @@ export default function TechnicalReportPage() {
   const [isLoadingCache, setIsLoadingCache] = useState(true);
   const [isSendingEmail, setIsSendingEmail] = useState(false);
   const [emailSent, setEmailSent] = useState(false);
+  const [processCode, setProcessCode] = useState('');
+  const [isSaving, setIsSaving] = useState(false);
+  const [savedOk, setSavedOk] = useState(false);
+  const [saveError, setSaveError] = useState('');
 
   // Load audit log and cached report from localStorage on mount
   useEffect(() => {
@@ -357,6 +362,50 @@ export default function TechnicalReportPage() {
     auditLog,
     score: {} as any,
   });
+
+  const handleSaveToDb = async () => {
+    if (!candidateInfo.fullName) {
+      setSaveError('Ingresá tu nombre completo antes de guardar');
+      return;
+    }
+    setIsSaving(true);
+    setSaveError('');
+    const bugsWithoutImages = bugs.map(({ images: _images, ...rest }) => rest);
+    const { error } = await saveExamResultAction({
+      exam_type: 'test-app',
+      exam_mode: 'exam',
+      participant_name: candidateInfo.fullName,
+      participant_email: candidateInfo.email || undefined,
+      candidate_id: candidateInfo.candidateId || undefined,
+      score: score.totalPoints,
+      total_questions: score.maxPoints,
+      correct_answers: score.totalPoints,
+      incorrect_answers: score.maxPoints - score.totalPoints,
+      passing_score: Math.round(score.maxPoints * 0.6),
+      passed: score.percentage >= 60,
+      percentage: score.percentage,
+      time_spent: testSession.duration * 60,
+      github_profile: candidateInfo.githubProfile || undefined,
+      process_code: processCode.trim().toUpperCase() || undefined,
+      metadata: {
+        bugs: bugsWithoutImages,
+        exploredSections: testSession.exploredSections,
+        bugCount: bugs.length,
+        severityCounts: {
+          critical: bugs.filter(b => b.severity === 'Critical').length,
+          high: bugs.filter(b => b.severity === 'High').length,
+          medium: bugs.filter(b => b.severity === 'Medium').length,
+          low: bugs.filter(b => b.severity === 'Low').length,
+        },
+      },
+    });
+    setIsSaving(false);
+    if (error) {
+      setSaveError(error);
+    } else {
+      setSavedOk(true);
+    }
+  };
 
   return (
     <div className={`min-h-screen py-8 ${isDarkMode ? 'bg-slate-900' : 'bg-gray-50'}`}>
@@ -871,7 +920,39 @@ export default function TechnicalReportPage() {
           <h2 className={`text-2xl font-bold mb-4 ${isDarkMode ? 'text-white' : 'text-gray-900'}`}>
             📄 Generar Informe
           </h2>
+
+          {/* Process code input */}
+          <div className="mb-5">
+            <label className={`block text-sm font-medium mb-1 ${isDarkMode ? 'text-slate-300' : 'text-gray-700'}`}>
+              Código de proceso <span className={`font-normal ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}>(opcional — si participás en un proceso de selección)</span>
+            </label>
+            <input
+              type="text"
+              value={processCode}
+              onChange={e => setProcessCode(e.target.value.toUpperCase())}
+              placeholder="Ej: CLT-2025-ABC"
+              className={`w-full max-w-xs px-3 py-2 rounded-lg border font-mono text-sm outline-none transition-colors ${
+                isDarkMode
+                  ? 'bg-slate-700 border-slate-600 text-white placeholder-slate-400 focus:border-indigo-500'
+                  : 'bg-white border-gray-300 text-gray-900 placeholder-gray-400 focus:border-indigo-500'
+              }`}
+            />
+          </div>
+
           <div className="flex flex-wrap gap-4">
+            <button
+              onClick={handleSaveToDb}
+              disabled={isSaving || savedOk}
+              className={`px-6 py-3 rounded-lg font-medium transition-colors ${
+                savedOk
+                  ? isDarkMode ? 'bg-green-900/50 text-green-300 cursor-not-allowed' : 'bg-green-100 text-green-700 cursor-not-allowed'
+                  : isSaving
+                  ? 'bg-indigo-400 text-white cursor-wait'
+                  : 'bg-indigo-600 hover:bg-indigo-700 text-white'
+              }`}
+            >
+              {isSaving ? 'Guardando...' : savedOk ? '✓ Guardado' : '💾 Guardar resultado'}
+            </button>
             <button
               onClick={handleGeneratePDF}
               className="px-6 py-3 bg-red-600 hover:bg-red-700 text-white rounded-lg font-medium transition-colors"
@@ -909,6 +990,19 @@ export default function TechnicalReportPage() {
               ← Volver al Test App
             </a>
           </div>
+
+          {saveError && (
+            <div className={`mt-4 p-4 rounded-lg ${isDarkMode ? 'bg-red-900/30 border border-red-700' : 'bg-red-50 border border-red-300'}`}>
+              <p className={`text-sm ${isDarkMode ? 'text-red-300' : 'text-red-700'}`}>{saveError}</p>
+            </div>
+          )}
+          {savedOk && (
+            <div className={`mt-4 p-4 rounded-lg ${isDarkMode ? 'bg-green-900/30 border border-green-700' : 'bg-green-50 border border-green-300'}`}>
+              <p className={`text-sm ${isDarkMode ? 'text-green-300' : 'text-green-800'}`}>
+                ✅ Resultado guardado. El employer puede ver tu informe en el dashboard del proceso.
+              </p>
+            </div>
+          )}
           {emailSent && (
             <div className={`mt-4 p-4 rounded-lg ${isDarkMode ? 'bg-green-900/30 border border-green-700' : 'bg-green-50 border border-green-300'}`}>
               <p className={`text-sm ${isDarkMode ? 'text-green-300' : 'text-green-800'}`}>

--- a/apps/frontend/src/components/auth/AuthForm.tsx
+++ b/apps/frontend/src/components/auth/AuthForm.tsx
@@ -82,212 +82,206 @@ export default function AuthForm({
         : `bg-white text-gray-900 placeholder-gray-500 ${hasError ? 'border-red-300' : 'border-gray-300'}`
     }`;
 
+  const fieldClass = (hasError: boolean) =>
+    `w-full px-4 py-2.5 rounded-xl border text-sm outline-none transition-colors ${
+      isDarkMode
+        ? `bg-slate-700/60 text-white placeholder-slate-400 ${hasError ? 'border-red-500 focus:border-red-400' : 'border-slate-600 focus:border-indigo-400'}`
+        : `bg-white text-gray-900 placeholder-gray-400 ${hasError ? 'border-red-400 focus:border-red-400' : 'border-gray-200 focus:border-indigo-400'}`
+    }`;
+
   return (
-    <div className={`min-h-screen flex items-center justify-center py-12 px-4 sm:px-6 lg:px-8 ${isDarkMode ? 'bg-slate-900' : 'bg-gray-50'}`}>
-      <div className="max-w-md w-full space-y-8">
-        <div>
-          <h2 className={`mt-6 text-center text-3xl font-extrabold ${isDarkMode ? 'text-white' : 'text-gray-900'}`}>
-            {title}
-          </h2>
-          <p className={`mt-2 text-center text-sm ${isDarkMode ? 'text-slate-400' : 'text-gray-600'}`}>
-            O{' '}
-            <Link href={linkHref} className="font-medium text-brand-accent hover:text-brand-primary">
-              {linkText}
-            </Link>
+    <div className={`min-h-screen flex items-center justify-center py-12 px-4 ${
+      isDarkMode
+        ? 'bg-slate-900'
+        : 'bg-gradient-to-br from-indigo-50 via-white to-violet-50'
+    }`}>
+
+      {/* Decorative blobs — light mode only */}
+      {!isDarkMode && (
+        <>
+          <div className="absolute top-0 left-0 w-96 h-96 bg-indigo-100 rounded-full mix-blend-multiply filter blur-3xl opacity-40 -translate-x-1/2 -translate-y-1/2 pointer-events-none" />
+          <div className="absolute bottom-0 right-0 w-96 h-96 bg-violet-100 rounded-full mix-blend-multiply filter blur-3xl opacity-40 translate-x-1/2 translate-y-1/2 pointer-events-none" />
+        </>
+      )}
+
+      <div className="relative max-w-md w-full">
+
+        {/* Brand header */}
+        <div className="text-center mb-8">
+          <div className="inline-flex items-center justify-center w-14 h-14 rounded-2xl bg-gradient-to-br from-indigo-500 to-violet-600 shadow-lg mb-4">
+            <span className="text-2xl">🎯</span>
+          </div>
+          <h1 className={`text-2xl font-bold tracking-tight ${isDarkMode ? 'text-white' : 'text-gray-900'}`}>
+            AIQUAA
+          </h1>
+          <p className={`text-sm mt-1 ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}>
+            Plataforma QA de Paraguay
           </p>
         </div>
 
-        <form className="mt-8 space-y-6" onSubmit={onSubmit}>
-          {/* Alertas generales */}
-          {showAlert && (
-            <Alert
-              type={alertType}
-              message={alertMessage}
-              onClose={onClearErrors}
-            />
-          )}
+        {/* Card */}
+        <div className={`rounded-2xl p-8 shadow-xl ${
+          isDarkMode
+            ? 'bg-slate-800 border border-slate-700/60'
+            : 'bg-white border border-gray-100'
+        }`}>
+          <h2 className={`text-xl font-semibold mb-1 ${isDarkMode ? 'text-white' : 'text-gray-900'}`}>
+            {title}
+          </h2>
+          <p className={`text-sm mb-6 ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}>
+            {isLogin ? '¿No tenés cuenta?' : '¿Ya tenés cuenta?'}{' '}
+            <Link href={linkHref} className="font-medium text-indigo-500 hover:text-indigo-400">
+              {linkText}
+            </Link>
+          </p>
 
-          {/* Reenviar confirmación */}
-          {showResend && onResend && (
-            <button
-              type="button"
-              onClick={onResend}
-              disabled={isResending}
-              className={`w-full flex justify-center items-center gap-2 px-4 py-2 border rounded-md text-sm font-medium focus:outline-none focus:ring-2 focus:ring-brand-accent disabled:opacity-50 disabled:cursor-not-allowed transition-colors ${
-                isDarkMode
-                  ? 'border-indigo-500 bg-indigo-900/30 text-indigo-300 hover:bg-indigo-900/50'
-                  : 'border-indigo-300 bg-indigo-50 text-indigo-700 hover:bg-indigo-100'
-              }`}
-            >
-              {isResending ? (
-                <>
-                  <svg className="animate-spin h-4 w-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
-                    <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
-                    <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"></path>
-                  </svg>
-                  {t('auth.resend.loading')}
-                </>
-              ) : (
-                t('auth.resend.button')
-              )}
-            </button>
-          )}
-
-          {/* Alertas de errores de URL */}
-          {error === "OAuthAccountNotLinked" && (
-            <Alert
-              type="error"
-              message={t('auth.error.oauth')}
-              onClose={onClearErrors}
-            />
-          )}
-          {error === "registration_disabled" && (
-            <Alert
-              type="error"
-              message={t('auth.error.registrationDisabled')}
-              onClose={onClearErrors}
-            />
-          )}
-
-          {/* Mensajes de éxito */}
-          {message === "registration_success" && (
-            <Alert
-              type="success"
-              message={t('auth.success.registration')}
-              onClose={onClearErrors}
-            />
-          )}
-
-          {/* Error de OAuth */}
-          {socialLoginError && (
-            <Alert
-              type="error"
-              message={socialLoginError}
-              onClose={() => onSocialError(null)}
-            />
-          )}
-
-          {/* Debug OAuth en desarrollo */}
+          {/* Alerts */}
+          {showAlert && <div className="mb-4"><Alert type={alertType} message={alertMessage} onClose={onClearErrors} /></div>}
+          {error === 'OAuthAccountNotLinked' && <div className="mb-4"><Alert type="error" message={t('auth.error.oauth')} onClose={onClearErrors} /></div>}
+          {error === 'registration_disabled' && <div className="mb-4"><Alert type="error" message={t('auth.error.registrationDisabled')} onClose={onClearErrors} /></div>}
+          {message === 'registration_success' && <div className="mb-4"><Alert type="success" message={t('auth.success.registration')} onClose={onClearErrors} /></div>}
+          {socialLoginError && <div className="mb-4"><Alert type="error" message={socialLoginError} onClose={() => onSocialError(null)} /></div>}
           {process.env.NODE_ENV === 'development' && <OAuthDebug />}
 
-          <div className={`rounded-md shadow-sm -space-y-px ${isDarkMode ? 'shadow-slate-700' : ''}`}>
+          <form onSubmit={onSubmit} className="space-y-4">
+
             {!isLogin && (
               <div>
-                <label htmlFor="name" className="sr-only">{t('auth.field.name')}</label>
+                <label htmlFor="name" className={`block text-xs font-medium mb-1.5 ${isDarkMode ? 'text-slate-300' : 'text-gray-600'}`}>
+                  {t('auth.field.name')}
+                </label>
                 <input
-                  id="name"
-                  name="name"
-                  type="text"
-                  autoComplete="name"
-                  className={inputClass(!!errors.name, 'rounded-t-md')}
-                  placeholder={t('auth.field.name')}
+                  id="name" name="name" type="text" autoComplete="name"
+                  className={fieldClass(!!errors.name)}
+                  placeholder="Tu nombre completo"
                   value={formData.name || ''}
                   onChange={onFieldChange}
                 />
-                {errors.name && <p className="mt-1 text-sm text-red-500">{errors.name}</p>}
+                {errors.name && <p className="mt-1 text-xs text-red-500">{errors.name}</p>}
               </div>
             )}
 
             <div>
-              <label htmlFor="email" className="sr-only">{t('auth.field.email')}</label>
+              <label htmlFor="email" className={`block text-xs font-medium mb-1.5 ${isDarkMode ? 'text-slate-300' : 'text-gray-600'}`}>
+                {t('auth.field.email')}
+              </label>
               <input
-                id="email"
-                name="email"
-                type="text"
-                autoComplete="email"
-                className={inputClass(!!errors.email, isLogin ? 'rounded-t-md' : '')}
-                placeholder={t('auth.field.email')}
+                id="email" name="email" type="text" autoComplete="email"
+                className={fieldClass(!!errors.email)}
+                placeholder="tu@email.com"
                 value={formData.email || ''}
                 onChange={onFieldChange}
               />
-              {errors.email && <p className="mt-1 text-sm text-red-500">{errors.email}</p>}
+              {errors.email && <p className="mt-1 text-xs text-red-500">{errors.email}</p>}
             </div>
 
             <div>
-              <label htmlFor="password" className="sr-only">{t('auth.field.password')}</label>
+              <label htmlFor="password" className={`block text-xs font-medium mb-1.5 ${isDarkMode ? 'text-slate-300' : 'text-gray-600'}`}>
+                {t('auth.field.password')}
+              </label>
               <PasswordInput
                 ref={passwordRef}
-                id="password"
-                name="password"
-                placeholder={t('auth.field.password')}
-                autoComplete={isLogin ? "current-password" : "new-password"}
+                id="password" name="password"
+                placeholder="••••••••"
+                autoComplete={isLogin ? 'current-password' : 'new-password'}
                 onChange={onPasswordChange ?? onFieldChange}
-                className={inputClass(!!errors.password, isLogin ? 'rounded-b-md' : '')}
+                className={fieldClass(!!errors.password)}
                 showStrength={!isLogin}
               />
-              {errors.password && <p className="mt-1 text-sm text-red-500">{errors.password}</p>}
+              {errors.password && <p className="mt-1 text-xs text-red-500">{errors.password}</p>}
             </div>
 
             {!isLogin && (
               <div>
-                <label htmlFor="confirmPassword" className="sr-only">{t('auth.field.confirmPassword')}</label>
+                <label htmlFor="confirmPassword" className={`block text-xs font-medium mb-1.5 ${isDarkMode ? 'text-slate-300' : 'text-gray-600'}`}>
+                  {t('auth.field.confirmPassword')}
+                </label>
                 <PasswordInput
                   ref={confirmPasswordRef}
-                  id="confirmPassword"
-                  name="confirmPassword"
-                  placeholder={t('auth.field.confirmPassword')}
+                  id="confirmPassword" name="confirmPassword"
+                  placeholder="••••••••"
                   autoComplete="new-password"
                   onChange={onPasswordChange ?? onFieldChange}
-                  className={inputClass(!!errors.confirmPassword, 'rounded-b-md')}
+                  className={fieldClass(!!errors.confirmPassword)}
                 />
-                {errors.confirmPassword && <p className="mt-1 text-sm text-red-500">{errors.confirmPassword}</p>}
+                {errors.confirmPassword && <p className="mt-1 text-xs text-red-500">{errors.confirmPassword}</p>}
               </div>
             )}
-          </div>
 
-          {/* Role selector — solo en registro */}
-          {!isLogin && (
-            <div>
-              <p className={`text-sm font-medium mb-2 ${isDarkMode ? 'text-slate-300' : 'text-gray-700'}`}>
-                ¿Cuál es tu rol en QA?
-              </p>
-              <div className="grid grid-cols-2 gap-2">
-                {ROLES.map(role => {
-                  const selected = formData.role === role.value;
-                  return (
-                    <button
-                      key={role.value}
-                      type="button"
-                      onClick={() => onRoleChange?.(role.value)}
-                      className={`flex items-center gap-2 px-3 py-2.5 rounded-lg border text-sm font-medium transition-all ${
-                        selected
-                          ? 'border-indigo-500 bg-indigo-600 text-white shadow-sm'
-                          : isDarkMode
-                            ? 'border-slate-600 bg-slate-700 text-slate-300 hover:border-indigo-400 hover:bg-slate-600'
-                            : 'border-gray-300 bg-white text-gray-700 hover:border-indigo-400 hover:bg-indigo-50'
-                      }`}
-                    >
-                      <span>{role.emoji}</span>
-                      <span className="truncate">{role.label}</span>
-                    </button>
-                  );
-                })}
+            {/* Role selector */}
+            {!isLogin && (
+              <div>
+                <p className={`text-xs font-medium mb-2 ${isDarkMode ? 'text-slate-300' : 'text-gray-600'}`}>
+                  ¿Cuál es tu rol en QA?
+                </p>
+                <div className="grid grid-cols-2 gap-2">
+                  {ROLES.map(role => {
+                    const selected = formData.role === role.value;
+                    return (
+                      <button
+                        key={role.value}
+                        type="button"
+                        onClick={() => onRoleChange?.(role.value)}
+                        className={`flex items-center gap-2 px-3 py-2.5 rounded-xl border text-sm font-medium transition-all ${
+                          selected
+                            ? 'border-indigo-500 bg-indigo-600 text-white shadow-sm'
+                            : isDarkMode
+                              ? 'border-slate-600 bg-slate-700/60 text-slate-300 hover:border-indigo-400'
+                              : 'border-gray-200 bg-gray-50 text-gray-700 hover:border-indigo-300 hover:bg-indigo-50'
+                        }`}
+                      >
+                        <span>{role.emoji}</span>
+                        <span className="truncate">{role.label}</span>
+                      </button>
+                    );
+                  })}
+                </div>
+                {errors.role && <p className="mt-1 text-xs text-red-500">{errors.role}</p>}
               </div>
-              {errors.role && <p className="mt-1 text-sm text-red-500">{errors.role}</p>}
-            </div>
-          )}
+            )}
 
-          <div>
-            <LoadingButton
-              isLoading={isLoading}
-              loadingText={loadingText}
-              type="submit"
-            >
-              {submitText}
-            </LoadingButton>
-          </div>
+            {/* Reenviar confirmación */}
+            {showResend && onResend && (
+              <button
+                type="button"
+                onClick={onResend}
+                disabled={isResending}
+                className={`w-full flex justify-center items-center gap-2 px-4 py-2 rounded-xl border text-sm font-medium transition-colors disabled:opacity-50 ${
+                  isDarkMode
+                    ? 'border-indigo-500 bg-indigo-900/30 text-indigo-300 hover:bg-indigo-900/50'
+                    : 'border-indigo-300 bg-indigo-50 text-indigo-700 hover:bg-indigo-100'
+                }`}
+              >
+                {isResending ? (
+                  <>
+                    <svg className="animate-spin h-4 w-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                      <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                      <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+                    </svg>
+                    {t('auth.resend.loading')}
+                  </>
+                ) : t('auth.resend.button')}
+              </button>
+            )}
 
-          {isLogin && (
-            <div className="flex items-center justify-between text-sm">
-              <Link href="/auth/forgot-password" className={`${isDarkMode ? 'text-slate-400 hover:text-slate-200' : 'text-gray-500 hover:text-gray-700'}`}>
-                ¿Olvidaste tu contraseña?
-              </Link>
-              <Link href="/register" className="font-medium text-brand-accent hover:text-brand-primary">
-                {t('auth.register.link')}
-              </Link>
+            <div className="pt-1">
+              <LoadingButton isLoading={isLoading} loadingText={loadingText} type="submit">
+                {submitText}
+              </LoadingButton>
             </div>
-          )}
-        </form>
+
+            {isLogin && (
+              <div className="flex items-center justify-between text-xs pt-1">
+                <Link href="/auth/forgot-password" className={`${isDarkMode ? 'text-slate-400 hover:text-slate-200' : 'text-gray-400 hover:text-gray-600'}`}>
+                  ¿Olvidaste tu contraseña?
+                </Link>
+                <Link href="/register" className="font-medium text-indigo-500 hover:text-indigo-400">
+                  {t('auth.register.link')}
+                </Link>
+              </div>
+            )}
+          </form>
+        </div>
       </div>
     </div>
   );

--- a/apps/frontend/src/components/auth/AuthForm.tsx
+++ b/apps/frontend/src/components/auth/AuthForm.tsx
@@ -75,18 +75,11 @@ export default function AuthForm({
   const linkText = isLogin ? t('auth.login.linkText') : t('auth.register.linkText');
   const linkHref = isLogin ? '/register' : '/login';
 
-  const inputClass = (hasError: boolean, extra = '') =>
-    `appearance-none rounded-none relative block w-full px-3 py-2 border text-sm focus:outline-none focus:ring-2 focus:ring-brand-accent focus:border-transparent focus:z-10 ${extra} ${
-      isDarkMode
-        ? `bg-slate-700 text-slate-100 placeholder-slate-400 ${hasError ? 'border-red-500' : 'border-slate-600'}`
-        : `bg-white text-gray-900 placeholder-gray-500 ${hasError ? 'border-red-300' : 'border-gray-300'}`
-    }`;
-
   const fieldClass = (hasError: boolean) =>
-    `w-full px-4 py-2.5 rounded-xl border text-sm outline-none transition-colors ${
+    `w-full px-4 py-2.5 rounded-xl border text-sm outline-none shadow-sm transition-all duration-200 focus-visible:ring-2 focus-visible:ring-indigo-400/70 focus-visible:ring-offset-1 ${
       isDarkMode
-        ? `bg-slate-700/60 text-white placeholder-slate-400 ${hasError ? 'border-red-500 focus:border-red-400' : 'border-slate-600 focus:border-indigo-400'}`
-        : `bg-white text-gray-900 placeholder-gray-400 ${hasError ? 'border-red-400 focus:border-red-400' : 'border-gray-200 focus:border-indigo-400'}`
+        ? `bg-slate-700/70 text-white placeholder-slate-400 ${hasError ? 'border-red-500 focus:border-red-400' : 'border-slate-500/80 focus:border-indigo-300'}`
+        : `bg-white text-gray-900 placeholder-gray-400 ${hasError ? 'border-red-400 focus:border-red-400' : 'border-gray-300 focus:border-indigo-400'}`
     }`;
 
   return (
@@ -114,23 +107,23 @@ export default function AuthForm({
           <h1 className={`text-2xl font-bold tracking-tight ${isDarkMode ? 'text-white' : 'text-gray-900'}`}>
             AIQUAA
           </h1>
-          <p className={`text-sm mt-1 ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}>
+          <p className={`text-sm mt-1 ${isDarkMode ? 'text-slate-300' : 'text-gray-600'}`}>
             Plataforma QA de Paraguay
           </p>
         </div>
 
         {/* Card */}
-        <div className={`rounded-2xl p-8 shadow-xl ${
+        <div className={`rounded-2xl p-6 sm:p-8 shadow-xl backdrop-blur-sm ${
           isDarkMode
-            ? 'bg-slate-800 border border-slate-700/60'
-            : 'bg-white border border-gray-100'
+            ? 'bg-slate-800/95 border border-slate-600/60'
+            : 'bg-white/95 border border-gray-200'
         }`}>
           <h2 className={`text-xl font-semibold mb-1 ${isDarkMode ? 'text-white' : 'text-gray-900'}`}>
             {title}
           </h2>
-          <p className={`text-sm mb-6 ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}>
+          <p className={`text-sm mb-6 ${isDarkMode ? 'text-slate-300' : 'text-gray-600'}`}>
             {isLogin ? '¿No tenés cuenta?' : '¿Ya tenés cuenta?'}{' '}
-            <Link href={linkHref} className="font-medium text-indigo-500 hover:text-indigo-400">
+            <Link href={linkHref} className="font-semibold text-indigo-500 hover:text-indigo-400 underline-offset-4 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400 rounded-sm">
               {linkText}
             </Link>
           </p>
@@ -157,7 +150,7 @@ export default function AuthForm({
                   value={formData.name || ''}
                   onChange={onFieldChange}
                 />
-                {errors.name && <p className="mt-1 text-xs text-red-500">{errors.name}</p>}
+                {errors.name && <p className="mt-1 text-xs text-red-500 dark:text-red-400 leading-relaxed">{errors.name}</p>}
               </div>
             )}
 
@@ -172,7 +165,7 @@ export default function AuthForm({
                 value={formData.email || ''}
                 onChange={onFieldChange}
               />
-              {errors.email && <p className="mt-1 text-xs text-red-500">{errors.email}</p>}
+              {errors.email && <p className="mt-1 text-xs text-red-500 dark:text-red-400 leading-relaxed">{errors.email}</p>}
             </div>
 
             <div>
@@ -188,7 +181,7 @@ export default function AuthForm({
                 className={fieldClass(!!errors.password)}
                 showStrength={!isLogin}
               />
-              {errors.password && <p className="mt-1 text-xs text-red-500">{errors.password}</p>}
+              {errors.password && <p className="mt-1 text-xs text-red-500 dark:text-red-400 leading-relaxed">{errors.password}</p>}
             </div>
 
             {!isLogin && (
@@ -204,7 +197,7 @@ export default function AuthForm({
                   onChange={onPasswordChange ?? onFieldChange}
                   className={fieldClass(!!errors.confirmPassword)}
                 />
-                {errors.confirmPassword && <p className="mt-1 text-xs text-red-500">{errors.confirmPassword}</p>}
+                {errors.confirmPassword && <p className="mt-1 text-xs text-red-500 dark:text-red-400 leading-relaxed">{errors.confirmPassword}</p>}
               </div>
             )}
 
@@ -222,7 +215,7 @@ export default function AuthForm({
                         key={role.value}
                         type="button"
                         onClick={() => onRoleChange?.(role.value)}
-                        className={`flex items-center gap-2 px-3 py-2.5 rounded-xl border text-sm font-medium transition-all ${
+                        className={`flex items-center gap-2 px-3 py-2.5 rounded-xl border text-sm font-medium transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400/70 ${
                           selected
                             ? 'border-indigo-500 bg-indigo-600 text-white shadow-sm'
                             : isDarkMode
@@ -236,7 +229,7 @@ export default function AuthForm({
                     );
                   })}
                 </div>
-                {errors.role && <p className="mt-1 text-xs text-red-500">{errors.role}</p>}
+                {errors.role && <p className="mt-1 text-xs text-red-500 dark:text-red-400 leading-relaxed">{errors.role}</p>}
               </div>
             )}
 
@@ -272,10 +265,10 @@ export default function AuthForm({
 
             {isLogin && (
               <div className="flex items-center justify-between text-xs pt-1">
-                <Link href="/auth/forgot-password" className={`${isDarkMode ? 'text-slate-400 hover:text-slate-200' : 'text-gray-400 hover:text-gray-600'}`}>
+                <Link href="/auth/forgot-password" className={`${isDarkMode ? 'text-slate-300 hover:text-white' : 'text-gray-500 hover:text-gray-700'} transition-colors`}>
                   ¿Olvidaste tu contraseña?
                 </Link>
-                <Link href="/register" className="font-medium text-indigo-500 hover:text-indigo-400">
+                <Link href="/register" className="font-semibold text-indigo-500 hover:text-indigo-400 underline-offset-4 hover:underline">
                   {t('auth.register.link')}
                 </Link>
               </div>

--- a/apps/frontend/src/components/labs/ProcessCodeInput.tsx
+++ b/apps/frontend/src/components/labs/ProcessCodeInput.tsx
@@ -1,0 +1,92 @@
+'use client';
+
+import { useState, useCallback, useEffect } from 'react';
+import { useTheme } from '@/contexts/ThemeContext';
+import { validateProcessCodeAction } from '@/actions/employer';
+
+interface Props {
+  value: string;
+  onChange: (code: string) => void;
+  onValidProcess?: (process: { company_name: string; position_name: string } | null) => void;
+  autoValidate?: boolean;
+}
+
+export default function ProcessCodeInput({ value, onChange, onValidProcess, autoValidate }: Props) {
+  const { isDarkMode } = useTheme();
+  const [status, setStatus] = useState<'idle' | 'checking' | 'valid' | 'invalid'>('idle');
+  const [processInfo, setProcessInfo] = useState<{ company_name: string; position_name: string } | null>(null);
+
+  const validate = useCallback(async (code: string) => {
+    if (!code.trim()) {
+      setStatus('idle');
+      setProcessInfo(null);
+      onValidProcess?.(null);
+      return;
+    }
+    setStatus('checking');
+    const { valid, process } = await validateProcessCodeAction(code);
+    if (valid && process) {
+      setStatus('valid');
+      setProcessInfo(process);
+      onValidProcess?.(process);
+    } else {
+      setStatus('invalid');
+      setProcessInfo(null);
+      onValidProcess?.(null);
+    }
+  }, [onValidProcess]);
+
+  useEffect(() => {
+    if (autoValidate && value.trim()) {
+      validate(value);
+    }
+  }, [autoValidate, value, validate]);
+
+  const inputBase = isDarkMode
+    ? 'bg-slate-700 border-slate-600 text-white placeholder-slate-400'
+    : 'bg-white border-gray-300 text-gray-900 placeholder-gray-400';
+
+  const borderColor =
+    status === 'valid' ? 'border-green-500 focus:ring-green-500' :
+    status === 'invalid' ? 'border-red-400 focus:ring-red-400' :
+    'focus:ring-amber-500';
+
+  return (
+    <div className="space-y-2">
+      <label className={`block text-sm font-medium ${isDarkMode ? 'text-white' : 'text-gray-900'}`}>
+        Código de proceso <span className={`font-normal ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}>(opcional)</span>
+      </label>
+      <div className="relative">
+        <input
+          type="text"
+          value={value}
+          onChange={e => onChange(e.target.value.toUpperCase())}
+          onBlur={() => validate(value)}
+          placeholder="Ej: CLT-2025-ABC"
+          className={`w-full px-4 py-2 rounded-lg border font-mono text-sm focus:outline-none focus:ring-2 transition-colors ${inputBase} ${borderColor}`}
+        />
+        {status === 'checking' && (
+          <span className="absolute right-3 top-2.5">
+            <span className="inline-block h-4 w-4 animate-spin rounded-full border-2 border-amber-500 border-t-transparent" />
+          </span>
+        )}
+        {status === 'valid' && <span className="absolute right-3 top-2 text-green-500 text-lg">✓</span>}
+        {status === 'invalid' && <span className="absolute right-3 top-2 text-red-400 text-lg">✗</span>}
+      </div>
+
+      {status === 'valid' && processInfo && (
+        <p className="text-xs text-green-600 dark:text-green-400">
+          Proceso: <strong>{processInfo.position_name}</strong> — {processInfo.company_name}
+        </p>
+      )}
+      {status === 'invalid' && (
+        <p className="text-xs text-red-500">Código inválido o proceso cerrado</p>
+      )}
+      {status === 'idle' && (
+        <p className={`text-xs ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}>
+          Si rendís este examen para un proceso de selección, ingresá el código que te enviaron
+        </p>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
- Tablas Supabase: hiring_processes + process_code en exam_results
- Server actions: employer (crear/listar/candidatos/status) + admin (usuarios/roles/stats)
- Portal empleador (/employer): crear procesos con código único, ver candidatos rankeados
- Portal admin (/admin): gestión de usuarios, roles, empresas y procesos
- Campo process_code en exámenes ISTQB/Git/Performance con validación en tiempo real
- Pre-llenado automático desde URL (?process=CODIGO)
- Función change_user_role en Supabase (solo admins)
- RLS actualizado para admins, employers y candidatos
- Save de resultado implementado en examen Performance