### PR TITLE
feat(empresa): dashboard, procesos, candidatos y redirects por audiencia

### DIFF
--- a/apps/frontend/src/actions/auth.ts
+++ b/apps/frontend/src/actions/auth.ts
@@ -8,10 +8,12 @@ export async function loginAction(formData: FormData) {
   const password = formData.get('password') as string;
 
   const supabase = await createClient();
-  const { error } = await supabase.auth.signInWithPassword({ email, password });
+  const { data, error } = await supabase.auth.signInWithPassword({ email, password });
 
   if (error) return { error: error.message };
-  redirect('/forum');
+
+  const audience = data.user?.user_metadata?.audience;
+  redirect(audience === 'empresa' ? '/empresa' : '/ranking?welcome=1');
 }
 
 export async function registerAction(formData: FormData) {

--- a/apps/frontend/src/app/auth/confirm/route.ts
+++ b/apps/frontend/src/app/auth/confirm/route.ts
@@ -1,12 +1,17 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@/lib/supabase/server';
 
+function getDefaultRedirect(audience?: string | null): string {
+  if (audience === 'empresa') return '/empresa';
+  return '/ranking?welcome=1';
+}
+
 export async function GET(request: NextRequest) {
   const { searchParams, origin } = new URL(request.url);
   const code = searchParams.get('code');
   const token_hash = searchParams.get('token_hash');
   const type = searchParams.get('type');
-  const next = searchParams.get('next') ?? '/forum';
+  const next = searchParams.get('next');
   const errorParam = searchParams.get('error');
 
   if (errorParam) {
@@ -16,9 +21,11 @@ export async function GET(request: NextRequest) {
   const supabase = createClient();
 
   if (code) {
-    const { error } = await supabase.auth.exchangeCodeForSession(code);
+    const { data, error } = await supabase.auth.exchangeCodeForSession(code);
     if (!error) {
-      return NextResponse.redirect(`${origin}${next}`);
+      const audience = data.user?.user_metadata?.audience;
+      const destination = next ?? getDefaultRedirect(audience);
+      return NextResponse.redirect(`${origin}${destination}`);
     }
   }
 
@@ -28,7 +35,10 @@ export async function GET(request: NextRequest) {
       type: type as 'signup' | 'recovery' | 'invite' | 'magiclink' | 'email',
     });
     if (!error) {
-      return NextResponse.redirect(`${origin}${next}`);
+      const { data: { user } } = await supabase.auth.getUser();
+      const audience = user?.user_metadata?.audience;
+      const destination = next ?? getDefaultRedirect(audience);
+      return NextResponse.redirect(`${origin}${destination}`);
     }
   }
 

--- a/apps/frontend/src/app/empresa/candidatos/page.tsx
+++ b/apps/frontend/src/app/empresa/candidatos/page.tsx
@@ -1,0 +1,196 @@
+'use client';
+
+import Link from 'next/link';
+import { useEffect, useState } from 'react';
+import { useTheme } from '@/contexts/ThemeContext';
+import { createClient } from '@/lib/supabase/client';
+
+type ExamResult = {
+  id: string;
+  participant_name: string | null;
+  participant_email: string | null;
+  exam_type: string;
+  score: number;
+  percentage: number;
+  passed: boolean;
+  time_spent: number;
+  created_at: string;
+  process_code: string | null;
+};
+
+type HiringProcess = {
+  id: string;
+  code: string;
+  position_name: string;
+  status: string;
+};
+
+export default function CandidatosPage() {
+  const { isDarkMode } = useTheme();
+  const [processes, setProcesses] = useState<HiringProcess[]>([]);
+  const [results, setResults] = useState<ExamResult[]>([]);
+  const [selectedCode, setSelectedCode] = useState<string | 'all'>('all');
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const load = async () => {
+      const supabase = createClient();
+
+      const [{ data: procs }, { data: res }] = await Promise.all([
+        supabase.from('hiring_processes').select('id, code, position_name, status').order('created_at', { ascending: false }),
+        supabase
+          .from('exam_results')
+          .select('id, participant_name, participant_email, exam_type, score, percentage, passed, time_spent, created_at, process_code')
+          .not('process_code', 'is', null)
+          .order('created_at', { ascending: false }),
+      ]);
+
+      // Filter results to only those whose process_code belongs to this employer
+      const myCodes = new Set((procs ?? []).map(p => p.code));
+      const myResults = (res ?? []).filter(r => r.process_code && myCodes.has(r.process_code));
+
+      setProcesses(procs ?? []);
+      setResults(myResults);
+      setLoading(false);
+    };
+    load();
+  }, []);
+
+  const filtered = selectedCode === 'all'
+    ? results
+    : results.filter(r => r.process_code === selectedCode);
+
+  const mins = (secs: number) => `${Math.floor(secs / 60)}m ${secs % 60}s`;
+
+  return (
+    <div className={`min-h-screen transition-colors duration-300 ${isDarkMode ? 'bg-dark-bg' : 'bg-gray-50'}`}>
+      <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+
+        <div className="flex items-center justify-between mb-8">
+          <div>
+            <h1 className={`text-2xl font-bold ${isDarkMode ? 'text-white' : 'text-gray-900'}`}>
+              Candidatos
+            </h1>
+            <p className={`text-sm mt-1 ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}>
+              Resultados de exámenes técnicos por proceso
+            </p>
+          </div>
+        </div>
+
+        {/* Filter by process */}
+        {processes.length > 0 && (
+          <div className="flex gap-2 flex-wrap mb-6">
+            <button
+              onClick={() => setSelectedCode('all')}
+              className={`px-3 py-1.5 rounded-full text-sm font-medium transition-colors ${
+                selectedCode === 'all'
+                  ? 'bg-indigo-600 text-white'
+                  : (isDarkMode ? 'bg-slate-700 text-slate-300 hover:bg-slate-600' : 'bg-gray-100 text-gray-600 hover:bg-gray-200')
+              }`}
+            >
+              Todos
+            </button>
+            {processes.map(p => (
+              <button
+                key={p.code}
+                onClick={() => setSelectedCode(p.code)}
+                className={`px-3 py-1.5 rounded-full text-sm font-medium transition-colors ${
+                  selectedCode === p.code
+                    ? 'bg-indigo-600 text-white'
+                    : (isDarkMode ? 'bg-slate-700 text-slate-300 hover:bg-slate-600' : 'bg-gray-100 text-gray-600 hover:bg-gray-200')
+                }`}
+              >
+                {p.position_name} <span className="opacity-60">({p.code})</span>
+              </button>
+            ))}
+          </div>
+        )}
+
+        {loading && (
+          <div className={`text-center py-16 ${isDarkMode ? 'text-slate-400' : 'text-gray-400'}`}>
+            Cargando...
+          </div>
+        )}
+
+        {!loading && filtered.length === 0 && (
+          <div className={`text-center py-16 rounded-xl border-2 border-dashed ${
+            isDarkMode ? 'border-slate-700 text-slate-500' : 'border-gray-200 text-gray-400'
+          }`}>
+            <p className="text-4xl mb-3">👥</p>
+            <p className="font-medium mb-1">Sin resultados todavía</p>
+            <p className="text-sm">Compartí el código del proceso con tus candidatos para que rindan los exámenes</p>
+          </div>
+        )}
+
+        {!loading && filtered.length > 0 && (
+          <div className={`rounded-xl border overflow-hidden ${isDarkMode ? 'border-slate-700' : 'border-gray-200'}`}>
+            <table className="w-full text-sm">
+              <thead>
+                <tr className={isDarkMode ? 'bg-slate-800' : 'bg-gray-50'}>
+                  {['Candidato', 'Examen', 'Proceso', 'Puntaje', 'Tiempo', 'Fecha'].map(h => (
+                    <th key={h} className={`px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}>
+                      {h}
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {filtered.map((r, i) => (
+                  <tr
+                    key={r.id}
+                    className={`border-t transition-colors ${
+                      isDarkMode
+                        ? `border-slate-700 ${i % 2 === 0 ? 'bg-dark-secondary' : 'bg-slate-800/50'}`
+                        : `border-gray-100 ${i % 2 === 0 ? 'bg-white' : 'bg-gray-50/50'}`
+                    }`}
+                  >
+                    <td className="px-4 py-3">
+                      <div className={`font-medium ${isDarkMode ? 'text-white' : 'text-gray-900'}`}>
+                        {r.participant_name || '—'}
+                      </div>
+                      {r.participant_email && (
+                        <div className={`text-xs ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}>
+                          {r.participant_email}
+                        </div>
+                      )}
+                    </td>
+                    <td className="px-4 py-3">
+                      <span className={`font-mono text-xs px-2 py-0.5 rounded ${isDarkMode ? 'bg-slate-700 text-slate-300' : 'bg-gray-100 text-gray-600'}`}>
+                        {r.exam_type}
+                      </span>
+                    </td>
+                    <td className={`px-4 py-3 text-xs ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}>
+                      {r.process_code}
+                    </td>
+                    <td className="px-4 py-3">
+                      <div className="flex items-center gap-2">
+                        <span className={`font-bold ${r.passed ? 'text-green-500' : 'text-red-500'}`}>
+                          {r.percentage}%
+                        </span>
+                        <span className={`text-xs ${isDarkMode ? 'text-slate-500' : 'text-gray-400'}`}>
+                          ({r.score} pts)
+                        </span>
+                      </div>
+                    </td>
+                    <td className={`px-4 py-3 text-xs ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}>
+                      {mins(r.time_spent)}
+                    </td>
+                    <td className={`px-4 py-3 text-xs ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}>
+                      {new Date(r.created_at).toLocaleDateString('es-PY')}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+
+        <div className="mt-8">
+          <Link href="/empresa" className={`text-sm ${isDarkMode ? 'text-slate-500 hover:text-slate-300' : 'text-gray-400 hover:text-gray-600'} transition-colors`}>
+            ← Volver al panel
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/src/app/empresa/page.tsx
+++ b/apps/frontend/src/app/empresa/page.tsx
@@ -1,0 +1,153 @@
+'use client';
+
+import Link from 'next/link';
+import { useSupabaseAuth } from '@/contexts/SupabaseAuthContext';
+import { useTheme } from '@/contexts/ThemeContext';
+
+const quickLinks = [
+  {
+    href: '/empresa/procesos/nuevo',
+    emoji: '📋',
+    title: 'Nuevo proceso de selección',
+    description: 'Creá un proceso y obtené un código para candidatos',
+    available: true,
+  },
+  {
+    href: '/empresa/procesos',
+    emoji: '📂',
+    title: 'Mis procesos',
+    description: 'Gestioná tus procesos activos y cerrados',
+    available: true,
+  },
+  {
+    href: '/empresa/candidatos',
+    emoji: '👥',
+    title: 'Candidatos',
+    description: 'Revisá los resultados de exámenes por proceso',
+    available: true,
+  },
+  {
+    href: '/perfil',
+    emoji: '🏢',
+    title: 'Perfil de empresa',
+    description: 'Editá la info de tu empresa',
+    available: true,
+  },
+];
+
+export default function EmpresaDashboardPage() {
+  const { user } = useSupabaseAuth();
+  const { isDarkMode } = useTheme();
+
+  const companyName =
+    user?.user_metadata?.company_name ||
+    user?.user_metadata?.full_name ||
+    'tu empresa';
+
+  return (
+    <div className={`min-h-screen transition-colors duration-300 ${isDarkMode ? 'bg-dark-bg' : 'bg-gray-50'}`}>
+      <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+
+        {/* Header */}
+        <div className="mb-10">
+          <div className="flex items-center gap-3 mb-2">
+            <span className="text-3xl">🏢</span>
+            <h1 className={`text-3xl font-bold ${isDarkMode ? 'text-white' : 'text-gray-900'}`}>
+              {companyName}
+            </h1>
+          </div>
+          <p className={`text-lg ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}>
+            Panel de empresa — AIQUAA
+          </p>
+        </div>
+
+        {/* Welcome banner */}
+        <div className={`rounded-xl border p-5 mb-10 flex items-start gap-4 ${
+          isDarkMode
+            ? 'bg-indigo-900/30 border-indigo-700/50 text-indigo-200'
+            : 'bg-indigo-50 border-indigo-200 text-indigo-800'
+        }`}>
+          <span className="text-2xl shrink-0">🎯</span>
+          <div>
+            <p className="font-semibold text-base mb-1">¡Bienvenido a tu panel de empresa!</p>
+            <p className={`text-sm ${isDarkMode ? 'text-indigo-300' : 'text-indigo-600'}`}>
+              Creá procesos de selección, compartí el código con tus candidatos y revisá sus resultados
+              de exámenes técnicos en un solo lugar.
+            </p>
+          </div>
+        </div>
+
+        {/* Quick links grid */}
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+          {quickLinks.map((item) => (
+            item.available ? (
+              <Link
+                key={item.href}
+                href={item.href}
+                className={`group rounded-xl border p-6 transition-all duration-200 ${
+                  isDarkMode
+                    ? 'bg-dark-secondary border-dark-secondary hover:border-indigo-500'
+                    : 'bg-white border-gray-200 hover:border-indigo-400 hover:shadow-md'
+                }`}
+              >
+                <div className="flex items-start gap-4">
+                  <span className="text-3xl">{item.emoji}</span>
+                  <div>
+                    <p className={`font-semibold text-base mb-1 ${isDarkMode ? 'text-white' : 'text-gray-900'}`}>
+                      {item.title}
+                    </p>
+                    <p className={`text-sm ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}>
+                      {item.description}
+                    </p>
+                  </div>
+                </div>
+              </Link>
+            ) : (
+              <div
+                key={item.href}
+                className={`rounded-xl border p-6 opacity-50 cursor-not-allowed ${
+                  isDarkMode
+                    ? 'bg-dark-secondary border-dark-secondary'
+                    : 'bg-white border-gray-200'
+                }`}
+              >
+                <div className="flex items-start gap-4">
+                  <span className="text-3xl">{item.emoji}</span>
+                  <div>
+                    <div className="flex items-center gap-2 mb-1">
+                      <p className={`font-semibold text-base ${isDarkMode ? 'text-white' : 'text-gray-900'}`}>
+                        {item.title}
+                      </p>
+                      <span className={`text-xs font-medium px-2 py-0.5 rounded-full ${
+                        isDarkMode ? 'bg-slate-700 text-slate-400' : 'bg-gray-100 text-gray-400'
+                      }`}>
+                        Próximamente
+                      </span>
+                    </div>
+                    <p className={`text-sm ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}>
+                      {item.description}
+                    </p>
+                  </div>
+                </div>
+              </div>
+            )
+          ))}
+        </div>
+
+        {/* Footer link to forum */}
+        <div className="mt-10 text-center">
+          <p className={`text-sm ${isDarkMode ? 'text-slate-500' : 'text-gray-400'}`}>
+            ¿Querés explorar la comunidad?{' '}
+            <Link
+              href="/forum"
+              className={`underline transition-colors ${isDarkMode ? 'text-indigo-400 hover:text-indigo-300' : 'text-indigo-600 hover:text-indigo-500'}`}
+            >
+              Ir al foro
+            </Link>
+          </p>
+        </div>
+
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/src/app/empresa/procesos/nuevo/page.tsx
+++ b/apps/frontend/src/app/empresa/procesos/nuevo/page.tsx
@@ -1,0 +1,229 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { useTheme } from '@/contexts/ThemeContext';
+import { createClient } from '@/lib/supabase/client';
+
+const EXAM_OPTIONS = [
+  { id: 'istqb',       label: 'ISTQB — Fundamentos de QA' },
+  { id: 'git',         label: 'Git — Control de versiones' },
+  { id: 'performance', label: 'Performance — Pruebas de carga' },
+];
+
+function generateCode(positionName: string): string {
+  const slug = positionName
+    .toLowerCase()
+    .replace(/[^a-z0-9\s]/g, '')
+    .trim()
+    .split(/\s+/)
+    .slice(0, 2)
+    .join('-');
+  const rand = Math.random().toString(36).substring(2, 6).toUpperCase();
+  return `${slug}-${rand}`;
+}
+
+export default function NuevoProcesoPage() {
+  const { isDarkMode } = useTheme();
+  const router = useRouter();
+
+  const [positionName, setPositionName] = useState('');
+  const [description, setDescription] = useState('');
+  const [examTypes, setExamTypes] = useState<string[]>(['istqb', 'git', 'performance']);
+  const [expiresAt, setExpiresAt] = useState('');
+  const [status, setStatus] = useState<'draft' | 'active'>('active');
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const toggleExam = (id: string) => {
+    setExamTypes(prev =>
+      prev.includes(id) ? prev.filter(e => e !== id) : [...prev, id]
+    );
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!positionName.trim()) return;
+    if (examTypes.length === 0) {
+      setError('Seleccioná al menos un tipo de examen.');
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+
+    const supabase = createClient();
+    const { data: { user } } = await supabase.auth.getUser();
+    if (!user) {
+      setError('No estás autenticado.');
+      setLoading(false);
+      return;
+    }
+
+    const code = generateCode(positionName);
+    const { error: insertError } = await supabase
+      .from('hiring_processes')
+      .insert({
+        code,
+        created_by: user.id,
+        company_name: user.user_metadata?.company_name ?? '',
+        position_name: positionName.trim(),
+        description: description.trim() || null,
+        exam_types: examTypes,
+        status,
+        expires_at: expiresAt || null,
+      });
+
+    if (insertError) {
+      setError(insertError.message);
+      setLoading(false);
+      return;
+    }
+
+    router.push('/empresa/procesos');
+  };
+
+  const inputClass = `w-full rounded-lg border px-3 py-2 text-sm outline-none transition-colors focus:ring-2 focus:ring-indigo-500 ${
+    isDarkMode
+      ? 'bg-slate-700 border-slate-600 text-white placeholder-slate-400'
+      : 'bg-white border-gray-300 text-gray-900 placeholder-gray-400'
+  }`;
+
+  const labelClass = `block text-sm font-medium mb-1.5 ${isDarkMode ? 'text-slate-300' : 'text-gray-700'}`;
+
+  return (
+    <div className={`min-h-screen transition-colors duration-300 ${isDarkMode ? 'bg-dark-bg' : 'bg-gray-50'}`}>
+      <div className="max-w-2xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+
+        <div className="mb-8">
+          <h1 className={`text-2xl font-bold ${isDarkMode ? 'text-white' : 'text-gray-900'}`}>
+            Nuevo proceso de selección
+          </h1>
+          <p className={`text-sm mt-1 ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}>
+            Creá un proceso y compartí el código con los candidatos para que rindan los exámenes
+          </p>
+        </div>
+
+        <form
+          onSubmit={handleSubmit}
+          className={`rounded-xl border p-6 space-y-6 ${
+            isDarkMode ? 'bg-dark-secondary border-slate-700' : 'bg-white border-gray-200'
+          }`}
+        >
+          {/* Position name */}
+          <div>
+            <label className={labelClass}>Puesto / posición *</label>
+            <input
+              type="text"
+              className={inputClass}
+              placeholder="ej. QA Analyst Jr."
+              value={positionName}
+              onChange={e => setPositionName(e.target.value)}
+              required
+              maxLength={120}
+            />
+          </div>
+
+          {/* Description */}
+          <div>
+            <label className={labelClass}>Descripción <span className={isDarkMode ? 'text-slate-500' : 'text-gray-400'}>(opcional)</span></label>
+            <textarea
+              className={`${inputClass} resize-none`}
+              rows={3}
+              placeholder="Describí brevemente el proceso o los requisitos del puesto"
+              value={description}
+              onChange={e => setDescription(e.target.value)}
+              maxLength={500}
+            />
+          </div>
+
+          {/* Exam types */}
+          <div>
+            <label className={labelClass}>Exámenes a rendir *</label>
+            <div className="space-y-2">
+              {EXAM_OPTIONS.map(opt => (
+                <label
+                  key={opt.id}
+                  className={`flex items-center gap-3 px-4 py-3 rounded-lg border cursor-pointer transition-colors ${
+                    examTypes.includes(opt.id)
+                      ? (isDarkMode ? 'border-indigo-500 bg-indigo-900/30' : 'border-indigo-400 bg-indigo-50')
+                      : (isDarkMode ? 'border-slate-600 hover:border-slate-500' : 'border-gray-200 hover:border-gray-300')
+                  }`}
+                >
+                  <input
+                    type="checkbox"
+                    className="accent-indigo-600 w-4 h-4"
+                    checked={examTypes.includes(opt.id)}
+                    onChange={() => toggleExam(opt.id)}
+                  />
+                  <span className={`text-sm font-medium ${isDarkMode ? 'text-slate-200' : 'text-gray-800'}`}>
+                    {opt.label}
+                  </span>
+                </label>
+              ))}
+            </div>
+          </div>
+
+          {/* Expires at */}
+          <div>
+            <label className={labelClass}>Fecha de vencimiento <span className={isDarkMode ? 'text-slate-500' : 'text-gray-400'}>(opcional)</span></label>
+            <input
+              type="date"
+              className={inputClass}
+              value={expiresAt}
+              onChange={e => setExpiresAt(e.target.value)}
+              min={new Date().toISOString().split('T')[0]}
+            />
+          </div>
+
+          {/* Status */}
+          <div>
+            <label className={labelClass}>Estado inicial</label>
+            <div className="flex gap-3">
+              {(['active', 'draft'] as const).map(s => (
+                <button
+                  key={s}
+                  type="button"
+                  onClick={() => setStatus(s)}
+                  className={`flex-1 py-2.5 rounded-lg text-sm font-medium border transition-colors ${
+                    status === s
+                      ? 'border-indigo-500 bg-indigo-600 text-white'
+                      : (isDarkMode ? 'border-slate-600 text-slate-300 hover:border-slate-500' : 'border-gray-300 text-gray-700 hover:border-gray-400')
+                  }`}
+                >
+                  {s === 'active' ? '✅ Activo (candidatos pueden rendir)' : '📝 Borrador (guardado, no visible)'}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          {error && (
+            <div className="rounded-lg border border-red-300 bg-red-50 text-red-700 px-4 py-3 text-sm">
+              {error}
+            </div>
+          )}
+
+          <div className="flex gap-3 pt-2">
+            <button
+              type="submit"
+              disabled={loading || !positionName.trim()}
+              className="flex-1 py-2.5 rounded-lg text-sm font-semibold bg-indigo-600 text-white hover:bg-indigo-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+            >
+              {loading ? 'Creando...' : 'Crear proceso'}
+            </button>
+            <button
+              type="button"
+              onClick={() => router.push('/empresa/procesos')}
+              className={`px-5 py-2.5 rounded-lg text-sm font-medium transition-colors ${
+                isDarkMode ? 'text-slate-300 hover:bg-slate-700' : 'text-gray-700 hover:bg-gray-100'
+              }`}
+            >
+              Cancelar
+            </button>
+          </div>
+        </form>
+
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/src/app/empresa/procesos/page.tsx
+++ b/apps/frontend/src/app/empresa/procesos/page.tsx
@@ -1,0 +1,166 @@
+'use client';
+
+import Link from 'next/link';
+import { useEffect, useState } from 'react';
+import { useTheme } from '@/contexts/ThemeContext';
+import { createClient } from '@/lib/supabase/client';
+
+type HiringProcess = {
+  id: string;
+  code: string;
+  position_name: string;
+  description: string | null;
+  status: 'draft' | 'active' | 'closed';
+  exam_types: string[];
+  expires_at: string | null;
+  created_at: string;
+};
+
+const statusLabel: Record<string, { text: string; className: string }> = {
+  draft:  { text: 'Borrador',  className: 'bg-gray-100 text-gray-600' },
+  active: { text: 'Activo',    className: 'bg-green-100 text-green-700' },
+  closed: { text: 'Cerrado',   className: 'bg-red-100 text-red-600' },
+};
+
+export default function ProcesosPage() {
+  const { isDarkMode } = useTheme();
+  const [processes, setProcesses] = useState<HiringProcess[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const load = async () => {
+      const supabase = createClient();
+      const { data, error } = await supabase
+        .from('hiring_processes')
+        .select('*')
+        .order('created_at', { ascending: false });
+
+      if (error) setError(error.message);
+      else setProcesses(data ?? []);
+      setLoading(false);
+    };
+    load();
+  }, []);
+
+  return (
+    <div className={`min-h-screen transition-colors duration-300 ${isDarkMode ? 'bg-dark-bg' : 'bg-gray-50'}`}>
+      <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+
+        <div className="flex items-center justify-between mb-8">
+          <div>
+            <h1 className={`text-2xl font-bold ${isDarkMode ? 'text-white' : 'text-gray-900'}`}>
+              Mis procesos de selección
+            </h1>
+            <p className={`text-sm mt-1 ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}>
+              Todos tus procesos activos, borradores y cerrados
+            </p>
+          </div>
+          <Link
+            href="/empresa/procesos/nuevo"
+            className="inline-flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-semibold bg-indigo-600 text-white hover:bg-indigo-700 transition-colors"
+          >
+            + Nuevo proceso
+          </Link>
+        </div>
+
+        {loading && (
+          <div className={`text-center py-16 ${isDarkMode ? 'text-slate-400' : 'text-gray-400'}`}>
+            Cargando...
+          </div>
+        )}
+
+        {error && (
+          <div className="rounded-xl border border-red-300 bg-red-50 text-red-700 px-5 py-4 text-sm">
+            Error al cargar procesos: {error}
+          </div>
+        )}
+
+        {!loading && !error && processes.length === 0 && (
+          <div className={`text-center py-16 rounded-xl border-2 border-dashed ${
+            isDarkMode ? 'border-slate-700 text-slate-500' : 'border-gray-200 text-gray-400'
+          }`}>
+            <p className="text-4xl mb-3">📂</p>
+            <p className="font-medium mb-1">No tenés procesos todavía</p>
+            <p className="text-sm mb-6">Creá tu primer proceso de selección para empezar a recibir candidatos</p>
+            <Link
+              href="/empresa/procesos/nuevo"
+              className="inline-flex items-center gap-2 px-5 py-2.5 rounded-lg text-sm font-semibold bg-indigo-600 text-white hover:bg-indigo-700 transition-colors"
+            >
+              Crear primer proceso
+            </Link>
+          </div>
+        )}
+
+        {!loading && !error && processes.length > 0 && (
+          <div className="space-y-3">
+            {processes.map((p) => {
+              const s = statusLabel[p.status] ?? statusLabel.draft;
+              return (
+                <div
+                  key={p.id}
+                  className={`rounded-xl border p-5 transition-colors ${
+                    isDarkMode ? 'bg-dark-secondary border-slate-700' : 'bg-white border-gray-200'
+                  }`}
+                >
+                  <div className="flex items-start justify-between gap-4">
+                    <div className="min-w-0 flex-1">
+                      <div className="flex items-center gap-2 flex-wrap mb-1">
+                        <h2 className={`font-semibold text-base ${isDarkMode ? 'text-white' : 'text-gray-900'}`}>
+                          {p.position_name}
+                        </h2>
+                        <span className={`text-xs font-medium px-2 py-0.5 rounded-full ${
+                          isDarkMode
+                            ? (p.status === 'active' ? 'bg-green-900/40 text-green-300' : p.status === 'closed' ? 'bg-red-900/40 text-red-300' : 'bg-slate-700 text-slate-400')
+                            : s.className
+                        }`}>
+                          {s.text}
+                        </span>
+                      </div>
+                      {p.description && (
+                        <p className={`text-sm mb-2 line-clamp-2 ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}>
+                          {p.description}
+                        </p>
+                      )}
+                      <div className="flex items-center gap-4 flex-wrap">
+                        <span className={`text-xs font-mono px-2 py-1 rounded ${
+                          isDarkMode ? 'bg-slate-700 text-slate-300' : 'bg-gray-100 text-gray-600'
+                        }`}>
+                          Código: {p.code}
+                        </span>
+                        <span className={`text-xs ${isDarkMode ? 'text-slate-500' : 'text-gray-400'}`}>
+                          {p.exam_types.join(', ')}
+                        </span>
+                        {p.expires_at && (
+                          <span className={`text-xs ${isDarkMode ? 'text-slate-500' : 'text-gray-400'}`}>
+                            Vence: {new Date(p.expires_at).toLocaleDateString('es-PY')}
+                          </span>
+                        )}
+                      </div>
+                    </div>
+                    <Link
+                      href={`/empresa/procesos/${p.id}`}
+                      className={`shrink-0 text-sm font-medium px-3 py-1.5 rounded-lg transition-colors ${
+                        isDarkMode
+                          ? 'text-indigo-300 hover:bg-slate-700'
+                          : 'text-indigo-600 hover:bg-indigo-50'
+                      }`}
+                    >
+                      Ver →
+                    </Link>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        )}
+
+        <div className="mt-8">
+          <Link href="/empresa" className={`text-sm ${isDarkMode ? 'text-slate-500 hover:text-slate-300' : 'text-gray-400 hover:text-gray-600'} transition-colors`}>
+            ← Volver al panel
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/src/app/ranking/page.tsx
+++ b/apps/frontend/src/app/ranking/page.tsx
@@ -2,7 +2,9 @@
 
 import React, { useState, useEffect } from 'react';
 import Image from 'next/image';
+import { useRouter, useSearchParams } from 'next/navigation';
 import { useTheme } from '@/contexts/ThemeContext';
+import { useSupabaseAuth } from '@/contexts/SupabaseAuthContext';
 import { getLeaderboardAction } from '@/actions/exams';
 import type { Reporter } from '@/app/api/github/reporters/route';
 
@@ -213,9 +215,26 @@ function ReportadoresTab({ isDarkMode }: { isDarkMode: boolean }) {
 
 export default function RankingPage() {
   const { isDarkMode } = useTheme();
+  const { user } = useSupabaseAuth();
+  const searchParams = useSearchParams();
+  const router = useRouter();
   const [activeTab, setActiveTab] = useState<TabKey>('reportes');
   const [examData, setExamData] = useState<Record<string, LeaderboardEntry[]>>({ git: [], istqb: [], performance: [] });
   const [examLoading, setExamLoading] = useState<Record<string, boolean>>({ git: true, istqb: true, performance: true });
+  const [showWelcome, setShowWelcome] = useState(false);
+
+  const isWelcome = searchParams.get('welcome') === '1';
+
+  useEffect(() => {
+    if (isWelcome) {
+      setShowWelcome(true);
+      // Remove param from URL without re-render
+      router.replace('/ranking', { scroll: false });
+      // Auto-dismiss after 6s
+      const t = setTimeout(() => setShowWelcome(false), 6000);
+      return () => clearTimeout(t);
+    }
+  }, [isWelcome, router]);
 
   useEffect(() => {
     (['git', 'istqb', 'performance'] as const).forEach((key) => {
@@ -234,9 +253,38 @@ export default function RankingPage() {
   const top3 = entries.slice(0, 3);
   const rest = entries.slice(3);
 
+  const firstName = user?.user_metadata?.full_name?.split(' ')[0] ?? 'por acá';
+
   return (
     <div className={`min-h-screen py-10 px-4 ${isDarkMode ? 'bg-slate-900' : 'bg-gray-50'}`}>
       <div className="max-w-3xl mx-auto space-y-8">
+
+        {/* Welcome banner */}
+        {showWelcome && (
+          <div
+            className={`rounded-2xl border px-5 py-4 flex items-start gap-4 transition-all duration-500 ${
+              isDarkMode
+                ? 'bg-indigo-900/40 border-indigo-700/60 text-indigo-100'
+                : 'bg-indigo-50 border-indigo-200 text-indigo-900'
+            }`}
+          >
+            <span className="text-3xl shrink-0">👋</span>
+            <div className="flex-1 min-w-0">
+              <p className="font-bold text-base">¡Bienvenido/a, {firstName}!</p>
+              <p className={`text-sm mt-0.5 ${isDarkMode ? 'text-indigo-300' : 'text-indigo-600'}`}>
+                Ya sos parte de AIQUAA. Acá podés ver el ranking de los mejores puntajes.
+                ¿Te animás a aparecer?
+              </p>
+            </div>
+            <button
+              onClick={() => setShowWelcome(false)}
+              className={`shrink-0 text-lg leading-none transition-opacity hover:opacity-60 ${isDarkMode ? 'text-indigo-300' : 'text-indigo-400'}`}
+              aria-label="Cerrar"
+            >
+              ×
+            </button>
+          </div>
+        )}
 
         {/* Header */}
         <div className="text-center space-y-2">

--- a/apps/frontend/src/components/Header.tsx
+++ b/apps/frontend/src/components/Header.tsx
@@ -20,6 +20,14 @@ const navLinks = [
   { href: '/about', label: 'nav.about', emoji: '' },
 ];
 
+const empresaNavLinks = [
+  { href: '/empresa', label: 'Panel', emoji: '🏢' },
+  { href: '/empresa/procesos', label: 'Mis procesos', emoji: '📂' },
+  { href: '/empresa/candidatos', label: 'Candidatos', emoji: '👥' },
+  { href: '/forum', label: 'Foro', emoji: '💬' },
+  { href: '/about', label: 'Nosotros', emoji: '' },
+];
+
 const Header = () => {
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
   const [isUserMenuOpen, setIsUserMenuOpen] = useState(false);
@@ -27,6 +35,8 @@ const Header = () => {
   const { isDarkMode, toggleDarkMode } = useTheme();
   const { t } = useLanguage();
   const { user, isAuthenticated, isLoading } = useSupabaseAuth();
+  const isEmpresa = user?.user_metadata?.audience === 'empresa';
+  const activeNavLinks = isEmpresa ? empresaNavLinks : navLinks;
 
   const closeMobileMenu = () => setIsMobileMenuOpen(false);
 
@@ -106,6 +116,17 @@ const Header = () => {
                         {user?.email}
                       </p>
                     </div>
+                    {isEmpresa && (
+                      <Link
+                        href="/empresa"
+                        onClick={() => setIsUserMenuOpen(false)}
+                        className={`flex items-center gap-2 px-4 py-2.5 text-sm font-medium transition-colors ${
+                          isDarkMode ? 'text-indigo-300 hover:bg-slate-700' : 'text-indigo-600 hover:bg-indigo-50'
+                        }`}
+                      >
+                        🏢 Panel de empresa
+                      </Link>
+                    )}
                     <Link
                       href="/perfil"
                       onClick={() => setIsUserMenuOpen(false)}
@@ -115,15 +136,17 @@ const Header = () => {
                     >
                       👤 Mi perfil
                     </Link>
-                    <Link
-                      href="/forum"
-                      onClick={() => setIsUserMenuOpen(false)}
-                      className={`flex items-center gap-2 px-4 py-2.5 text-sm transition-colors ${
-                        isDarkMode ? 'text-slate-200 hover:bg-slate-700' : 'text-gray-700 hover:bg-gray-50'
-                      }`}
-                    >
-                      💬 Foro
-                    </Link>
+                    {!isEmpresa && (
+                      <Link
+                        href="/forum"
+                        onClick={() => setIsUserMenuOpen(false)}
+                        className={`flex items-center gap-2 px-4 py-2.5 text-sm transition-colors ${
+                          isDarkMode ? 'text-slate-200 hover:bg-slate-700' : 'text-gray-700 hover:bg-gray-50'
+                        }`}
+                      >
+                        💬 Foro
+                      </Link>
+                    )}
                     <div className={`border-t ${isDarkMode ? 'border-slate-700' : 'border-gray-100'}`} />
                     <button
                       onClick={handleLogout}
@@ -208,7 +231,7 @@ const Header = () => {
           role="navigation"
           aria-label="Navegación principal"
         >
-          {navLinks.map((link, i) => (
+          {activeNavLinks.map((link, i) => (
             <span key={link.href} className="flex items-center">
               {i > 0 && (
                 <span className={`mx-2 text-xs select-none ${isDarkMode ? 'text-dark-secondary' : 'text-white/20'}`}>
@@ -217,7 +240,7 @@ const Header = () => {
               )}
               <Link href={link.href} className={`${linkClass} flex items-center gap-1`}>
                 {link.emoji && <span>{link.emoji}</span>}
-                {t(link.label)}
+                {link.label.startsWith('nav.') ? t(link.label) : link.label}
               </Link>
             </span>
           ))}
@@ -233,7 +256,7 @@ const Header = () => {
               <LanguageSelector />
             </div>
 
-            {navLinks.map((link) => (
+            {activeNavLinks.map((link) => (
               <Link
                 key={link.href}
                 href={link.href}
@@ -243,7 +266,7 @@ const Header = () => {
                 }`}
               >
                 {link.emoji && <span>{link.emoji}</span>}
-                {t(link.label)}
+                {link.label.startsWith('nav.') ? t(link.label) : link.label}
               </Link>
             ))}
 
@@ -267,6 +290,17 @@ const Header = () => {
                     </p>
                   </div>
                 </div>
+                {isEmpresa && (
+                  <Link
+                    href="/empresa"
+                    onClick={closeMobileMenu}
+                    className={`flex items-center gap-2 px-3 py-2 rounded-md text-base font-semibold transition-colors duration-200 ${
+                      isDarkMode ? 'text-indigo-300 hover:bg-dark-secondary' : 'text-indigo-300 hover:bg-white/10'
+                    }`}
+                  >
+                    🏢 Panel de empresa
+                  </Link>
+                )}
                 <Link
                   href="/perfil"
                   onClick={closeMobileMenu}

--- a/apps/frontend/src/middleware.ts
+++ b/apps/frontend/src/middleware.ts
@@ -1,7 +1,7 @@
 import { createServerClient } from '@supabase/ssr';
 import { NextResponse, type NextRequest } from 'next/server';
 
-const PROTECTED_ROUTES = ['/dashboard', '/labs', '/perfil'];
+const PROTECTED_ROUTES = ['/dashboard', '/labs', '/perfil', '/empresa'];
 const AUTH_ROUTES = ['/login', '/register'];
 
 export async function middleware(request: NextRequest) {
@@ -54,6 +54,8 @@ export const config = {
     '/dashboard/:path*',
     '/labs/:path*',
     '/perfil/:path*',
+    '/empresa',
+    '/empresa/:path*',
     '/login',
     '/register',
   ],


### PR DESCRIPTION
- Redirect post-login/confirmación: empresa → /empresa, candidatos → /ranking?welcome=1
- Panel de empresa (/empresa) con acceso rápido a procesos y candidatos
- Página de procesos (/empresa/procesos) — lista hiring_processes del usuario
- Formulario nuevo proceso (/empresa/procesos/nuevo) — crea hiring_process con código
- Página candidatos (/empresa/candidatos) — resultados de exámenes por proceso
- Header con nav condicional: empresa ve Panel, Mis procesos, Candidatos
- Middleware protege /empresa y /empresa/* (requiere auth)
- Banner de bienvenida en ranking con nombre del usuario
- Supabase: trigger handle_new_user asigna role=employer a empresas, backfill existentes