### PR TITLE
fix(performance-exam): resolve timer double-conversion, answer count,…

### DIFF
--- a/apps/frontend/src/app/labs/performance/components/ExamSimulator.tsx
+++ b/apps/frontend/src/app/labs/performance/components/ExamSimulator.tsx
@@ -220,7 +220,7 @@ export default function ExamSimulator({
   }
 
   const currentQuestion = questions[currentQuestionIndex];
-  const answeredCount = answers.size;
+  const answeredCount = [...answers.values()].filter((v) => v.length > 0).length;
   const progress = (answeredCount / questions.length) * 100;
   const unansweredCount = questions.length - answeredCount;
   const isLastQuestion = currentQuestionIndex === questions.length - 1;

--- a/apps/frontend/src/app/labs/performance/components/QuestionCard.tsx
+++ b/apps/frontend/src/app/labs/performance/components/QuestionCard.tsx
@@ -73,6 +73,7 @@ export default function QuestionCard({
   };
 
   const handleMultipleAnswer = (label: string, checked: boolean) => {
+    if (checked && selectedAnswers.length >= question.correctAnswer.length) return;
     const newAnswers = checked
       ? [...selectedAnswers, label]
       : selectedAnswers.filter((a) => a !== label);

--- a/apps/frontend/src/app/labs/performance/page.tsx
+++ b/apps/frontend/src/app/labs/performance/page.tsx
@@ -8,6 +8,8 @@ import { useTheme } from '@/contexts/ThemeContext';
 import { Alert } from '@/components/common';
 import ExamSimulator from './components/ExamSimulator';
 import { loadExamData } from './utils';
+
+const EXAM_DATA = loadExamData();
 import { SuruFloating } from '@/components/Suru';
 import { useSupabaseAuth } from '@/contexts/SupabaseAuthContext';
 import { getExamUserDefaults } from '@/lib/exam-user-defaults';
@@ -89,7 +91,7 @@ export default function PerformanceExamPage() {
         examPurpose={examPurpose}
         companyName={companyName}
         mode={examMode}
-        examData={loadExamData()}
+        examData={EXAM_DATA}
         onExamComplete={handleExamComplete}
       />
     );

--- a/apps/frontend/src/app/labs/performance/utils.ts
+++ b/apps/frontend/src/app/labs/performance/utils.ts
@@ -70,7 +70,7 @@ export function loadExamData(): ExamData {
     version: rawData.metadata.version,
     totalQuestions: allQuestions.length,
     passingScore: Math.ceil(allQuestions.length * (rawData.metadata.passing_score_percentage / 100)),
-    timeLimit: rawData.metadata.estimated_duration_minutes * 60, // Convertir a segundos
+    timeLimit: rawData.metadata.estimated_duration_minutes,
     pointsPerQuestion: 1
   };
 


### PR DESCRIPTION
… and question ordering

- Remove * 60 in utils.ts: timeLimit was stored as seconds but ExamSimulator multiplied by 60 again, causing timer to show ~60 hours instead of 60 minutes (Issue #58)
- Add max-selection guard in QuestionCard: checkboxes now prevent selecting more answers than required for multi-select questions (Issue #58)
- Fix answered count: filter out empty-array entries from answers Map so deselected questions don't count as answered (Issue #58)
- Stabilize examData: extract loadExamData() to module-level constant to prevent question reshuffling on parent re-renders (Issue #58)

https://claude.ai/code/session_014FtGuFpbirmzVYFY3wR1Sc