### PR TITLE
feat(integrations): Aiquaa Talent outbound webhook for evaluation res…

### DIFF
--- a/apps/backend/.env.example
+++ b/apps/backend/.env.example
@@ -37,3 +37,13 @@ GITHUB_CLIENT_SECRET=your-github-client-secret
 # Supabase
 SUPABASE_URL=https://your-project.supabase.co
 SUPABASE_SERVICE_ROLE_KEY=replace-with-real-service-role-key
+
+# ── Aiquaa Talent Integration (outbound webhook) ─────────────────────────────
+# URL base del servidor Aiquaa Talent (sin trailing slash)
+AIQUAA_TALENT_WEBHOOK_URL=https://talent.aiquaa.com
+# Secreto compartido para firma HMAC-SHA256 (mínimo 32 chars, aleatorio)
+AIQUAA_TALENT_WEBHOOK_SECRET=replace-with-shared-secret-min-32-chars
+# Activar/desactivar envío de webhooks (false por defecto en dev/test)
+AIQUAA_TALENT_WEBHOOK_ENABLED=false
+# Timeout por request en ms (default 8000)
+AIQUAA_TALENT_WEBHOOK_TIMEOUT_MS=8000

--- a/apps/backend/.eslintrc.js
+++ b/apps/backend/.eslintrc.js
@@ -15,7 +15,13 @@ module.exports = {
     node: true,
     jest: true,
   },
-  ignorePatterns: ['.eslintrc.js', 'prisma/**', 'test/**'],
+  ignorePatterns: [
+    '.eslintrc.js',
+    'prisma/**',
+    'test/**',
+    'src/**/*.spec.ts',
+    'jest.*.config.ts',
+  ],
   rules: {
     '@typescript-eslint/interface-name-prefix': 'off',
     '@typescript-eslint/explicit-function-return-type': 'off',

--- a/apps/backend/jest.aiquaa-talent.config.ts
+++ b/apps/backend/jest.aiquaa-talent.config.ts
@@ -1,0 +1,21 @@
+/**
+ * Lightweight Jest config for the Aiquaa Talent integration unit tests.
+ * No Docker / PostgreSQL required — all dependencies are mocked.
+ */
+import type { Config } from 'jest';
+
+const config: Config = {
+  moduleFileExtensions: ['js', 'json', 'ts'],
+  rootDir: 'src',
+  testRegex: 'integrations/aiquaa-talent/.*\\.spec\\.ts$',
+  transform: {
+    '^.+\\.(t|j)s$': 'ts-jest',
+  },
+  testEnvironment: 'node',
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/$1',
+  },
+  testTimeout: 15000,
+};
+
+export default config;

--- a/apps/backend/src/integrations/aiquaa-talent/README.md
+++ b/apps/backend/src/integrations/aiquaa-talent/README.md
@@ -1,0 +1,174 @@
+# Integración AIQUAA → Aiquaa Talent
+
+Cuando un postulante finaliza su evaluación en AIQUAA, este módulo envía automáticamente el resultado a **Aiquaa Talent** para actualizar el estado del candidato en el proceso de selección.
+
+---
+
+## Variables de entorno
+
+| Variable                           | Requerida       | Default | Descripción                                   |
+| ---------------------------------- | --------------- | ------- | --------------------------------------------- |
+| `AIQUAA_TALENT_WEBHOOK_URL`        | Sí (si enabled) | —       | URL base de Aiquaa Talent, sin trailing slash |
+| `AIQUAA_TALENT_WEBHOOK_SECRET`     | Sí (si enabled) | —       | Secreto compartido HMAC-SHA256, mín 32 chars  |
+| `AIQUAA_TALENT_WEBHOOK_ENABLED`    | No              | `false` | `true` para activar envíos reales             |
+| `AIQUAA_TALENT_WEBHOOK_TIMEOUT_MS` | No              | `8000`  | Timeout por request en ms                     |
+
+Agregar en `apps/backend/.env.local`:
+
+```env
+AIQUAA_TALENT_WEBHOOK_URL=https://talent.aiquaa.com
+AIQUAA_TALENT_WEBHOOK_SECRET=<secreto-min-32-chars>
+AIQUAA_TALENT_WEBHOOK_ENABLED=true
+AIQUAA_TALENT_WEBHOOK_TIMEOUT_MS=8000
+```
+
+---
+
+## Cómo activar por evaluación
+
+### Examen de Performance (postulación)
+
+El webhook se dispara **solo** cuando `examPurpose === 'postulacion'`. El frontend debe enviar al menos uno de los campos de proceso:
+
+```json
+{
+  "examPurpose": "postulacion",
+  "candidateEmail": "candidato@correo.com",
+  "talentProcessId": "proc-abc-123",
+  "talentApplicationId": "app-xyz-456", // opcional
+  "talentPublicLinkToken": "tok-abc" // opcional
+}
+```
+
+### Examen ISTQB
+
+El webhook se dispara cuando el body incluye al menos uno de:
+
+```json
+{
+  "talentProcessId": "proc-abc-123",
+  "talentApplicationId": "app-xyz-456",
+  "talentPublicLinkToken": "tok-abc"
+}
+```
+
+Si ninguno está presente, no se envía (se loggea en WARN).
+
+---
+
+## Endpoint destino
+
+```
+POST ${AIQUAA_TALENT_WEBHOOK_URL}/api/integrations/aiquaa/evaluation-result
+```
+
+### Headers
+
+| Header               | Valor                 |
+| -------------------- | --------------------- |
+| `Content-Type`       | `application/json`    |
+| `X-Aiquaa-Event-Id`  | UUID único del evento |
+| `X-Aiquaa-Timestamp` | Unix timestamp en ms  |
+| `X-Aiquaa-Signature` | `sha256=<hmac-hex>`   |
+
+### Firma HMAC
+
+```
+message  = timestamp_ms + "." + raw_body_json
+signature = HMAC_SHA256(AIQUAA_TALENT_WEBHOOK_SECRET, message)
+header   = "sha256=" + hex(signature)
+```
+
+### Payload de ejemplo
+
+```json
+{
+  "eventId": "550e8400-e29b-41d4-a716-446655440000",
+  "eventType": "candidate.evaluation.completed",
+  "occurredAt": "2026-01-15T10:30:00.000Z",
+  "source": "aiquaa",
+  "tenant": {
+    "companyId": "acme-corp"
+  },
+  "candidate": {
+    "email": "candidato@correo.com",
+    "externalId": "@github-handle"
+  },
+  "process": {
+    "processId": "proc-abc-123",
+    "applicationId": "app-xyz-456"
+  },
+  "evaluation": {
+    "evaluationId": "42",
+    "evaluationType": "PERFORMANCE",
+    "score": 22,
+    "maxScore": 26,
+    "status": "PASSED",
+    "summary": "Juan Pérez — 84.6%"
+  }
+}
+```
+
+---
+
+## Confiabilidad
+
+- **Reintentos**: hasta 3 intentos con backoff exponencial (1s → 3s → 9s)
+- **Timeout**: configurable via `AIQUAA_TALENT_WEBHOOK_TIMEOUT_MS` (default 8s)
+- **Non-blocking**: fallos del webhook no afectan la respuesta al postulante
+- **Idempotente**: `eventId` UUID único por evento; el receptor puede desduplicar
+
+---
+
+## Cómo probar localmente
+
+### 1. Levantar mock receiver
+
+```bash
+# Con npx json-server o cualquier echo server, ej:
+npx -y @hoppscotch/cli run collection.json
+
+# O simple con Node:
+node -e "
+const http = require('http');
+http.createServer((req, res) => {
+  let body = '';
+  req.on('data', d => body += d);
+  req.on('end', () => {
+    console.log('Headers:', JSON.stringify(req.headers, null, 2));
+    console.log('Body:', body);
+    res.writeHead(200); res.end('ok');
+  });
+}).listen(4000, () => console.log('Mock receiver on :4000'));
+"
+```
+
+### 2. Configurar env
+
+```env
+AIQUAA_TALENT_WEBHOOK_URL=http://localhost:4000
+AIQUAA_TALENT_WEBHOOK_SECRET=dev-secret-min-32-chars-xxxxxxxxxxx
+AIQUAA_TALENT_WEBHOOK_ENABLED=true
+```
+
+### 3. Enviar examen desde el frontend
+
+Marcar `examPurpose: "postulacion"` + incluir `talentProcessId`.
+
+### 4. Verificar logs
+
+```
+[AiquaaTalent] Sending eventId=... candidate=ca***@empresa.com processId=proc-7 attempt=1
+[AiquaaTalent] Sent OK eventId=... status=200 attempt=1
+```
+
+---
+
+## Tests
+
+```bash
+cd apps/backend
+pnpm test -- --testPathPattern=aiquaa-talent
+```
+
+Cubre: construcción de payload, firma HMAC, envío 2xx, reintentos en 5xx/timeout, skip por flag desactivado, skip por falta de processId, ausencia de datos sensibles en payload.

--- a/apps/backend/src/integrations/aiquaa-talent/aiquaa-talent-webhook.client.spec.ts
+++ b/apps/backend/src/integrations/aiquaa-talent/aiquaa-talent-webhook.client.spec.ts
@@ -1,0 +1,108 @@
+import { ConfigService } from '@nestjs/config';
+import {
+  AiquaaTalentWebhookClient,
+  FetchFn,
+} from './aiquaa-talent-webhook.client';
+import { AiquaaTalentWebhookPayload } from './aiquaa-talent-webhook.types';
+
+const BASE_PAYLOAD: AiquaaTalentWebhookPayload = {
+  eventId: 'evt-001',
+  eventType: 'candidate.evaluation.completed',
+  occurredAt: '2026-01-15T10:30:00.000Z',
+  source: 'aiquaa',
+  tenant: { companyId: 'acme' },
+  candidate: { email: 'candidato@correo.com' },
+  process: { processId: 'proc-42' },
+  evaluation: {
+    evaluationId: 'eval-7',
+    evaluationType: 'PERFORMANCE',
+    score: 82,
+    maxScore: 100,
+    status: 'PASSED',
+  },
+};
+
+function makeClient(fetchFn: FetchFn, overrides: Record<string, string> = {}) {
+  const config = {
+    get: (key: string, def?: unknown) => {
+      const map: Record<string, string> = {
+        AIQUAA_TALENT_WEBHOOK_URL: 'https://talent.example.com',
+        AIQUAA_TALENT_WEBHOOK_SECRET: 'test-secret-32chars-xxxxxxxxxxx',
+        AIQUAA_TALENT_WEBHOOK_TIMEOUT_MS: '8000',
+        ...overrides,
+      };
+      return map[key] ?? def;
+    },
+  } as unknown as ConfigService;
+
+  return new AiquaaTalentWebhookClient(config, fetchFn);
+}
+
+describe('AiquaaTalentWebhookClient', () => {
+  it('sends POST to correct URL', async () => {
+    const calls: string[] = [];
+    const fetchFn: FetchFn = async (url) => {
+      calls.push(url as string);
+      return { status: 200, ok: true };
+    };
+
+    await makeClient(fetchFn).send(BASE_PAYLOAD);
+    expect(calls[0]).toBe(
+      'https://talent.example.com/api/integrations/aiquaa/evaluation-result'
+    );
+  });
+
+  it('sends required headers', async () => {
+    let capturedHeaders: Record<string, string> = {};
+    const fetchFn: FetchFn = async (_url, init) => {
+      capturedHeaders = init.headers as Record<string, string>;
+      return { status: 200, ok: true };
+    };
+
+    await makeClient(fetchFn).send(BASE_PAYLOAD);
+    expect(capturedHeaders['Content-Type']).toBe('application/json');
+    expect(capturedHeaders['X-Aiquaa-Event-Id']).toBe('evt-001');
+    expect(capturedHeaders['X-Aiquaa-Timestamp']).toMatch(/^\d+$/);
+    expect(capturedHeaders['X-Aiquaa-Signature']).toMatch(
+      /^sha256=[a-f0-9]{64}$/
+    );
+  });
+
+  it('returns ok=true on 2xx', async () => {
+    const fetchFn: FetchFn = async () => ({ status: 200, ok: true });
+    const result = await makeClient(fetchFn).send(BASE_PAYLOAD);
+    expect(result.ok).toBe(true);
+    expect(result.statusCode).toBe(200);
+  });
+
+  it('returns ok=false on 5xx', async () => {
+    const fetchFn: FetchFn = async () => ({ status: 500, ok: false });
+    const result = await makeClient(fetchFn).send(BASE_PAYLOAD);
+    expect(result.ok).toBe(false);
+    expect(result.statusCode).toBe(500);
+  });
+
+  it('throws on timeout (AbortError)', async () => {
+    const fetchFn: FetchFn = async () => {
+      const err = new Error('The operation was aborted');
+      err.name = 'AbortError';
+      throw err;
+    };
+
+    const client = makeClient(fetchFn, {
+      AIQUAA_TALENT_WEBHOOK_TIMEOUT_MS: '1',
+    });
+    await expect(client.send(BASE_PAYLOAD)).rejects.toThrow(/timed out/i);
+  });
+
+  it('body does not contain webhook secret', async () => {
+    let capturedBody = '';
+    const fetchFn: FetchFn = async (_url, init) => {
+      capturedBody = init.body as string;
+      return { status: 200, ok: true };
+    };
+
+    await makeClient(fetchFn).send(BASE_PAYLOAD);
+    expect(capturedBody).not.toContain('test-secret-32chars-xxxxxxxxxxx');
+  });
+});

--- a/apps/backend/src/integrations/aiquaa-talent/aiquaa-talent-webhook.client.ts
+++ b/apps/backend/src/integrations/aiquaa-talent/aiquaa-talent-webhook.client.ts
@@ -1,0 +1,78 @@
+import { Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { signWebhookPayload } from './aiquaa-talent-webhook.signer';
+import { AiquaaTalentWebhookPayload } from './aiquaa-talent-webhook.types';
+
+const ENDPOINT_PATH = '/api/integrations/aiquaa/evaluation-result';
+
+export interface HttpResponse {
+  status: number;
+  ok: boolean;
+}
+
+export interface WebhookClientSendResult {
+  statusCode: number;
+  ok: boolean;
+}
+
+/** Injectable wrapper so tests can mock the actual fetch call. */
+export type FetchFn = (
+  url: string,
+  init: RequestInit
+) => Promise<{ status: number; ok: boolean }>;
+
+@Injectable()
+export class AiquaaTalentWebhookClient {
+  private readonly baseUrl: string;
+  private readonly secret: string;
+  private readonly timeoutMs: number;
+  private readonly fetchFn: FetchFn;
+
+  constructor(config: ConfigService, fetchImpl?: FetchFn) {
+    this.baseUrl = config.get<string>('AIQUAA_TALENT_WEBHOOK_URL', '');
+    this.secret = config.get<string>('AIQUAA_TALENT_WEBHOOK_SECRET', '');
+    this.timeoutMs = config.get<number>(
+      'AIQUAA_TALENT_WEBHOOK_TIMEOUT_MS',
+      8000
+    );
+    this.fetchFn = fetchImpl ?? ((url, init) => fetch(url, init));
+  }
+
+  async send(
+    payload: AiquaaTalentWebhookPayload
+  ): Promise<WebhookClientSendResult> {
+    const url = `${this.baseUrl}${ENDPOINT_PATH}`;
+    const rawBody = JSON.stringify(payload);
+    const timestampMs = Date.now();
+    const signature = signWebhookPayload(this.secret, timestampMs, rawBody);
+
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+      'X-Aiquaa-Event-Id': payload.eventId,
+      'X-Aiquaa-Timestamp': String(timestampMs),
+      'X-Aiquaa-Signature': signature,
+    };
+
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), this.timeoutMs);
+
+    try {
+      const response = await this.fetchFn(url, {
+        method: 'POST',
+        headers,
+        body: rawBody,
+        signal: controller.signal as AbortSignal,
+      });
+
+      return { statusCode: response.status, ok: response.ok };
+    } catch (err) {
+      const error = err as Error;
+      if (error.name === 'AbortError') {
+        throw new Error(`Webhook request timed out after ${this.timeoutMs}ms`);
+      }
+      throw error;
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+}

--- a/apps/backend/src/integrations/aiquaa-talent/aiquaa-talent-webhook.service.spec.ts
+++ b/apps/backend/src/integrations/aiquaa-talent/aiquaa-talent-webhook.service.spec.ts
@@ -1,0 +1,220 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+import { AiquaaTalentWebhookService } from './aiquaa-talent-webhook.service';
+import { AiquaaTalentWebhookClient } from './aiquaa-talent-webhook.client';
+import { SendWebhookInput } from './aiquaa-talent-webhook.types';
+
+const BASE_INPUT: SendWebhookInput = {
+  evaluationId: 'eval-42',
+  evaluationType: 'PERFORMANCE',
+  candidateEmail: 'ana@empresa.com',
+  companyId: 'acme',
+  processId: 'proc-7',
+  score: 82,
+  maxScore: 100,
+  passed: true,
+};
+
+function makeModule(
+  enabled: boolean,
+  clientSendImpl: jest.Mock
+): Promise<AiquaaTalentWebhookService> {
+  return Test.createTestingModule({
+    providers: [
+      AiquaaTalentWebhookService,
+      {
+        provide: AiquaaTalentWebhookClient,
+        useValue: { send: clientSendImpl },
+      },
+      {
+        provide: ConfigService,
+        useValue: {
+          get: (key: string, def?: unknown) => {
+            if (key === 'AIQUAA_TALENT_WEBHOOK_ENABLED')
+              return enabled ? 'true' : 'false';
+            return def;
+          },
+        },
+      },
+    ],
+  })
+    .compile()
+    .then((m: TestingModule) => m.get(AiquaaTalentWebhookService));
+}
+
+describe('AiquaaTalentWebhookService', () => {
+  describe('when WEBHOOK_ENABLED=false', () => {
+    it('skips send and returns skipped result', async () => {
+      const sendMock = jest.fn();
+      const svc = await makeModule(false, sendMock);
+
+      const result = await svc.sendEvaluationCompleted(BASE_INPUT);
+
+      expect(result.skipped).toBe(true);
+      expect(result.skipReason).toBe('WEBHOOK_DISABLED');
+      expect(result.sent).toBe(false);
+      expect(sendMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('when WEBHOOK_ENABLED=true', () => {
+    it('sends on 2xx and returns sent=true', async () => {
+      const sendMock = jest.fn().mockResolvedValue({ status: 200, ok: true });
+      const svc = await makeModule(true, sendMock);
+
+      const result = await svc.sendEvaluationCompleted(BASE_INPUT);
+
+      expect(result.sent).toBe(true);
+      expect(result.attempts).toBe(1);
+      expect(sendMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('skips when no process identifier provided', async () => {
+      const sendMock = jest.fn();
+      const svc = await makeModule(true, sendMock);
+
+      const input: SendWebhookInput = { ...BASE_INPUT, processId: undefined };
+      const result = await svc.sendEvaluationCompleted(input);
+
+      expect(result.skipped).toBe(true);
+      expect(result.skipReason).toBe('MISSING_PROCESS_IDENTIFIER');
+      expect(sendMock).not.toHaveBeenCalled();
+    });
+
+    it('sets status=PASSED when passed=true', async () => {
+      let capturedPayload: any;
+      const sendMock = jest.fn().mockImplementation(async (payload) => {
+        capturedPayload = payload;
+        return { status: 200, ok: true };
+      });
+      const svc = await makeModule(true, sendMock);
+
+      await svc.sendEvaluationCompleted({ ...BASE_INPUT, passed: true });
+      expect(capturedPayload.evaluation.status).toBe('PASSED');
+    });
+
+    it('sets status=FAILED when passed=false', async () => {
+      let capturedPayload: any;
+      const sendMock = jest.fn().mockImplementation(async (payload) => {
+        capturedPayload = payload;
+        return { status: 200, ok: true };
+      });
+      const svc = await makeModule(true, sendMock);
+
+      await svc.sendEvaluationCompleted({ ...BASE_INPUT, passed: false });
+      expect(capturedPayload.evaluation.status).toBe('FAILED');
+    });
+
+    it('sets status=PENDING_REVIEW when pendingReview=true', async () => {
+      let capturedPayload: any;
+      const sendMock = jest.fn().mockImplementation(async (payload) => {
+        capturedPayload = payload;
+        return { status: 200, ok: true };
+      });
+      const svc = await makeModule(true, sendMock);
+
+      await svc.sendEvaluationCompleted({ ...BASE_INPUT, pendingReview: true });
+      expect(capturedPayload.evaluation.status).toBe('PENDING_REVIEW');
+    });
+
+    it('retries up to 3 times on 5xx then returns sent=false', async () => {
+      const sendMock = jest.fn().mockResolvedValue({ status: 500, ok: false });
+      const svc = await makeModule(true, sendMock);
+
+      // Patch sleep to avoid real delays in tests
+      jest.spyOn(global, 'setTimeout').mockImplementation((fn: any) => {
+        fn();
+        return 0 as any;
+      });
+
+      const result = await svc.sendEvaluationCompleted(BASE_INPUT);
+
+      expect(result.sent).toBe(false);
+      expect(result.attempts).toBe(3);
+      expect(sendMock).toHaveBeenCalledTimes(3);
+
+      jest.restoreAllMocks();
+    }, 15000);
+
+    it('retries on error then succeeds on 2nd attempt', async () => {
+      const sendMock = jest
+        .fn()
+        .mockRejectedValueOnce(new Error('network error'))
+        .mockResolvedValueOnce({ status: 200, ok: true });
+
+      jest.spyOn(global, 'setTimeout').mockImplementation((fn: any) => {
+        fn();
+        return 0 as any;
+      });
+
+      const svc = await makeModule(true, sendMock);
+      const result = await svc.sendEvaluationCompleted(BASE_INPUT);
+
+      expect(result.sent).toBe(true);
+      expect(result.attempts).toBe(2);
+
+      jest.restoreAllMocks();
+    });
+
+    it('payload does not contain passwords or raw secrets', async () => {
+      let capturedPayload: any;
+      const sendMock = jest.fn().mockImplementation(async (payload) => {
+        capturedPayload = payload;
+        return { status: 200, ok: true };
+      });
+      const svc = await makeModule(true, sendMock);
+
+      await svc.sendEvaluationCompleted(BASE_INPUT);
+
+      const payloadStr = JSON.stringify(capturedPayload);
+      expect(payloadStr).not.toMatch(/password|secret|token.*secret/i);
+      // eventId must be a UUID
+      expect(capturedPayload.eventId).toMatch(
+        /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+      );
+    });
+
+    it('payload uses applicationId as processId when processId absent', async () => {
+      let capturedPayload: any;
+      const sendMock = jest.fn().mockImplementation(async (payload) => {
+        capturedPayload = payload;
+        return { status: 200, ok: true };
+      });
+      const svc = await makeModule(true, sendMock);
+
+      await svc.sendEvaluationCompleted({
+        ...BASE_INPUT,
+        processId: undefined,
+        applicationId: 'app-99',
+      });
+
+      expect(capturedPayload.process.processId).toBe('app-99');
+      expect(capturedPayload.process.applicationId).toBe('app-99');
+    });
+
+    it('payload structure matches spec', async () => {
+      let capturedPayload: any;
+      const sendMock = jest.fn().mockImplementation(async (payload) => {
+        capturedPayload = payload;
+        return { status: 200, ok: true };
+      });
+      const svc = await makeModule(true, sendMock);
+
+      await svc.sendEvaluationCompleted(BASE_INPUT);
+
+      expect(capturedPayload).toMatchObject({
+        eventType: 'candidate.evaluation.completed',
+        source: 'aiquaa',
+        tenant: { companyId: 'acme' },
+        candidate: { email: 'ana@empresa.com' },
+        process: { processId: 'proc-7' },
+        evaluation: {
+          evaluationId: 'eval-42',
+          score: 82,
+          maxScore: 100,
+          status: 'PASSED',
+        },
+      });
+    });
+  });
+});

--- a/apps/backend/src/integrations/aiquaa-talent/aiquaa-talent-webhook.service.ts
+++ b/apps/backend/src/integrations/aiquaa-talent/aiquaa-talent-webhook.service.ts
@@ -1,0 +1,162 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { randomUUID } from 'crypto';
+import { AiquaaTalentWebhookClient } from './aiquaa-talent-webhook.client';
+import {
+  AiquaaTalentWebhookPayload,
+  EvaluationStatus,
+  SendWebhookInput,
+  WebhookSendResult,
+} from './aiquaa-talent-webhook.types';
+
+const MAX_RETRIES = 3;
+const BASE_BACKOFF_MS = 1000;
+
+function maskEmail(email: string): string {
+  const [local, domain] = email.split('@');
+  if (!domain) return '***';
+  return `${local.slice(0, 2)}***@${domain}`;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+@Injectable()
+export class AiquaaTalentWebhookService {
+  private readonly logger = new Logger(AiquaaTalentWebhookService.name);
+  private readonly enabled: boolean;
+
+  constructor(
+    private readonly client: AiquaaTalentWebhookClient,
+    config: ConfigService
+  ) {
+    this.enabled =
+      config
+        .get<string>('AIQUAA_TALENT_WEBHOOK_ENABLED', 'false')
+        .toLowerCase() === 'true';
+  }
+
+  async sendEvaluationCompleted(
+    input: SendWebhookInput
+  ): Promise<WebhookSendResult> {
+    if (!this.enabled) {
+      this.logger.debug(
+        `[AiquaaTalent] Webhook disabled — skipping evaluation=${input.evaluationId}`
+      );
+      return { sent: false, skipped: true, skipReason: 'WEBHOOK_DISABLED' };
+    }
+
+    // Guard: require at least one process identifier
+    if (!input.processId && !input.applicationId && !input.publicLinkToken) {
+      this.logger.warn(
+        `[AiquaaTalent] Missing process identifier for evaluation=${input.evaluationId} — event not sent`
+      );
+      return {
+        sent: false,
+        skipped: true,
+        skipReason: 'MISSING_PROCESS_IDENTIFIER',
+      };
+    }
+
+    const processId =
+      input.processId ?? input.applicationId ?? input.publicLinkToken!;
+    const status: EvaluationStatus = input.pendingReview
+      ? 'PENDING_REVIEW'
+      : input.passed
+        ? 'PASSED'
+        : 'FAILED';
+
+    const eventId = randomUUID();
+    const payload: AiquaaTalentWebhookPayload = {
+      eventId,
+      eventType: 'candidate.evaluation.completed',
+      occurredAt: new Date().toISOString(),
+      source: 'aiquaa',
+      tenant: {
+        companyId: input.companyId,
+      },
+      candidate: {
+        email: input.candidateEmail,
+        ...(input.candidateExternalId && {
+          externalId: input.candidateExternalId,
+        }),
+      },
+      process: {
+        processId,
+        ...(input.applicationId && { applicationId: input.applicationId }),
+        ...(input.publicLinkToken && {
+          publicLinkToken: input.publicLinkToken,
+        }),
+      },
+      evaluation: {
+        evaluationId: input.evaluationId,
+        evaluationType: input.evaluationType,
+        score: input.score,
+        maxScore: input.maxScore,
+        status,
+        ...(input.summary && { summary: input.summary }),
+      },
+    };
+
+    return this.sendWithRetry(payload);
+  }
+
+  private async sendWithRetry(
+    payload: AiquaaTalentWebhookPayload
+  ): Promise<WebhookSendResult> {
+    const maskedEmail = maskEmail(payload.candidate.email);
+    let lastStatusCode: number | undefined;
+
+    for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
+      try {
+        this.logger.log(
+          `[AiquaaTalent] Sending eventId=${payload.eventId} eventType=${payload.eventType} ` +
+            `candidate=${maskedEmail} processId=${payload.process.processId} attempt=${attempt}`
+        );
+
+        const result = await this.client.send(payload);
+        lastStatusCode = result.statusCode;
+
+        if (result.ok) {
+          this.logger.log(
+            `[AiquaaTalent] Sent OK eventId=${payload.eventId} status=${result.statusCode} attempt=${attempt}`
+          );
+          return {
+            sent: true,
+            eventId: payload.eventId,
+            attempts: attempt,
+            lastStatusCode: result.statusCode,
+          };
+        }
+
+        this.logger.warn(
+          `[AiquaaTalent] Non-2xx eventId=${payload.eventId} status=${result.statusCode} attempt=${attempt}`
+        );
+      } catch (err) {
+        const error = err as Error;
+        this.logger.warn(
+          `[AiquaaTalent] Request error eventId=${payload.eventId} attempt=${attempt}: ${error.message}`
+        );
+      }
+
+      if (attempt < MAX_RETRIES) {
+        const backoffMs = BASE_BACKOFF_MS * Math.pow(3, attempt - 1); // 1s, 3s, 9s
+        this.logger.debug(`[AiquaaTalent] Retrying in ${backoffMs}ms…`);
+        await sleep(backoffMs);
+      }
+    }
+
+    this.logger.error(
+      `[AiquaaTalent] Failed after ${MAX_RETRIES} attempts eventId=${payload.eventId} ` +
+        `lastStatus=${lastStatusCode} result=failed`
+    );
+    return {
+      sent: false,
+      eventId: payload.eventId,
+      attempts: MAX_RETRIES,
+      lastStatusCode,
+      error: 'MAX_RETRIES_EXCEEDED',
+    };
+  }
+}

--- a/apps/backend/src/integrations/aiquaa-talent/aiquaa-talent-webhook.signer.spec.ts
+++ b/apps/backend/src/integrations/aiquaa-talent/aiquaa-talent-webhook.signer.spec.ts
@@ -1,0 +1,56 @@
+import {
+  signWebhookPayload,
+  verifyWebhookSignature,
+} from './aiquaa-talent-webhook.signer';
+
+describe('AiquaaTalentWebhookSigner', () => {
+  const SECRET = 'test-secret-32-chars-xxxxxxxxxxx';
+  const TIMESTAMP = 1700000000000;
+  const BODY = '{"eventId":"abc"}';
+
+  it('produces sha256= prefixed signature', () => {
+    const sig = signWebhookPayload(SECRET, TIMESTAMP, BODY);
+    expect(sig).toMatch(/^sha256=[a-f0-9]{64}$/);
+  });
+
+  it('signature is deterministic for same inputs', () => {
+    const sig1 = signWebhookPayload(SECRET, TIMESTAMP, BODY);
+    const sig2 = signWebhookPayload(SECRET, TIMESTAMP, BODY);
+    expect(sig1).toBe(sig2);
+  });
+
+  it('different timestamp = different signature', () => {
+    const sig1 = signWebhookPayload(SECRET, TIMESTAMP, BODY);
+    const sig2 = signWebhookPayload(SECRET, TIMESTAMP + 1, BODY);
+    expect(sig1).not.toBe(sig2);
+  });
+
+  it('different body = different signature', () => {
+    const sig1 = signWebhookPayload(SECRET, TIMESTAMP, BODY);
+    const sig2 = signWebhookPayload(SECRET, TIMESTAMP, '{"eventId":"xyz"}');
+    expect(sig1).not.toBe(sig2);
+  });
+
+  it('different secret = different signature', () => {
+    const sig1 = signWebhookPayload(SECRET, TIMESTAMP, BODY);
+    const sig2 = signWebhookPayload('other-secret', TIMESTAMP, BODY);
+    expect(sig1).not.toBe(sig2);
+  });
+
+  it('verifyWebhookSignature returns true for valid signature', () => {
+    const sig = signWebhookPayload(SECRET, TIMESTAMP, BODY);
+    expect(verifyWebhookSignature(SECRET, TIMESTAMP, BODY, sig)).toBe(true);
+  });
+
+  it('verifyWebhookSignature returns false for tampered body', () => {
+    const sig = signWebhookPayload(SECRET, TIMESTAMP, BODY);
+    expect(
+      verifyWebhookSignature(SECRET, TIMESTAMP, '{"tampered":true}', sig)
+    ).toBe(false);
+  });
+
+  it('does not embed secret in output', () => {
+    const sig = signWebhookPayload(SECRET, TIMESTAMP, BODY);
+    expect(sig).not.toContain(SECRET);
+  });
+});

--- a/apps/backend/src/integrations/aiquaa-talent/aiquaa-talent-webhook.signer.ts
+++ b/apps/backend/src/integrations/aiquaa-talent/aiquaa-talent-webhook.signer.ts
@@ -1,0 +1,30 @@
+import { createHmac } from 'crypto';
+
+/**
+ * Signs a webhook payload with HMAC-SHA256.
+ * Signature covers: `${timestampMs}.${rawBody}`
+ * Header: `X-Aiquaa-Signature: sha256=<hex>`
+ */
+export function signWebhookPayload(
+  secret: string,
+  timestampMs: number,
+  rawBody: string
+): string {
+  const message = `${timestampMs}.${rawBody}`;
+  const hmac = createHmac('sha256', secret);
+  hmac.update(message);
+  return `sha256=${hmac.digest('hex')}`;
+}
+
+/**
+ * Verifies a webhook signature (useful for tests / receiver side).
+ */
+export function verifyWebhookSignature(
+  secret: string,
+  timestampMs: number,
+  rawBody: string,
+  signature: string
+): boolean {
+  const expected = signWebhookPayload(secret, timestampMs, rawBody);
+  return expected === signature;
+}

--- a/apps/backend/src/integrations/aiquaa-talent/aiquaa-talent-webhook.types.ts
+++ b/apps/backend/src/integrations/aiquaa-talent/aiquaa-talent-webhook.types.ts
@@ -1,0 +1,55 @@
+export type EvaluationStatus = 'PASSED' | 'FAILED' | 'PENDING_REVIEW';
+export type EvaluationType = 'ISTQB' | 'PERFORMANCE';
+
+export interface AiquaaTalentWebhookPayload {
+  eventId: string;
+  eventType: 'candidate.evaluation.completed';
+  occurredAt: string;
+  source: 'aiquaa';
+  tenant: {
+    companyId: string;
+  };
+  candidate: {
+    email: string;
+    externalId?: string;
+  };
+  process: {
+    processId: string;
+    applicationId?: string;
+    publicLinkToken?: string;
+  };
+  evaluation: {
+    evaluationId: string;
+    evaluationType: EvaluationType;
+    score: number;
+    maxScore: number;
+    status: EvaluationStatus;
+    summary?: string;
+  };
+}
+
+export interface SendWebhookInput {
+  evaluationId: string;
+  evaluationType: EvaluationType;
+  candidateEmail: string;
+  candidateExternalId?: string;
+  companyId: string;
+  processId?: string;
+  applicationId?: string;
+  publicLinkToken?: string;
+  score: number;
+  maxScore: number;
+  passed: boolean;
+  pendingReview?: boolean;
+  summary?: string;
+}
+
+export interface WebhookSendResult {
+  sent: boolean;
+  skipped?: boolean;
+  skipReason?: string;
+  eventId?: string;
+  attempts?: number;
+  lastStatusCode?: number;
+  error?: string;
+}

--- a/apps/backend/src/integrations/aiquaa-talent/aiquaa-talent.module.ts
+++ b/apps/backend/src/integrations/aiquaa-talent/aiquaa-talent.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
+import { AiquaaTalentWebhookClient } from './aiquaa-talent-webhook.client';
+import { AiquaaTalentWebhookService } from './aiquaa-talent-webhook.service';
+
+@Module({
+  imports: [ConfigModule],
+  providers: [AiquaaTalentWebhookClient, AiquaaTalentWebhookService],
+  exports: [AiquaaTalentWebhookService],
+})
+export class AiquaaTalentModule {}

--- a/apps/backend/src/istqb/dto/submit-exam.dto.ts
+++ b/apps/backend/src/istqb/dto/submit-exam.dto.ts
@@ -78,7 +78,10 @@ export class LearningObjectiveResultDto {
 }
 
 export class SubmitExamDto {
-  @ApiProperty({ description: 'Nombre del participante', example: 'Juan Pérez' })
+  @ApiProperty({
+    description: 'Nombre del participante',
+    example: 'Juan Pérez',
+  })
   @IsString()
   participantName!: string;
 
@@ -99,7 +102,10 @@ export class SubmitExamDto {
   @IsDateString()
   endTime!: string;
 
-  @ApiProperty({ description: 'Tiempo total empleado en segundos', example: 3600 })
+  @ApiProperty({
+    description: 'Tiempo total empleado en segundos',
+    example: 3600,
+  })
   @IsInt()
   @Min(0)
   timeSpent!: number;
@@ -159,4 +165,29 @@ export class SubmitExamDto {
   @ValidateNested({ each: true })
   @Type(() => LearningObjectiveResultDto)
   learningObjectiveAnalysis!: LearningObjectiveResultDto[];
+
+  // ── Aiquaa Talent integration fields ────────────────────────────────────────
+  @ApiProperty({
+    description: 'ID del proceso de selección en Aiquaa Talent',
+    required: false,
+  })
+  @IsOptional()
+  @IsString()
+  talentProcessId?: string;
+
+  @ApiProperty({
+    description: 'ID de postulación en Aiquaa Talent',
+    required: false,
+  })
+  @IsOptional()
+  @IsString()
+  talentApplicationId?: string;
+
+  @ApiProperty({
+    description: 'Token de enlace público de postulación en Aiquaa Talent',
+    required: false,
+  })
+  @IsOptional()
+  @IsString()
+  talentPublicLinkToken?: string;
 }

--- a/apps/backend/src/istqb/istqb.module.ts
+++ b/apps/backend/src/istqb/istqb.module.ts
@@ -4,9 +4,10 @@ import { IstqbController } from './istqb.controller';
 import { IstqbService } from './istqb.service';
 import { PrismaModule } from '../prisma/prisma.module';
 import { MailerModule } from '../mailer/mailer.module';
+import { AiquaaTalentModule } from '../integrations/aiquaa-talent/aiquaa-talent.module';
 
 @Module({
-  imports: [PrismaModule, MailerModule, CqrsModule],
+  imports: [PrismaModule, MailerModule, CqrsModule, AiquaaTalentModule],
   controllers: [IstqbController],
   providers: [IstqbService],
   exports: [IstqbService],

--- a/apps/backend/src/istqb/istqb.service.ts
+++ b/apps/backend/src/istqb/istqb.service.ts
@@ -4,6 +4,7 @@ import { PrismaService } from '../prisma/prisma.service';
 import { SubmitExamDto } from './dto/submit-exam.dto';
 import { Decimal } from '@prisma/client/runtime/library';
 import { IstqbExamCompletedEvent } from './events/istqb-exam-completed.event';
+import { AiquaaTalentWebhookService } from '../integrations/aiquaa-talent/aiquaa-talent-webhook.service';
 
 @Injectable()
 export class IstqbService {
@@ -11,7 +12,8 @@ export class IstqbService {
 
   constructor(
     private prisma: PrismaService,
-    private eventBus: EventBus
+    private eventBus: EventBus,
+    private readonly talentWebhook: AiquaaTalentWebhookService
   ) {}
 
   async submitExamResult(examData: SubmitExamDto, userId?: number) {
@@ -47,6 +49,33 @@ export class IstqbService {
           examData.mode
         )
       );
+    }
+
+    // Fire Aiquaa Talent webhook best-effort (non-blocking)
+    if (
+      examData.talentProcessId ||
+      examData.talentApplicationId ||
+      examData.talentPublicLinkToken
+    ) {
+      this.talentWebhook
+        .sendEvaluationCompleted({
+          evaluationId: result.id.toString(),
+          evaluationType: 'ISTQB',
+          candidateEmail: examData.participantEmail ?? examData.participantName,
+          companyId: 'aiquaa',
+          processId: examData.talentProcessId,
+          applicationId: examData.talentApplicationId,
+          publicLinkToken: examData.talentPublicLinkToken,
+          score: examData.score,
+          maxScore: examData.totalQuestions,
+          passed: examData.passed,
+          summary: `${examData.participantName} — ${examData.percentage.toFixed(1)}%`,
+        })
+        .catch((err: Error) =>
+          this.logger.error(
+            `[AiquaaTalent] Unhandled error sending webhook for result=${result.id}: ${err.message}`
+          )
+        );
     }
 
     return {

--- a/apps/backend/src/performance/dto/submit-exam.dto.ts
+++ b/apps/backend/src/performance/dto/submit-exam.dto.ts
@@ -2,6 +2,7 @@ import { ApiProperty } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
 import {
   IsString,
+  IsEmail,
   IsDateString,
   IsInt,
   IsNumber,
@@ -9,6 +10,7 @@ import {
   IsArray,
   ValidateNested,
   IsEnum,
+  IsOptional,
   Min,
   Max,
 } from 'class-validator';
@@ -48,7 +50,9 @@ export class AnswerDetailDto {
   @IsBoolean()
   isCorrect!: boolean;
 
-  @ApiProperty({ description: 'Sección de la pregunta (Fundamentos, Métricas, Herramientas)' })
+  @ApiProperty({
+    description: 'Sección de la pregunta (Fundamentos, Métricas, Herramientas)',
+  })
   @IsString()
   learningObjective!: string;
 
@@ -83,11 +87,17 @@ export class LearningObjectiveResultDto {
 }
 
 export class SubmitPerformanceExamDto {
-  @ApiProperty({ description: 'Nombre del participante', example: 'Juan Pérez' })
+  @ApiProperty({
+    description: 'Nombre del participante',
+    example: 'Juan Pérez',
+  })
   @IsString()
   participantName!: string;
 
-  @ApiProperty({ description: 'Perfil de GitHub del participante', example: '@juanperez' })
+  @ApiProperty({
+    description: 'Perfil de GitHub del participante',
+    example: '@juanperez',
+  })
   @IsString()
   githubProfile!: string;
 
@@ -115,7 +125,10 @@ export class SubmitPerformanceExamDto {
   @IsDateString()
   endTime!: string;
 
-  @ApiProperty({ description: 'Tiempo total empleado en segundos', example: 3600 })
+  @ApiProperty({
+    description: 'Tiempo total empleado en segundos',
+    example: 3600,
+  })
   @IsInt()
   @Min(0)
   timeSpent!: number;
@@ -175,4 +188,38 @@ export class SubmitPerformanceExamDto {
   @ValidateNested({ each: true })
   @Type(() => LearningObjectiveResultDto)
   learningObjectiveAnalysis!: LearningObjectiveResultDto[];
+
+  // ── Aiquaa Talent integration fields ────────────────────────────────────────
+  @ApiProperty({
+    description:
+      'Email del candidato para notificar a Aiquaa Talent (requerido si examPurpose=postulacion)',
+    required: false,
+  })
+  @IsOptional()
+  @IsEmail()
+  candidateEmail?: string;
+
+  @ApiProperty({
+    description: 'ID del proceso de selección en Aiquaa Talent',
+    required: false,
+  })
+  @IsOptional()
+  @IsString()
+  talentProcessId?: string;
+
+  @ApiProperty({
+    description: 'ID de postulación en Aiquaa Talent',
+    required: false,
+  })
+  @IsOptional()
+  @IsString()
+  talentApplicationId?: string;
+
+  @ApiProperty({
+    description: 'Token de enlace público de postulación en Aiquaa Talent',
+    required: false,
+  })
+  @IsOptional()
+  @IsString()
+  talentPublicLinkToken?: string;
 }

--- a/apps/backend/src/performance/performance.module.ts
+++ b/apps/backend/src/performance/performance.module.ts
@@ -3,9 +3,10 @@ import { CqrsModule } from '@nestjs/cqrs';
 import { PerformanceController } from './performance.controller';
 import { PerformanceService } from './performance.service';
 import { PrismaModule } from '../prisma/prisma.module';
+import { AiquaaTalentModule } from '../integrations/aiquaa-talent/aiquaa-talent.module';
 
 @Module({
-  imports: [PrismaModule, CqrsModule],
+  imports: [PrismaModule, CqrsModule, AiquaaTalentModule],
   controllers: [PerformanceController],
   providers: [PerformanceService],
   exports: [PerformanceService],

--- a/apps/backend/src/performance/performance.service.ts
+++ b/apps/backend/src/performance/performance.service.ts
@@ -1,9 +1,10 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { EventBus } from '@nestjs/cqrs';
 import { PrismaService } from '../prisma/prisma.service';
-import { SubmitPerformanceExamDto } from './dto/submit-exam.dto';
+import { SubmitPerformanceExamDto, ExamPurpose } from './dto/submit-exam.dto';
 import { PerformanceExamCompletedEvent } from './events/performance-exam-completed.event';
 import { Decimal } from '@prisma/client/runtime/library';
+import { AiquaaTalentWebhookService } from '../integrations/aiquaa-talent/aiquaa-talent-webhook.service';
 
 @Injectable()
 export class PerformanceService {
@@ -11,7 +12,8 @@ export class PerformanceService {
 
   constructor(
     private readonly prisma: PrismaService,
-    private readonly eventBus: EventBus
+    private readonly eventBus: EventBus,
+    private readonly talentWebhook: AiquaaTalentWebhookService
   ) {}
 
   async submitExamResult(examData: SubmitPerformanceExamDto, userId?: number) {
@@ -49,6 +51,30 @@ export class PerformanceService {
             examData.mode
           )
         );
+      }
+
+      // Fire Aiquaa Talent webhook best-effort (non-blocking)
+      if (examData.examPurpose === ExamPurpose.POSTULACION) {
+        this.talentWebhook
+          .sendEvaluationCompleted({
+            evaluationId: result.id.toString(),
+            evaluationType: 'PERFORMANCE',
+            candidateEmail: examData.candidateEmail ?? examData.githubProfile,
+            candidateExternalId: examData.githubProfile,
+            companyId: examData.companyName ?? 'unknown',
+            processId: examData.talentProcessId,
+            applicationId: examData.talentApplicationId,
+            publicLinkToken: examData.talentPublicLinkToken,
+            score: examData.score,
+            maxScore: examData.totalQuestions,
+            passed: examData.passed,
+            summary: `${examData.participantName} — ${examData.percentage.toFixed(1)}%`,
+          })
+          .catch((err: Error) =>
+            this.logger.error(
+              `[AiquaaTalent] Unhandled error sending webhook for result=${result.id}: ${err.message}`
+            )
+          );
       }
 
       return {


### PR DESCRIPTION
…ults

Adds a self-contained integration module that fires a signed HMAC-SHA256 webhook to Aiquaa Talent whenever a candidate finishes a Performance or ISTQB evaluation, so the result appears automatically in the hiring kanban.

## What changed

### New: src/integrations/aiquaa-talent/
- aiquaa-talent-webhook.types.ts   shared payload / result types
- aiquaa-talent-webhook.signer.ts  HMAC-SHA256 sign + verify helpers
- aiquaa-talent-webhook.client.ts  HTTP client with configurable timeout
- aiquaa-talent-webhook.service.ts payload builder, process-id guard,
  3-attempt exponential backoff (1s > 3s > 9s), structured logging
- aiquaa-talent.module.ts           NestJS module exported to consumers
- README.md                         env vars, payload example, local test guide
- *.spec.ts (3 files, 25 tests)    signer, client, service fully covered

### DTOs extended (non-breaking, all fields optional)
- performance/dto/submit-exam.dto.ts: candidateEmail, talentProcessId, talentApplicationId, talentPublicLinkToken
- istqb/dto/submit-exam.dto.ts: talentProcessId, talentApplicationId, talentPublicLinkToken

### Services wired
- PerformanceService fires webhook when examPurpose === 'postulacion'
- IstqbService fires webhook when any talent field is present
- Both fire-and-forget (.catch logged) - no impact on candidate response

### ESLint config
- Added src/**/*.spec.ts and jest.*.config.ts to ignorePatterns so spec files collocated in src/ do not fail the typed-linting check

### Env vars documented in apps/backend/.env.example
  AIQUAA_TALENT_WEBHOOK_URL, AIQUAA_TALENT_WEBHOOK_SECRET,
  AIQUAA_TALENT_WEBHOOK_ENABLED (default false), AIQUAA_TALENT_WEBHOOK_TIMEOUT_MS