### PR TITLE
fix(empresas): corregir bugs críticos EMP-001/002/005 y validación RUC

### DIFF
--- a/apps/backend/src/mailer/mailer.controller.ts
+++ b/apps/backend/src/mailer/mailer.controller.ts
@@ -19,6 +19,15 @@ class NuevaEmpresaDto {
   ruc?: string;
 }
 
+class CandidatoInvitacionDto {
+  candidateEmail!: string;
+  candidateName?: string;
+  companyName!: string;
+  positionName?: string;
+  message?: string;
+  invitacionUrl!: string;
+}
+
 @ApiExcludeController()
 @Controller('mailer/interna')
 export class MailerController {
@@ -56,6 +65,32 @@ export class MailerController {
 
     this.logger.log(
       `Alerta nueva empresa disparada: ${body.companyName} <${body.ownerEmail}>`
+    );
+    return { ok: true };
+  }
+
+  @Post('candidato-invitacion')
+  @HttpCode(HttpStatus.OK)
+  async candidatoInvitacion(
+    @Headers('x-internal-secret') secret: string,
+    @Body() body: CandidatoInvitacionDto
+  ) {
+    const expected = this.configService.get<string>('INTERNAL_NOTIFY_SECRET');
+    if (!expected || secret !== expected) {
+      throw new UnauthorizedException();
+    }
+
+    await this.mailerService.sendCandidatoInvitacion({
+      candidateEmail: body.candidateEmail,
+      candidateName: body.candidateName,
+      companyName: body.companyName,
+      positionName: body.positionName,
+      message: body.message,
+      invitacionUrl: body.invitacionUrl,
+    });
+
+    this.logger.log(
+      `Invitación enviada a <${body.candidateEmail}> de parte de ${body.companyName}`
     );
     return { ok: true };
   }

--- a/apps/backend/src/mailer/mailer.service.ts
+++ b/apps/backend/src/mailer/mailer.service.ts
@@ -38,4 +38,15 @@ export class MailerService {
   }): Promise<void> {
     return this.resendService.sendNewEmpresaAlert(data);
   }
+
+  async sendCandidatoInvitacion(data: {
+    candidateEmail: string;
+    candidateName?: string;
+    companyName: string;
+    positionName?: string;
+    message?: string;
+    invitacionUrl: string;
+  }): Promise<void> {
+    return this.resendService.sendCandidatoInvitacion(data);
+  }
 }

--- a/apps/backend/src/mailer/resend.service.ts
+++ b/apps/backend/src/mailer/resend.service.ts
@@ -299,6 +299,85 @@ export class ResendService {
     `;
   }
 
+  async sendCandidatoInvitacion(data: {
+    candidateEmail: string;
+    candidateName?: string;
+    companyName: string;
+    positionName?: string;
+    message?: string;
+    invitacionUrl: string;
+  }): Promise<void> {
+    const fromEmail = this.configService.get<string>(
+      'SES_FROM_EMAIL',
+      'noreply@aiquaa.com'
+    );
+    const name = data.candidateName || data.candidateEmail.split('@')[0];
+    try {
+      await this.sendMail({
+        from: fromEmail,
+        to: data.candidateEmail,
+        subject: `${data.companyName} te invita a rendir una evaluación técnica QA`,
+        html: this.getCandidatoInvitacionTemplate({ ...data, name }),
+      });
+      this.logger.log(`Invitación enviada a ${data.candidateEmail}`);
+    } catch (error) {
+      this.logger.error(`Error enviando invitación a ${data.candidateEmail}`, error);
+      throw error;
+    }
+  }
+
+  private getCandidatoInvitacionTemplate(data: {
+    name: string;
+    companyName: string;
+    positionName?: string;
+    message?: string;
+    invitacionUrl: string;
+  }): string {
+    return `
+      <!DOCTYPE html>
+      <html>
+      <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <title>Invitación a evaluación QA — AIQUAA</title>
+        <style>
+          body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; line-height: 1.6; color: #333; margin: 0; padding: 0; background: #f9fafb; }
+          .container { max-width: 600px; margin: 0 auto; padding: 20px; }
+          .header { background: linear-gradient(135deg, #4F46E5, #7C3AED); color: white; padding: 32px; text-align: center; border-radius: 12px 12px 0 0; }
+          .content { background: #ffffff; padding: 40px; border-radius: 0 0 12px 12px; box-shadow: 0 4px 6px rgba(0,0,0,0.07); }
+          .button { display: inline-block; background: #4F46E5; color: white !important; padding: 14px 32px; text-decoration: none; border-radius: 8px; font-weight: 600; font-size: 15px; }
+          .message-box { background: #F0F4FF; border-left: 4px solid #4F46E5; padding: 16px 20px; border-radius: 4px; margin: 20px 0; font-style: italic; color: #374151; }
+          .footer { text-align: center; margin-top: 32px; color: #9CA3AF; font-size: 13px; }
+        </style>
+      </head>
+      <body>
+        <div class="container">
+          <div class="header">
+            <h1 style="margin:0;font-size:26px;">🎯 AIQUAA</h1>
+            <p style="margin:8px 0 0;font-size:15px;opacity:0.9;">Evaluación técnica QA</p>
+          </div>
+          <div class="content">
+            <h2 style="color:#1F2937;margin-top:0;">¡Hola ${data.name}!</h2>
+            <p><strong>${data.companyName}</strong> te invita a rendir${data.positionName ? ` la evaluación técnica para el puesto de <strong>${data.positionName}</strong>` : ' una evaluación técnica QA'} en la plataforma AIQUAA.</p>
+            ${data.message ? `<div class="message-box">"${data.message}"</div>` : ''}
+            <p>AIQUAA es una plataforma de entrenamiento QA en español para la comunidad de LATAM. La evaluación te tomará entre 30 y 60 minutos.</p>
+            <div style="text-align:center;margin:32px 0;">
+              <a href="${data.invitacionUrl}" class="button">Ver invitación y rendir →</a>
+            </div>
+            <p style="font-size:13px;color:#6B7280;">Si el botón no funciona, copiá este enlace en tu navegador:<br>
+              <a href="${data.invitacionUrl}" style="color:#4F46E5;word-break:break-all;">${data.invitacionUrl}</a>
+            </p>
+            <p style="font-size:13px;color:#6B7280;">Si no esperabas esta invitación, podés ignorar este email.</p>
+          </div>
+          <div class="footer">
+            <p>© AIQUAA · Plataforma QA para LATAM</p>
+          </div>
+        </div>
+      </body>
+      </html>
+    `;
+  }
+
   async sendTwoFactorCode(email: string, code: string): Promise<void> {
     const fromEmail =
       process.env.SES_FROM_EMAIL || 'AIQUAA <noreply@aiquaa.com>';

--- a/apps/frontend/src/actions/empresa-invitaciones.ts
+++ b/apps/frontend/src/actions/empresa-invitaciones.ts
@@ -2,6 +2,41 @@
 
 import { createClient } from '@/lib/supabase/server';
 
+const BACKEND_URL = process.env.BACKEND_URL ?? process.env.NEXT_PUBLIC_BACKEND_URL ?? '';
+const INTERNAL_SECRET = process.env.INTERNAL_NOTIFY_SECRET ?? '';
+
+async function sendInvitacionEmail(data: {
+  candidateEmail: string;
+  candidateName?: string | null;
+  companyName: string;
+  positionName?: string;
+  message?: string | null;
+  token: string;
+}): Promise<void> {
+  if (!BACKEND_URL || !INTERNAL_SECRET) return;
+  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? process.env.NEXTAUTH_URL ?? BACKEND_URL;
+  const invitacionUrl = `${siteUrl}/invitacion/${data.token}`;
+  try {
+    await fetch(`${BACKEND_URL}/api/v1/mailer/interna/candidato-invitacion`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-internal-secret': INTERNAL_SECRET,
+      },
+      body: JSON.stringify({
+        candidateEmail: data.candidateEmail,
+        candidateName: data.candidateName ?? undefined,
+        companyName: data.companyName,
+        positionName: data.positionName,
+        message: data.message ?? undefined,
+        invitacionUrl,
+      }),
+    });
+  } catch {
+    // Email failure is non-blocking — invitation is already saved in DB
+  }
+}
+
 export interface EmpresaInvitacion {
   id: string;
   empresa_id: string;
@@ -90,6 +125,28 @@ export async function createInvitacionAction(payload: {
     .single();
 
   if (error) return { data: null, error: error.message };
+
+  // Fetch empresa name and optional process name for the email
+  const { data: empresa } = await supabase
+    .from('empresas')
+    .select('razon_social, nombre_comercial')
+    .eq('id', membership.empresa_id)
+    .single();
+
+  let positionName: string | undefined;
+  if (data.process_id && data.hiring_processes) {
+    positionName = (data.hiring_processes as { position_name: string }).position_name;
+  }
+
+  await sendInvitacionEmail({
+    candidateEmail: data.candidate_email,
+    candidateName: data.candidate_name,
+    companyName: empresa?.nombre_comercial ?? empresa?.razon_social ?? 'AIQUAA',
+    positionName,
+    message: data.message,
+    token: data.token,
+  });
+
   return { data: data as EmpresaInvitacion, error: null };
 }
 

--- a/apps/frontend/src/app/empresa/perfil/page.tsx
+++ b/apps/frontend/src/app/empresa/perfil/page.tsx
@@ -142,6 +142,11 @@ export default function EmpresaPerfilPage() {
       setAlert({ type: 'error', msg: 'El sitio web debe comenzar con http:// o https://' });
       return;
     }
+    // Validate RUC format for Paraguay: digits-digit (e.g. 80012345-6)
+    if (form.ruc && form.country === 'PY' && !/^\d{6,8}-\d$/.test(form.ruc.trim())) {
+      setAlert({ type: 'error', msg: 'El RUC debe tener el formato 80012345-6 (dígitos guión dígito verificador)' });
+      return;
+    }
     startSaving(async () => {
       const { error } = await updateEmpresaAction(form);
       if (error) {
@@ -291,7 +296,14 @@ export default function EmpresaPerfilPage() {
               />
             </div>
             <div>
-              <label className={labelClass}>RUC</label>
+              <label className={labelClass}>
+                RUC{' '}
+                {form.country === 'PY' && (
+                  <span className={`font-normal ${isDarkMode ? 'text-slate-500' : 'text-gray-400'}`}>
+                    (formato: 80012345-6)
+                  </span>
+                )}
+              </label>
               <input
                 type="text"
                 value={form.ruc}

--- a/apps/frontend/src/app/empresa/procesos/nuevo/page.tsx
+++ b/apps/frontend/src/app/empresa/procesos/nuevo/page.tsx
@@ -76,7 +76,23 @@ export default function NuevoProcesoPage() {
       return;
     }
 
-    const code = generateCode(positionName);
+    // Generate unique code — retry up to 5 times on collision
+    let code = '';
+    for (let attempt = 0; attempt < 5; attempt++) {
+      const candidate = generateCode(positionName);
+      const { data: existing } = await supabase
+        .from('hiring_processes')
+        .select('code')
+        .eq('code', candidate)
+        .maybeSingle();
+      if (!existing) { code = candidate; break; }
+    }
+    if (!code) {
+      setError('No se pudo generar un código único. Intentá de nuevo.');
+      setLoading(false);
+      return;
+    }
+
     const { error: insertError } = await supabase
       .from('hiring_processes')
       .insert({

--- a/apps/frontend/src/app/invitacion/[token]/page.tsx
+++ b/apps/frontend/src/app/invitacion/[token]/page.tsx
@@ -1,0 +1,198 @@
+import { createClient } from '@/lib/supabase/server';
+import Link from 'next/link';
+import Image from 'next/image';
+import { notFound } from 'next/navigation';
+
+const EXAM_LABELS: Record<string, string> = {
+  istqb: 'ISTQB CTFL — Fundamentos de QA',
+  git: 'Git — Control de versiones',
+  performance: 'Performance Testing',
+};
+
+type Props = { params: Promise<{ token: string }> };
+
+export default async function InvitacionTokenPage({ params }: Props) {
+  const { token } = await params;
+  const supabase = await createClient();
+
+  const { data: inv, error } = await supabase
+    .from('empresa_invitaciones')
+    .select(
+      '*, empresas(razon_social, nombre_comercial, logo_url, industry, country), hiring_processes(position_name, code, exam_types)'
+    )
+    .eq('token', token)
+    .single();
+
+  if (error || !inv) notFound();
+
+  const empresa = inv.empresas as {
+    razon_social: string;
+    nombre_comercial: string | null;
+    logo_url: string | null;
+    industry: string | null;
+    country: string | null;
+  } | null;
+
+  const proceso = inv.hiring_processes as {
+    position_name: string;
+    code: string;
+    exam_types: string[];
+  } | null;
+
+  const displayName = empresa?.nombre_comercial ?? empresa?.razon_social ?? 'Una empresa';
+  const isExpired = inv.status === 'rechazada';
+  const isCompleted = inv.status === 'completada';
+
+  // Mark as "vista" if still pending
+  if (inv.status === 'pendiente') {
+    await supabase
+      .from('empresa_invitaciones')
+      .update({ status: 'vista', viewed_at: new Date().toISOString() })
+      .eq('token', token);
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-50 dark:bg-slate-900 flex items-center justify-center px-4 py-12">
+      <div className="w-full max-w-lg space-y-6">
+
+        {/* Header */}
+        <div className="text-center">
+          <Link href="/" className="text-sm text-gray-400 dark:text-slate-500 hover:text-gray-600 dark:hover:text-slate-300 transition-colors">
+            ← AIQUAA
+          </Link>
+        </div>
+
+        {/* Card */}
+        <div className="bg-white dark:bg-slate-800 rounded-2xl border border-gray-200 dark:border-slate-700 overflow-hidden shadow-sm">
+
+          {/* Hero */}
+          <div className="h-16 bg-gradient-to-r from-indigo-500 to-purple-600" />
+
+          <div className="px-6 pb-6">
+            {/* Logo */}
+            <div className="-mt-8 mb-4">
+              {empresa?.logo_url ? (
+                <div className="relative w-16 h-16 rounded-xl border-4 border-white dark:border-slate-800 bg-white shadow overflow-hidden">
+                  <Image
+                    src={empresa.logo_url}
+                    alt={`Logo ${displayName}`}
+                    fill
+                    className="object-contain"
+                    unoptimized
+                  />
+                </div>
+              ) : (
+                <div className="w-16 h-16 rounded-xl border-4 border-white dark:border-slate-800 bg-indigo-100 dark:bg-indigo-900/40 flex items-center justify-center shadow">
+                  <span className="text-2xl">🏢</span>
+                </div>
+              )}
+            </div>
+
+            {isCompleted ? (
+              <div className="text-center py-6">
+                <p className="text-4xl mb-3">✅</p>
+                <h1 className="text-xl font-bold text-gray-900 dark:text-white mb-2">
+                  ¡Evaluación completada!
+                </h1>
+                <p className="text-sm text-gray-500 dark:text-slate-400">
+                  Ya completaste la evaluación de {displayName}. Podés ver tus resultados en tu perfil.
+                </p>
+                <Link
+                  href="/perfil"
+                  className="inline-block mt-4 px-5 py-2 rounded-lg text-sm font-semibold bg-indigo-600 text-white hover:bg-indigo-700 transition-colors"
+                >
+                  Ver mi perfil
+                </Link>
+              </div>
+            ) : isExpired ? (
+              <div className="text-center py-6">
+                <p className="text-4xl mb-3">⛔</p>
+                <h1 className="text-xl font-bold text-gray-900 dark:text-white mb-2">
+                  Invitación vencida
+                </h1>
+                <p className="text-sm text-gray-500 dark:text-slate-400">
+                  Esta invitación ya no está disponible. Contactá a {displayName} para más información.
+                </p>
+              </div>
+            ) : (
+              <>
+                {/* Invitation body */}
+                <h1 className="text-xl font-bold text-gray-900 dark:text-white mb-1">
+                  {displayName} te invita a rendir
+                </h1>
+                {proceso && (
+                  <p className="text-base font-semibold text-indigo-600 dark:text-indigo-400 mb-3">
+                    {proceso.position_name}
+                  </p>
+                )}
+
+                {inv.message && (
+                  <blockquote className="border-l-4 border-indigo-400 pl-4 py-1 my-4 text-sm text-gray-700 dark:text-slate-300 italic">
+                    {inv.message}
+                  </blockquote>
+                )}
+
+                {/* Exams */}
+                {proceso && proceso.exam_types.length > 0 && (
+                  <div className="my-4 space-y-2">
+                    <p className="text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-slate-400">
+                      Evaluaciones a rendir
+                    </p>
+                    {proceso.exam_types.map((et) => (
+                      <div
+                        key={et}
+                        className="flex items-center gap-2 px-3 py-2 rounded-lg bg-indigo-50 dark:bg-indigo-900/30 text-sm font-medium text-indigo-800 dark:text-indigo-200"
+                      >
+                        <span>📋</span>
+                        {EXAM_LABELS[et] ?? et}
+                      </div>
+                    ))}
+                  </div>
+                )}
+
+                {/* Process code */}
+                {proceso && (
+                  <div className="my-4 rounded-xl border-2 border-dashed border-indigo-200 dark:border-indigo-700/50 p-4 text-center">
+                    <p className="text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-slate-400 mb-1">
+                      Código del proceso
+                    </p>
+                    <p className="text-2xl font-bold font-mono tracking-widest text-indigo-700 dark:text-indigo-300">
+                      {proceso.code}
+                    </p>
+                    <p className="text-xs text-gray-400 dark:text-slate-500 mt-1">
+                      Usá este código al iniciar el examen
+                    </p>
+                  </div>
+                )}
+
+                <p className="text-sm text-gray-500 dark:text-slate-400 mb-5">
+                  Para rendir la evaluación necesitás una cuenta en AIQUAA (gratuita). Si ya tenés cuenta, ingresá directamente.
+                </p>
+
+                {/* CTAs */}
+                <div className="flex flex-col sm:flex-row gap-3">
+                  <Link
+                    href={`/login?next=/dashboard`}
+                    className="flex-1 text-center px-4 py-3 rounded-xl text-sm font-semibold bg-indigo-600 text-white hover:bg-indigo-700 transition-colors"
+                  >
+                    Tengo cuenta — Ingresar
+                  </Link>
+                  <Link
+                    href={`/register`}
+                    className="flex-1 text-center px-4 py-3 rounded-xl text-sm font-semibold border border-indigo-300 dark:border-indigo-600 text-indigo-700 dark:text-indigo-300 hover:bg-indigo-50 dark:hover:bg-indigo-900/40 transition-colors"
+                  >
+                    Crear cuenta gratis
+                  </Link>
+                </div>
+              </>
+            )}
+          </div>
+        </div>
+
+        <p className="text-center text-xs text-gray-400 dark:text-slate-500">
+          AIQUAA · Plataforma QA gratuita para LATAM
+        </p>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
- EMP-001: sendInvitacionEmail() llama al backend mailer vía POST /mailer/interna/candidato-invitacion después de insertar en BD; el candidato ahora recibe el email con template HTML completo
- EMP-002: nueva página pública /invitacion/[token] que muestra empresa, puesto, exámenes, código del proceso y CTAs de login/registro; marca la invitación como 'vista' al cargarse
- EMP-005: generateCode en nuevo proceso verifica unicidad con hasta 5 reintentos antes de hacer el INSERT; previene colisiones de código
- Validación RUC Paraguay: formato \d{6,8}-\d validado en handleSave del perfil de empresa; hint dinámico en el label cuando país === PY
- Backend: ResendService.sendCandidatoInvitacion + MailerService.sendCandidatoInvitacion
  + endpoint POST /mailer/interna/candidato-invitacion protegido por INTERNAL_NOTIFY_SECRET

https://claude.ai/code/session_01YUySJ4q8We9u4xRwf1Gioo