### PR TITLE
fix(auth): fix OTP expired error page and login network error handling

### DIFF
--- a/apps/frontend/src/actions/auth.ts
+++ b/apps/frontend/src/actions/auth.ts
@@ -83,7 +83,7 @@ export async function resendConfirmationAction(email: string) {
 export async function forgotPasswordAction(email: string) {
   const supabase = createClient();
   const siteUrl =
-    process.env.NEXT_PUBLIC_SITE_URL || process.env.NEXTAUTH_URL || '';
+    process.env.NEXT_PUBLIC_SITE_URL || process.env.NEXTAUTH_URL || 'https://aiquaa.com';
   const { error } = await supabase.auth.resetPasswordForEmail(email, {
     redirectTo: `${siteUrl}/auth/confirm?next=/auth/reset-password`,
   });

--- a/apps/frontend/src/app/auth/confirm-result/page.tsx
+++ b/apps/frontend/src/app/auth/confirm-result/page.tsx
@@ -4,9 +4,19 @@ import LogoMark from '@/components/LogoMark';
 export default async function ConfirmResultPage({
   searchParams,
 }: {
-  searchParams: Promise<{ error?: string }>;
+  searchParams: Promise<{ error?: string; next?: string }>;
 }) {
-  const { error } = await searchParams;
+  const { error, next } = await searchParams;
+
+  const isExpired = error === 'link_expired' || error === 'access_denied';
+  const isPasswordReset = next?.includes('reset-password');
+
+  const message = isExpired
+    ? 'El enlace expiró o ya fue usado. Solicitá uno nuevo.'
+    : 'Ocurrió un error durante la confirmación. Intentá de nuevo.';
+
+  const actionHref = isPasswordReset ? '/auth/forgot-password' : '/register';
+  const actionLabel = isPasswordReset ? 'Solicitar nuevo link' : 'Volver al registro';
 
   return (
     <div className="min-h-screen flex items-center justify-center bg-gray-50 py-12 px-4">
@@ -22,18 +32,22 @@ export default async function ConfirmResultPage({
         </div>
 
         <h2 className="text-2xl font-bold text-gray-900">Error de confirmación</h2>
-        <p className="text-gray-600">
-          {error === 'link_expired'
-            ? 'El enlace expiró o ya fue usado. Solicitá uno nuevo.'
-            : 'Ocurrió un error durante la confirmación. Intentá de nuevo.'}
-        </p>
+        <p className="text-gray-600">{message}</p>
 
         <Link
-          href="/register"
+          href={actionHref}
           className="inline-block w-full py-2 px-4 bg-indigo-600 hover:bg-indigo-700 text-white rounded-md text-sm font-medium"
         >
-          Volver al registro
+          {actionLabel}
         </Link>
+
+        {isPasswordReset && (
+          <p className="text-sm text-gray-500">
+            <Link href="/login" className="text-indigo-600 hover:text-indigo-500">
+              ← Volver al login
+            </Link>
+          </p>
+        )}
       </div>
     </div>
   );

--- a/apps/frontend/src/app/auth/confirm/route.ts
+++ b/apps/frontend/src/app/auth/confirm/route.ts
@@ -15,7 +15,10 @@ export async function GET(request: NextRequest) {
   const errorParam = searchParams.get('error');
 
   if (errorParam) {
-    return NextResponse.redirect(`${origin}/auth/confirm-result?error=${encodeURIComponent(errorParam)}`);
+    const resultUrl = new URL(`${origin}/auth/confirm-result`);
+    resultUrl.searchParams.set('error', errorParam);
+    if (next) resultUrl.searchParams.set('next', next);
+    return NextResponse.redirect(resultUrl.toString());
   }
 
   const supabase = createClient();
@@ -42,5 +45,8 @@ export async function GET(request: NextRequest) {
     }
   }
 
-  return NextResponse.redirect(`${origin}/auth/confirm-result?error=link_expired`);
+  const fallbackUrl = new URL(`${origin}/auth/confirm-result`);
+  fallbackUrl.searchParams.set('error', 'link_expired');
+  if (next) fallbackUrl.searchParams.set('next', next);
+  return NextResponse.redirect(fallbackUrl.toString());
 }

--- a/apps/frontend/src/components/auth/LoginForm.tsx
+++ b/apps/frontend/src/components/auth/LoginForm.tsx
@@ -63,6 +63,12 @@ export default function LoginForm() {
         msg =
           'Tu email aún no fue confirmado. Revisá tu bandeja de entrada o reenviá el correo.';
         setShowResend(true);
+      } else if (
+        error.message.toLowerCase().includes('fetch') ||
+        error.message.toLowerCase().includes('network') ||
+        error.message.toLowerCase().includes('failed')
+      ) {
+        msg = 'Error de conexión. Verificá tu internet e intentá de nuevo.';
       }
       setAlertMessage(msg);
       setAlertType('error');


### PR DESCRIPTION
- confirm/route.ts: pass `next` param to confirm-result on error so the
  page knows whether the failure was a password reset or email signup
- confirm-result/page.tsx: recognise `access_denied` (Supabase OTP expired)
  as expired-link error; show "Solicitar nuevo link → /auth/forgot-password"
  for reset-password flows instead of the generic "Volver al registro"
- LoginForm.tsx: handle "Failed to fetch" / network errors with a
  user-friendly Spanish message instead of the raw Supabase error string
- auth.ts (forgotPasswordAction): fall back to aiquaa.com so the
  redirectTo URL is always absolute when env vars are not set

https://claude.ai/code/session_01Pcmg1kMYcDsHvwd7u99AMa