### PR TITLE
fix(performance): corregir conteo de preguntas y cálculo de porcentaj…

### DIFF
--- a/apps/frontend/src/app/labs/page.tsx
+++ b/apps/frontend/src/app/labs/page.tsx
@@ -45,7 +45,7 @@ export default function LabsPage() {
           id: 'performance',
           name: 'Examen de Performance Testing',
           description:
-            'Prueba técnica de 30 preguntas sobre fundamentos, métricas y herramientas de pruebas de rendimiento',
+            'Prueba técnica de 27 preguntas sobre fundamentos, métricas y herramientas de pruebas de rendimiento',
           icon: '⚡',
           color: 'from-cyan-500 to-blue-600',
           href: '/labs/performance',

--- a/apps/frontend/src/app/labs/performance/page.tsx
+++ b/apps/frontend/src/app/labs/performance/page.tsx
@@ -71,7 +71,7 @@ export default function PerformanceExamPage() {
       total_questions: result.totalQuestions,
       correct_answers: result.correctAnswers,
       incorrect_answers: result.incorrectAnswers,
-      passing_score: Math.round(result.totalQuestions * 0.7),
+      passing_score: EXAM_DATA.examInfo.passingScore,
       passed: result.passed,
       percentage: result.percentage,
       time_spent: result.timeSpent,
@@ -476,7 +476,7 @@ export default function PerformanceExamPage() {
                 isDarkMode ? 'text-slate-400' : 'text-gray-600'
               }`}>
                 <li>• Timer de 60 minutos</li>
-                <li>• 26 preguntas de selección</li>
+                <li>• 27 preguntas de selección</li>
                 <li>• Sin retroalimentación durante el examen</li>
                 <li>• Informe completo al finalizar</li>
               </ul>
@@ -511,7 +511,7 @@ export default function PerformanceExamPage() {
                 isDarkMode ? 'text-slate-400' : 'text-gray-600'
               }`}>
                 <li>• Sin límite de tiempo</li>
-                <li>• 26 preguntas de selección</li>
+                <li>• 27 preguntas de selección</li>
                 <li>• Retroalimentación inmediata</li>
                 <li>• Explicaciones detalladas</li>
               </ul>

--- a/apps/frontend/src/app/labs/performance/utils.ts
+++ b/apps/frontend/src/app/labs/performance/utils.ts
@@ -64,12 +64,14 @@ export function loadExamData(): ExamData {
     });
   });
 
+  const maxPossibleScore = allQuestions.reduce((sum, q) => sum + q.points, 0);
+
   // Crear el ExamInfo
   const examInfo: ExamInfo = {
     title: rawData.metadata.title,
     version: rawData.metadata.version,
     totalQuestions: allQuestions.length,
-    passingScore: Math.ceil(allQuestions.length * (rawData.metadata.passing_score_percentage / 100)),
+    passingScore: Math.ceil(maxPossibleScore * (rawData.metadata.passing_score_percentage / 100)),
     timeLimit: rawData.metadata.estimated_duration_minutes,
     pointsPerQuestion: 1
   };
@@ -180,7 +182,8 @@ export function generateExamResult(
   const score = calculateScore(questions, answers);
   const correctAnswers = answerDetails.filter((a) => a.isCorrect).length;
   const incorrectAnswers = answerDetails.length - correctAnswers;
-  const percentage = (score / questions.length) * 100;
+  const maxPossibleScore = questions.reduce((sum, q) => sum + q.points, 0);
+  const percentage = (score / maxPossibleScore) * 100;
   const passed = score >= passingScore;
 
   const learningObjectiveAnalysis = calculateLearningObjectiveAnalysis(


### PR DESCRIPTION
…e ponderado

- labs/page.tsx: actualiza descripción de 30 a 27 preguntas (closes #63)
- performance/page.tsx: corrige tarjetas de modo que decían '26 preguntas' (debían ser 27)
- performance/page.tsx: usa examInfo.passingScore (basado en pesos) en vez de totalQuestions * 0.7
- performance/utils.ts: calcula percentage como score/maxPossibleScore (suma de pesos=35) evitando porcentajes > 100%
- performance/utils.ts: calcula passingScore sobre el total de puntos ponderados (no sobre conteo de preguntas)

El examen tiene 8 preguntas con weight=2 → max posible = 35 pts. El cálculo anterior usaba questions.length (27) como denominador, generando porcentajes de 114% y registros con score > total_questions en la DB.

https://claude.ai/code/session_01BvVPnZnHpz6xMQ9TLCKnnu