### PR TITLE
fix(auth): corregir errores de reset de contraseña, login y registro de empresas

### DIFF
--- a/apps/frontend/src/middleware.ts
+++ b/apps/frontend/src/middleware.ts
@@ -3,6 +3,7 @@ import { NextResponse, type NextRequest } from 'next/server';
 
 const PROTECTED_ROUTES = ['/dashboard', '/labs', '/perfil', '/empresa'];
 const AUTH_ROUTES = ['/login', '/register'];
+const PUBLIC_PATHS = ['/empresa/registro'];
 
 export async function middleware(request: NextRequest) {
   let supabaseResponse = NextResponse.next({ request });
@@ -32,7 +33,9 @@ export async function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl;
 
   // Redirect unauthenticated users away from protected routes
-  const isProtected = PROTECTED_ROUTES.some(route => pathname.startsWith(route));
+  const isProtected =
+    PROTECTED_ROUTES.some(route => pathname.startsWith(route)) &&
+    !PUBLIC_PATHS.some(path => pathname.startsWith(path));
   if (!user && isProtected) {
     const loginUrl = request.nextUrl.clone();
     loginUrl.pathname = '/login';


### PR DESCRIPTION
## Resumen

- **Reset de contraseña (OTP expirado)**: la página de error ahora reconoce el código `access_denied` de Supabase como "link expirado" y muestra el botón correcto según el flujo (reset → "Solicitar nuevo link" en vez de "Volver al registro")
- **Login empresa - "Failed to fetch"**: el formulario de login ahora muestra un mensaje amigable en vez del error crudo de red de Supabase
- **Registro de empresas bloqueado**: el middleware impedía que usuarios sin sesión accedieran a `/empresa/registro`; ahora esa ruta es pública

## Cambios

### `apps/frontend/src/app/auth/confirm/route.ts`
- Pasa el parámetro `next` al redirigir a `confirm-result` en caso de error, para que la página sepa si era un flujo de reset de contraseña
- Idem para el redirect final (link expirado / token inválido)

### `apps/frontend/src/app/auth/confirm-result/page.tsx`
- Reconoce `access_denied` (código de Supabase para OTP expirado) además de `link_expired`
- Si el contexto es reset de contraseña (`next` contiene `reset-password`), muestra "Solicitar nuevo link" → `/auth/forgot-password` en vez de "Volver al registro"
- Agrega link secundario "← Volver al login" para el flujo de reset

### `apps/frontend/src/components/auth/LoginForm.tsx`
- Detecta errores de red (`fetch`/`network`/`failed`) y muestra "Error de conexión. Verificá tu internet e intentá de nuevo." en vez del mensaje crudo de Supabase

### `apps/frontend/src/actions/auth.ts`
- `forgotPasswordAction`: fallback explícito a `https://aiquaa.com` para `siteUrl`, evitando que `redirectTo` sea una URL relativa vacía cuando las variables de entorno no están configuradas

### `apps/frontend/src/middleware.ts`
- Agrega `PUBLIC_PATHS = ['/empresa/registro']` para excluirla del chequeo de rutas protegidas; usuarios sin sesión ahora pueden acceder al formulario de registro de empresa

## Test plan

- [ ] Solicitar reset de contraseña → hacer click en link expirado → verificar mensaje "El enlace expiró" y botón "Solicitar nuevo link"
- [ ] Desde página de error de reset → click "Solicitar nuevo link" → llega a `/auth/forgot-password`
- [ ] Login con credenciales válidas de empresa → acceso correcto al panel `/empresa`
- [ ] Acceder a `/empresa/registro` sin estar logueado → ver formulario de registro (no redirigir a login)
- [ ] Registrar nueva empresa desde `/empresa/registro` → recibir email de confirmación

https://claude.ai/code/session_01Pcmg1kMYcDsHvwd7u99AMa

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pcmg1kMYcDsHvwd7u99AMa)_