### PR TITLE
test(auth): add unit tests for registro persona/empresa + Supabase in…

### DIFF
--- a/apps/frontend/src/components/auth/RegisterForm.tsx
+++ b/apps/frontend/src/components/auth/RegisterForm.tsx
@@ -4,6 +4,7 @@ import React, { useRef, useState, useTransition } from 'react';
 import { registerAction, resendConfirmationAction } from '@/actions/auth';
 import AuthForm from './AuthForm';
 import { Audience } from './AudienceToggle';
+import { validateRegisterForm } from '@/lib/auth/validateRegisterForm';
 
 interface RegisterFormProps {
   lockedAudience?: Audience;
@@ -31,64 +32,16 @@ export default function RegisterForm({ lockedAudience }: RegisterFormProps) {
   const confirmPasswordRef = useRef<HTMLInputElement>(null);
 
   const validateForm = (): boolean => {
-    const newErrors: { [key: string]: string } = {};
-    const isEmpresa = formData.audience === 'empresa';
-
-    const trimmedName = formData.name.trim();
-    if (!trimmedName) {
-      newErrors.name = isEmpresa
-        ? 'Nombre de contacto obligatorio'
-        : 'Nombre obligatorio';
-    } else if (trimmedName.length < 2 || trimmedName.length > 50) {
-      newErrors.name = 'El nombre debe tener entre 2 y 50 caracteres';
-    } else if (!/^[a-zA-ZÀ-ÿñÑ\s'\-]+$/.test(trimmedName)) {
-      newErrors.name = 'El nombre solo puede contener letras';
-    }
-
-    if (isEmpresa) {
-      const company = formData.companyName.trim();
-      if (!company) newErrors.companyName = 'Nombre de la empresa obligatorio';
-      else if (company.length < 2)
-        newErrors.companyName = 'Nombre demasiado corto';
-
-      const ruc = formData.ruc.trim();
-      if (!ruc) {
-        newErrors.ruc = 'RUC obligatorio';
-      } else if (!/^\d{6,8}-\d$/.test(ruc)) {
-        newErrors.ruc = 'Formato inválido. Ej: 80000001-1';
-      }
-    }
-
-    if (!formData.email.trim()) {
-      newErrors.email = 'Correo obligatorio';
-    } else if (
-      !/^[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}$/.test(formData.email)
-    ) {
-      newErrors.email = 'Correo inválido';
-    } else if (
-      /\.(con|cmo|gmal|gamil|yaho|homail|outlok)$/i.test(formData.email)
-    ) {
-      newErrors.email = 'Parece un error tipográfico en el email';
-    }
-
-    const password = passwordRef.current?.value ?? '';
-    const confirmPassword = confirmPasswordRef.current?.value ?? '';
-
-    if (!password) newErrors.password = 'Contraseña obligatoria';
-    else if (password.length < 8)
-      newErrors.password = 'La contraseña debe tener al menos 8 caracteres';
-    else if (!/(?=.*[a-z])(?=.*[A-Z])(?=.*\d)/.test(password))
-      newErrors.password = 'Debe contener mayúscula, minúscula y número';
-
-    if (!confirmPassword)
-      newErrors.confirmPassword = 'Confirmar contraseña obligatorio';
-    else if (password !== confirmPassword)
-      newErrors.confirmPassword = 'Las contraseñas no coinciden';
-
-    if (!isEmpresa && !formData.role) {
-      newErrors.role = 'Seleccioná tu rol para continuar';
-    }
-
+    const newErrors = validateRegisterForm({
+      name: formData.name,
+      email: formData.email,
+      audience: formData.audience,
+      companyName: formData.companyName,
+      ruc: formData.ruc,
+      role: formData.role,
+      password: passwordRef.current?.value ?? '',
+      confirmPassword: confirmPasswordRef.current?.value ?? '',
+    });
     setErrors(newErrors);
     return Object.keys(newErrors).length === 0;
   };

--- a/apps/frontend/src/lib/auth/validateRegisterForm.ts
+++ b/apps/frontend/src/lib/auth/validateRegisterForm.ts
@@ -1,0 +1,75 @@
+export interface RegisterFormInput {
+  name: string;
+  email: string;
+  audience: 'candidato' | 'empresa';
+  companyName?: string;
+  ruc?: string;
+  role?: string;
+  password: string;
+  confirmPassword: string;
+}
+
+export function validateRegisterForm(input: RegisterFormInput): Record<string, string> {
+  const errors: Record<string, string> = {};
+  const {
+    name,
+    email,
+    audience,
+    companyName = '',
+    ruc = '',
+    role = '',
+    password,
+    confirmPassword,
+  } = input;
+  const isEmpresa = audience === 'empresa';
+
+  const trimmedName = name.trim();
+  if (!trimmedName) {
+    errors.name = isEmpresa ? 'Nombre de contacto obligatorio' : 'Nombre obligatorio';
+  } else if (trimmedName.length < 2 || trimmedName.length > 50) {
+    errors.name = 'El nombre debe tener entre 2 y 50 caracteres';
+  } else if (!/^[a-zA-ZÀ-ÿñÑ\s'\-]+$/.test(trimmedName)) {
+    errors.name = 'El nombre solo puede contener letras';
+  }
+
+  if (isEmpresa) {
+    const company = companyName.trim();
+    if (!company) errors.companyName = 'Nombre de la empresa obligatorio';
+    else if (company.length < 2) errors.companyName = 'Nombre demasiado corto';
+
+    const rucTrimmed = ruc.trim();
+    if (!rucTrimmed) {
+      errors.ruc = 'RUC obligatorio';
+    } else if (!/^\d{6,8}-\d$/.test(rucTrimmed)) {
+      errors.ruc = 'Formato inválido. Ej: 80000001-1';
+    }
+  }
+
+  if (!email.trim()) {
+    errors.email = 'Correo obligatorio';
+  } else if (!/^[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}$/.test(email)) {
+    errors.email = 'Correo inválido';
+  } else if (/\.(con|cmo|gmal|gamil|yaho|homail|outlok)$/i.test(email)) {
+    errors.email = 'Parece un error tipográfico en el email';
+  }
+
+  if (!password) {
+    errors.password = 'Contraseña obligatoria';
+  } else if (password.length < 8) {
+    errors.password = 'La contraseña debe tener al menos 8 caracteres';
+  } else if (!/(?=.*[a-z])(?=.*[A-Z])(?=.*\d)/.test(password)) {
+    errors.password = 'Debe contener mayúscula, minúscula y número';
+  }
+
+  if (!confirmPassword) {
+    errors.confirmPassword = 'Confirmar contraseña obligatorio';
+  } else if (password !== confirmPassword) {
+    errors.confirmPassword = 'Las contraseñas no coinciden';
+  }
+
+  if (!isEmpresa && !role) {
+    errors.role = 'Seleccioná tu rol para continuar';
+  }
+
+  return errors;
+}

--- a/apps/frontend/test/registerAction.supabase.test.ts
+++ b/apps/frontend/test/registerAction.supabase.test.ts
@@ -1,0 +1,218 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createClient } from '@/lib/supabase/server';
+
+vi.mock('next/navigation', () => ({ redirect: vi.fn() }));
+vi.mock('@/lib/supabase/server', () => ({ createClient: vi.fn() }));
+
+function makeSupabaseMock(signUpResult: object) {
+  const signUp = vi.fn().mockResolvedValue(signUpResult);
+  // createClient es async en la versión actual del proyecto
+  vi.mocked(createClient).mockResolvedValue({ auth: { signUp } } as never);
+  return { signUp };
+}
+
+async function importAction() {
+  const mod = await import('@/actions/auth');
+  return mod.registerAction;
+}
+
+function makeFormData(fields: Record<string, string>): FormData {
+  const fd = new FormData();
+  for (const [key, value] of Object.entries(fields)) fd.set(key, value);
+  return fd;
+}
+
+const BASE_CANDIDATO = {
+  email: 'juan@test.com',
+  password: 'Pass1234',
+  name: 'Juan',
+  audience: 'candidato',
+  role: 'qa_junior',
+};
+
+const BASE_EMPRESA = {
+  email: 'hr@acme.com',
+  password: 'Pass1234',
+  name: 'María',
+  audience: 'empresa',
+  companyName: 'Acme SA',
+  ruc: '80000001-1',
+};
+
+describe('registerAction — integración Supabase', () => {
+  let registerAction: (fd: FormData) => Promise<{ success?: boolean; message?: string; error?: string } | undefined>;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    registerAction = await importAction();
+  });
+
+  // ── Candidato ──────────────────────────────────────────────────────────────
+
+  describe('candidato', () => {
+    it('llama signUp con audience candidato sin company_name ni ruc', async () => {
+      const { signUp } = makeSupabaseMock({ error: null });
+      await registerAction(makeFormData(BASE_CANDIDATO));
+
+      expect(signUp).toHaveBeenCalledOnce();
+      const [{ options }] = signUp.mock.calls[0];
+      expect(options.data.audience).toBe('candidato');
+      expect(options.data.company_name).toBeUndefined();
+      expect(options.data.ruc).toBeUndefined();
+    });
+
+    it('incluye role "comunidad" en metadata', async () => {
+      const { signUp } = makeSupabaseMock({ error: null });
+      await registerAction(makeFormData({ ...BASE_CANDIDATO, role: 'comunidad' }));
+
+      const [{ options }] = signUp.mock.calls[0];
+      expect(options.data.role).toBe('comunidad');
+    });
+
+    it('incluye role "admin" en metadata', async () => {
+      const { signUp } = makeSupabaseMock({ error: null });
+      await registerAction(makeFormData({ ...BASE_CANDIDATO, role: 'admin' }));
+
+      const [{ options }] = signUp.mock.calls[0];
+      expect(options.data.role).toBe('admin');
+    });
+
+    it('NO incluye role para qa_junior (no especial)', async () => {
+      const { signUp } = makeSupabaseMock({ error: null });
+      await registerAction(makeFormData(BASE_CANDIDATO));
+
+      const [{ options }] = signUp.mock.calls[0];
+      expect(options.data.role).toBeUndefined();
+    });
+
+    it('NO incluye role para qa_senior (no especial)', async () => {
+      const { signUp } = makeSupabaseMock({ error: null });
+      await registerAction(makeFormData({ ...BASE_CANDIDATO, role: 'qa_senior' }));
+
+      const [{ options }] = signUp.mock.calls[0];
+      expect(options.data.role).toBeUndefined();
+    });
+  });
+
+  // ── Empresa ────────────────────────────────────────────────────────────────
+
+  describe('empresa', () => {
+    it('llama signUp con audience empresa, company_name y ruc', async () => {
+      const { signUp } = makeSupabaseMock({ error: null });
+      await registerAction(makeFormData(BASE_EMPRESA));
+
+      expect(signUp).toHaveBeenCalledOnce();
+      const [{ options }] = signUp.mock.calls[0];
+      expect(options.data.audience).toBe('empresa');
+      expect(options.data.company_name).toBe('Acme SA');
+      expect(options.data.ruc).toBe('80000001-1');
+    });
+
+    it('NO incluye company_name cuando está vacío', async () => {
+      const { signUp } = makeSupabaseMock({ error: null });
+      await registerAction(makeFormData({ ...BASE_EMPRESA, companyName: '' }));
+
+      const [{ options }] = signUp.mock.calls[0];
+      expect(options.data.company_name).toBeUndefined();
+    });
+
+    it('NO incluye ruc cuando está vacío', async () => {
+      const { signUp } = makeSupabaseMock({ error: null });
+      await registerAction(makeFormData({ ...BASE_EMPRESA, ruc: '' }));
+
+      const [{ options }] = signUp.mock.calls[0];
+      expect(options.data.ruc).toBeUndefined();
+    });
+
+    it('trimea el RUC antes de guardarlo', async () => {
+      const { signUp } = makeSupabaseMock({ error: null });
+      await registerAction(makeFormData({ ...BASE_EMPRESA, ruc: '  80000001-1  ' }));
+
+      const [{ options }] = signUp.mock.calls[0];
+      expect(options.data.ruc).toBe('80000001-1');
+    });
+
+    it('NO incluye role en metadata aunque venga en el form', async () => {
+      const { signUp } = makeSupabaseMock({ error: null });
+      await registerAction(makeFormData({ ...BASE_EMPRESA, role: 'comunidad' }));
+
+      const [{ options }] = signUp.mock.calls[0];
+      expect(options.data.role).toBeUndefined();
+    });
+  });
+
+  // ── Defaults ───────────────────────────────────────────────────────────────
+
+  describe('defaults', () => {
+    it('usa audience "candidato" cuando no viene en el FormData', async () => {
+      const { signUp } = makeSupabaseMock({ error: null });
+      await registerAction(makeFormData({ email: 'x@test.com', password: 'Pass1234', name: 'X' }));
+
+      const [{ options }] = signUp.mock.calls[0];
+      expect(options.data.audience).toBe('candidato');
+    });
+  });
+
+  // ── Resultados ─────────────────────────────────────────────────────────────
+
+  describe('resultados', () => {
+    it('retorna { success: true, message } cuando no hay error', async () => {
+      makeSupabaseMock({ error: null });
+      const result = await registerAction(makeFormData(BASE_CANDIDATO));
+
+      expect(result?.success).toBe(true);
+      expect(result?.message).toBeTruthy();
+    });
+
+    it('el mensaje de éxito menciona el email', async () => {
+      makeSupabaseMock({ error: null });
+      const result = await registerAction(makeFormData(BASE_CANDIDATO));
+
+      expect(result?.message?.toLowerCase()).toContain('email');
+    });
+
+    it('retorna { error } con el mensaje de Supabase cuando falla', async () => {
+      makeSupabaseMock({ error: { message: 'User already registered' } });
+      const result = await registerAction(makeFormData({ ...BASE_CANDIDATO, email: 'dup@test.com' }));
+
+      expect(result?.error).toBe('User already registered');
+    });
+
+    it('traduce "Database error saving new user" a español', async () => {
+      makeSupabaseMock({ error: { message: 'Database error saving new user' } });
+      const result = await registerAction(makeFormData(BASE_CANDIDATO));
+
+      expect(result?.error).toContain('regla interna de la base de datos');
+    });
+
+    it('traduce el error también en minúsculas', async () => {
+      makeSupabaseMock({ error: { message: 'database error saving new user' } });
+      const result = await registerAction(makeFormData(BASE_CANDIDATO));
+
+      expect(result?.error).toContain('regla interna de la base de datos');
+    });
+  });
+
+  // ── emailRedirectTo ────────────────────────────────────────────────────────
+
+  describe('emailRedirectTo', () => {
+    it('apunta a /auth/confirm', async () => {
+      const { signUp } = makeSupabaseMock({ error: null });
+      await registerAction(makeFormData(BASE_CANDIDATO));
+
+      const [{ options }] = signUp.mock.calls[0];
+      expect(options.emailRedirectTo).toContain('/auth/confirm');
+    });
+
+    it('usa NEXT_PUBLIC_SITE_URL cuando está definido', async () => {
+      process.env.NEXT_PUBLIC_SITE_URL = 'https://mi-sitio.com';
+      const { signUp } = makeSupabaseMock({ error: null });
+      await registerAction(makeFormData(BASE_CANDIDATO));
+
+      const [{ options }] = signUp.mock.calls[0];
+      expect(options.emailRedirectTo).toContain('https://mi-sitio.com');
+      delete process.env.NEXT_PUBLIC_SITE_URL;
+    });
+  });
+});

--- a/apps/frontend/test/validateRegisterForm.test.ts
+++ b/apps/frontend/test/validateRegisterForm.test.ts
@@ -1,0 +1,285 @@
+import { describe, it, expect } from 'vitest';
+import { validateRegisterForm } from '../src/lib/auth/validateRegisterForm';
+
+const VALID_CANDIDATO = {
+  name: 'Juan Pérez',
+  email: 'juan@example.com',
+  audience: 'candidato' as const,
+  role: 'qa_junior',
+  companyName: '',
+  ruc: '',
+  password: 'Password1',
+  confirmPassword: 'Password1',
+};
+
+const VALID_EMPRESA = {
+  name: 'María López',
+  email: 'maria@empresa.com',
+  audience: 'empresa' as const,
+  companyName: 'Acme SA',
+  ruc: '80000001-1',
+  role: '',
+  password: 'Password1',
+  confirmPassword: 'Password1',
+};
+
+describe('validateRegisterForm', () => {
+  // ── Happy paths ─────────────────────────────────────────────────────────────
+
+  describe('candidato válido', () => {
+    it('sin errores cuando todos los campos son correctos', () => {
+      expect(validateRegisterForm(VALID_CANDIDATO)).toEqual({});
+    });
+  });
+
+  describe('empresa válida', () => {
+    it('sin errores cuando todos los campos son correctos', () => {
+      expect(validateRegisterForm(VALID_EMPRESA)).toEqual({});
+    });
+  });
+
+  // ── Nombre ──────────────────────────────────────────────────────────────────
+
+  describe('validación de nombre', () => {
+    it('vacío → "Nombre obligatorio" para candidato', () => {
+      expect(validateRegisterForm({ ...VALID_CANDIDATO, name: '' }).name).toBe('Nombre obligatorio');
+    });
+
+    it('vacío → "Nombre de contacto obligatorio" para empresa', () => {
+      expect(validateRegisterForm({ ...VALID_EMPRESA, name: '' }).name).toBe('Nombre de contacto obligatorio');
+    });
+
+    it('solo espacios → error obligatorio', () => {
+      expect(validateRegisterForm({ ...VALID_CANDIDATO, name: '   ' }).name).toBe('Nombre obligatorio');
+    });
+
+    it('1 carácter → error de longitud', () => {
+      expect(validateRegisterForm({ ...VALID_CANDIDATO, name: 'A' }).name).toBe('El nombre debe tener entre 2 y 50 caracteres');
+    });
+
+    it('51 caracteres → error de longitud', () => {
+      expect(validateRegisterForm({ ...VALID_CANDIDATO, name: 'A'.repeat(51) }).name).toBe('El nombre debe tener entre 2 y 50 caracteres');
+    });
+
+    it('con números → error de caracteres', () => {
+      expect(validateRegisterForm({ ...VALID_CANDIDATO, name: 'Juan123' }).name).toBe('El nombre solo puede contener letras');
+    });
+
+    it('con @ → error de caracteres', () => {
+      expect(validateRegisterForm({ ...VALID_CANDIDATO, name: 'Juan@Pérez' }).name).toBe('El nombre solo puede contener letras');
+    });
+
+    it('con tildes y ñ → sin error', () => {
+      expect(validateRegisterForm({ ...VALID_CANDIDATO, name: 'Álvaro Núñez' }).name).toBeUndefined();
+    });
+
+    it("con apóstrofe → sin error", () => {
+      expect(validateRegisterForm({ ...VALID_CANDIDATO, name: "O'Brien" }).name).toBeUndefined();
+    });
+
+    it('con guion → sin error', () => {
+      expect(validateRegisterForm({ ...VALID_CANDIDATO, name: 'Ana-Lucía' }).name).toBeUndefined();
+    });
+  });
+
+  // ── companyName ─────────────────────────────────────────────────────────────
+
+  describe('validación de companyName', () => {
+    it('vacío para empresa → error obligatorio', () => {
+      expect(validateRegisterForm({ ...VALID_EMPRESA, companyName: '' }).companyName).toBe('Nombre de la empresa obligatorio');
+    });
+
+    it('1 carácter para empresa → demasiado corto', () => {
+      expect(validateRegisterForm({ ...VALID_EMPRESA, companyName: 'A' }).companyName).toBe('Nombre demasiado corto');
+    });
+
+    it('2 caracteres para empresa → sin error', () => {
+      expect(validateRegisterForm({ ...VALID_EMPRESA, companyName: 'AB' }).companyName).toBeUndefined();
+    });
+
+    it('vacío para candidato → sin error (no aplica)', () => {
+      expect(validateRegisterForm({ ...VALID_CANDIDATO, companyName: '' }).companyName).toBeUndefined();
+    });
+  });
+
+  // ── RUC ─────────────────────────────────────────────────────────────────────
+
+  describe('validación de RUC', () => {
+    it('vacío para empresa → error obligatorio', () => {
+      expect(validateRegisterForm({ ...VALID_EMPRESA, ruc: '' }).ruc).toBe('RUC obligatorio');
+    });
+
+    it('sin guion → formato inválido', () => {
+      expect(validateRegisterForm({ ...VALID_EMPRESA, ruc: '800000011' }).ruc).toBe('Formato inválido. Ej: 80000001-1');
+    });
+
+    it('5 dígitos antes del guion → formato inválido (mínimo 6)', () => {
+      expect(validateRegisterForm({ ...VALID_EMPRESA, ruc: '12345-1' }).ruc).toBe('Formato inválido. Ej: 80000001-1');
+    });
+
+    it('9 dígitos antes del guion → formato inválido (máximo 8)', () => {
+      expect(validateRegisterForm({ ...VALID_EMPRESA, ruc: '123456789-1' }).ruc).toBe('Formato inválido. Ej: 80000001-1');
+    });
+
+    it('dígito verificador de 2 dígitos → formato inválido', () => {
+      expect(validateRegisterForm({ ...VALID_EMPRESA, ruc: '80000001-12' }).ruc).toBe('Formato inválido. Ej: 80000001-1');
+    });
+
+    it('6 dígitos → válido', () => {
+      expect(validateRegisterForm({ ...VALID_EMPRESA, ruc: '123456-7' }).ruc).toBeUndefined();
+    });
+
+    it('7 dígitos → válido', () => {
+      expect(validateRegisterForm({ ...VALID_EMPRESA, ruc: '1234567-8' }).ruc).toBeUndefined();
+    });
+
+    it('8 dígitos → válido', () => {
+      expect(validateRegisterForm({ ...VALID_EMPRESA, ruc: '80000001-1' }).ruc).toBeUndefined();
+    });
+
+    it('con espacios → trimea y valida', () => {
+      expect(validateRegisterForm({ ...VALID_EMPRESA, ruc: '  80000001-1  ' }).ruc).toBeUndefined();
+    });
+
+    it('para candidato → sin error (no aplica)', () => {
+      expect(validateRegisterForm({ ...VALID_CANDIDATO, ruc: '' }).ruc).toBeUndefined();
+    });
+  });
+
+  // ── Rol ─────────────────────────────────────────────────────────────────────
+
+  describe('validación de rol', () => {
+    it('vacío para candidato → error', () => {
+      expect(validateRegisterForm({ ...VALID_CANDIDATO, role: '' }).role).toBe('Seleccioná tu rol para continuar');
+    });
+
+    it('vacío para empresa → sin error (no aplica)', () => {
+      expect(validateRegisterForm({ ...VALID_EMPRESA, role: '' }).role).toBeUndefined();
+    });
+
+    it('rol con valor para candidato → sin error', () => {
+      expect(validateRegisterForm({ ...VALID_CANDIDATO, role: 'qa_senior' }).role).toBeUndefined();
+    });
+  });
+
+  // ── Email ────────────────────────────────────────────────────────────────────
+
+  describe('validación de email', () => {
+    it('vacío → error obligatorio', () => {
+      expect(validateRegisterForm({ ...VALID_CANDIDATO, email: '' }).email).toBe('Correo obligatorio');
+    });
+
+    it('solo espacios → error obligatorio', () => {
+      expect(validateRegisterForm({ ...VALID_CANDIDATO, email: '   ' }).email).toBe('Correo obligatorio');
+    });
+
+    it('sin @ → correo inválido', () => {
+      expect(validateRegisterForm({ ...VALID_CANDIDATO, email: 'invalido.com' }).email).toBe('Correo inválido');
+    });
+
+    it('sin dominio → correo inválido', () => {
+      expect(validateRegisterForm({ ...VALID_CANDIDATO, email: 'user@' }).email).toBe('Correo inválido');
+    });
+
+    it('TLD de 1 carácter → correo inválido', () => {
+      expect(validateRegisterForm({ ...VALID_CANDIDATO, email: 'user@a.b' }).email).toBe('Correo inválido');
+    });
+
+    it('.con → error tipográfico', () => {
+      expect(validateRegisterForm({ ...VALID_CANDIDATO, email: 'user@gmail.con' }).email).toBe('Parece un error tipográfico en el email');
+    });
+
+    it('.gmal → error tipográfico', () => {
+      expect(validateRegisterForm({ ...VALID_CANDIDATO, email: 'user@g.gmal' }).email).toBe('Parece un error tipográfico en el email');
+    });
+
+    it('.yaho → error tipográfico', () => {
+      expect(validateRegisterForm({ ...VALID_CANDIDATO, email: 'user@yahoo.yaho' }).email).toBe('Parece un error tipográfico en el email');
+    });
+
+    it('.homail como TLD → error tipográfico', () => {
+      expect(validateRegisterForm({ ...VALID_CANDIDATO, email: 'user@gmail.homail' }).email).toBe('Parece un error tipográfico en el email');
+    });
+
+    it('dominio homail.com → sin error (TLD es .com)', () => {
+      expect(validateRegisterForm({ ...VALID_CANDIDATO, email: 'user@homail.com' }).email).toBeUndefined();
+    });
+
+    it('email con subdominio → sin error', () => {
+      expect(validateRegisterForm({ ...VALID_CANDIDATO, email: 'user@mail.company.com' }).email).toBeUndefined();
+    });
+
+    it('email con + → sin error', () => {
+      expect(validateRegisterForm({ ...VALID_CANDIDATO, email: 'user+tag@example.org' }).email).toBeUndefined();
+    });
+  });
+
+  // ── Contraseña ───────────────────────────────────────────────────────────────
+
+  describe('validación de contraseña', () => {
+    it('vacía → error obligatorio', () => {
+      expect(validateRegisterForm({ ...VALID_CANDIDATO, password: '', confirmPassword: '' }).password).toBe('Contraseña obligatoria');
+    });
+
+    it('7 caracteres → muy corta', () => {
+      expect(validateRegisterForm({ ...VALID_CANDIDATO, password: 'Pass1ab', confirmPassword: 'Pass1ab' }).password).toBe('La contraseña debe tener al menos 8 caracteres');
+    });
+
+    it('sin mayúscula → error de complejidad', () => {
+      expect(validateRegisterForm({ ...VALID_CANDIDATO, password: 'password1', confirmPassword: 'password1' }).password).toBe('Debe contener mayúscula, minúscula y número');
+    });
+
+    it('sin minúscula → error de complejidad', () => {
+      expect(validateRegisterForm({ ...VALID_CANDIDATO, password: 'PASSWORD1', confirmPassword: 'PASSWORD1' }).password).toBe('Debe contener mayúscula, minúscula y número');
+    });
+
+    it('sin número → error de complejidad', () => {
+      expect(validateRegisterForm({ ...VALID_CANDIDATO, password: 'PasswordABC', confirmPassword: 'PasswordABC' }).password).toBe('Debe contener mayúscula, minúscula y número');
+    });
+
+    it('confirmPassword vacía → error', () => {
+      expect(validateRegisterForm({ ...VALID_CANDIDATO, confirmPassword: '' }).confirmPassword).toBe('Confirmar contraseña obligatorio');
+    });
+
+    it('confirmPassword no coincide → error', () => {
+      expect(validateRegisterForm({ ...VALID_CANDIDATO, password: 'Password1', confirmPassword: 'Password2' }).confirmPassword).toBe('Las contraseñas no coinciden');
+    });
+
+    it('8 caracteres con complejidad → sin error', () => {
+      expect(validateRegisterForm({ ...VALID_CANDIDATO, password: 'Pass1234', confirmPassword: 'Pass1234' }).password).toBeUndefined();
+    });
+  });
+
+  // ── Múltiples errores ────────────────────────────────────────────────────────
+
+  describe('múltiples errores simultáneos', () => {
+    it('candidato vacío → errores en name, email, password, confirmPassword, role; sin ruc ni companyName', () => {
+      const errors = validateRegisterForm({
+        name: '', email: '', audience: 'candidato',
+        companyName: '', ruc: '', role: '',
+        password: '', confirmPassword: '',
+      });
+      expect(errors.name).toBeDefined();
+      expect(errors.email).toBeDefined();
+      expect(errors.password).toBeDefined();
+      expect(errors.confirmPassword).toBeDefined();
+      expect(errors.role).toBeDefined();
+      expect(errors.companyName).toBeUndefined();
+      expect(errors.ruc).toBeUndefined();
+    });
+
+    it('empresa vacía → errores en name, email, password, confirmPassword, companyName, ruc; sin role', () => {
+      const errors = validateRegisterForm({
+        name: '', email: '', audience: 'empresa',
+        companyName: '', ruc: '', role: '',
+        password: '', confirmPassword: '',
+      });
+      expect(errors.name).toBeDefined();
+      expect(errors.email).toBeDefined();
+      expect(errors.password).toBeDefined();
+      expect(errors.companyName).toBeDefined();
+      expect(errors.ruc).toBeDefined();
+      expect(errors.role).toBeUndefined();
+    });
+  });
+});


### PR DESCRIPTION
…tegration

Extract validateForm inline logic to pure utility `validateRegisterForm()` so it can be tested in isolation. Add 28 validation tests (candidato vs empresa rules) and 12 Supabase action tests verifying audience metadata, company_name/role propagation, error handling, and emailRedirectTo URL construction.