### PR TITLE
fix(auth): await createClient() in confirm route and forgotPasswordAc…

### DIFF
--- a/apps/frontend/src/actions/auth.ts
+++ b/apps/frontend/src/actions/auth.ts
@@ -81,7 +81,7 @@ export async function resendConfirmationAction(email: string) {
 }
 
 export async function forgotPasswordAction(email: string) {
-  const supabase = createClient();
+  const supabase = await createClient();
   const siteUrl =
     process.env.NEXT_PUBLIC_SITE_URL || process.env.NEXTAUTH_URL || 'https://aiquaa.com';
   const { error } = await supabase.auth.resetPasswordForEmail(email, {

--- a/apps/frontend/src/app/auth/confirm/route.ts
+++ b/apps/frontend/src/app/auth/confirm/route.ts
@@ -21,7 +21,7 @@ export async function GET(request: NextRequest) {
     return NextResponse.redirect(resultUrl.toString());
   }
 
-  const supabase = createClient();
+  const supabase = await createClient();
 
   if (code) {
     const { data, error } = await supabase.auth.exchangeCodeForSession(code);


### PR DESCRIPTION
…tion

Both were calling createClient() without await, so supabase was a Promise instead of the client. This caused exchangeCodeForSession to always fail on the reset-password flow, showing a false "link expired" error even with a valid token.