### PR TITLE
fix(auth): call resetPasswordForEmail client-side to fix PKCE flow

### DIFF
--- a/apps/frontend/src/app/auth/confirm/route.ts
+++ b/apps/frontend/src/app/auth/confirm/route.ts
@@ -30,6 +30,7 @@ export async function GET(request: NextRequest) {
       const destination = next ?? getDefaultRedirect(audience);
       return NextResponse.redirect(`${origin}${destination}`);
     }
+    console.error('[auth/confirm] exchangeCodeForSession failed:', error?.message);
   }
 
   if (token_hash && type) {
@@ -43,6 +44,11 @@ export async function GET(request: NextRequest) {
       const destination = next ?? getDefaultRedirect(audience);
       return NextResponse.redirect(`${origin}${destination}`);
     }
+    console.error('[auth/confirm] verifyOtp failed:', error?.message);
+  }
+
+  if (!code && !token_hash) {
+    console.error('[auth/confirm] no code or token_hash in request. params:', Object.fromEntries(searchParams));
   }
 
   const fallbackUrl = new URL(`${origin}/auth/confirm-result`);

--- a/apps/frontend/src/app/auth/forgot-password/page.tsx
+++ b/apps/frontend/src/app/auth/forgot-password/page.tsx
@@ -2,7 +2,7 @@
 
 import React, { useState } from 'react';
 import Link from 'next/link';
-import { forgotPasswordAction } from '@/actions/auth';
+import { createClient } from '@/lib/supabase/client';
 import { useTheme } from '@/contexts/ThemeContext';
 
 export default function ForgotPasswordPage() {
@@ -20,10 +20,14 @@ export default function ForgotPasswordPage() {
       return;
     }
     setIsLoading(true);
-    const result = await forgotPasswordAction(email);
+    const supabase = createClient();
+    const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || window.location.origin;
+    const { error: sbError } = await supabase.auth.resetPasswordForEmail(email, {
+      redirectTo: `${siteUrl}/auth/confirm?next=/auth/reset-password`,
+    });
     setIsLoading(false);
-    if (result.error) {
-      setError(result.error);
+    if (sbError) {
+      setError(sbError.message);
     } else {
       setSent(true);
     }


### PR DESCRIPTION
When resetPasswordForEmail was called from a server action, Supabase generated the PKCE code_verifier server-side. The cookie storing the verifier may not have reached the browser, causing exchangeCodeForSession to fail silently at the confirm callback and fall through to link_expired.

Moving the call to the browser client ensures @supabase/ssr handles the code_verifier in browser cookies natively, so the confirm route can exchange the code correctly.

Also adds error logging in confirm/route.ts to surface future failures.