### PR TITLE
fix: ciclo QA — gamification, favicon, cards, performance score, email confirm

### DIFF
--- a/apps/frontend/src/app/auth/confirm-result/page.tsx
+++ b/apps/frontend/src/app/auth/confirm-result/page.tsx
@@ -4,9 +4,39 @@ import LogoMark from '@/components/LogoMark';
 export default async function ConfirmResultPage({
   searchParams,
 }: {
-  searchParams: Promise<{ error?: string; next?: string }>;
+  searchParams: Promise<{ error?: string; next?: string; success?: string }>;
 }) {
-  const { error, next } = await searchParams;
+  const { error, next, success } = await searchParams;
+
+  if (success === 'true') {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-gray-50 py-12 px-4">
+        <div className="max-w-md w-full text-center space-y-6">
+          <div className="mx-auto h-12 w-12 flex items-center justify-center rounded-full bg-slate-900 mb-4">
+            <LogoMark size={32} color="#ffffff" wordmark={false} />
+          </div>
+
+          <div className="mx-auto flex items-center justify-center h-12 w-12 rounded-full bg-green-100">
+            <svg className="h-6 w-6 text-green-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+            </svg>
+          </div>
+
+          <h2 className="text-2xl font-bold text-gray-900">¡Email confirmado!</h2>
+          <p className="text-gray-600">
+            Tu cuenta fue verificada exitosamente. Ya podés usar AIQUAA.
+          </p>
+
+          <Link
+            href={next ?? '/ranking'}
+            className="inline-block w-full py-2 px-4 bg-indigo-600 hover:bg-indigo-700 text-white rounded-md text-sm font-medium"
+          >
+            Ingresar a la app →
+          </Link>
+        </div>
+      </div>
+    );
+  }
 
   const isExpired = error === 'link_expired' || error === 'access_denied';
   const isPasswordReset = next?.includes('reset-password');

--- a/apps/frontend/src/app/auth/confirm/route.ts
+++ b/apps/frontend/src/app/auth/confirm/route.ts
@@ -28,7 +28,15 @@ export async function GET(request: NextRequest) {
     if (!error) {
       const audience = data.user?.user_metadata?.audience;
       const destination = next ?? getDefaultRedirect(audience);
-      return NextResponse.redirect(`${origin}${destination}`);
+
+      if (next?.includes('reset-password')) {
+        return NextResponse.redirect(`${origin}${destination}`);
+      }
+
+      const successUrl = new URL(`${origin}/auth/confirm-result`);
+      successUrl.searchParams.set('success', 'true');
+      successUrl.searchParams.set('next', destination);
+      return NextResponse.redirect(successUrl.toString());
     }
     console.error('[auth/confirm] exchangeCodeForSession failed:', error?.message);
   }
@@ -42,7 +50,15 @@ export async function GET(request: NextRequest) {
       const { data: { user } } = await supabase.auth.getUser();
       const audience = user?.user_metadata?.audience;
       const destination = next ?? getDefaultRedirect(audience);
-      return NextResponse.redirect(`${origin}${destination}`);
+
+      if (type === 'recovery') {
+        return NextResponse.redirect(`${origin}${destination}`);
+      }
+
+      const successUrl = new URL(`${origin}/auth/confirm-result`);
+      successUrl.searchParams.set('success', 'true');
+      successUrl.searchParams.set('next', destination);
+      return NextResponse.redirect(successUrl.toString());
     }
     console.error('[auth/confirm] verifyOtp failed:', error?.message);
   }


### PR DESCRIPTION
## Resumen

Fixes del ciclo QA horario. Cierra #67, #72, #73, #78, #79, #80.

- **Gamification (#79)**: creado `award_xp()` + trigger `on_exam_result_award_xp` AFTER INSERT en `exam_results`. Backfill de XP para los 38 registros históricos. 4 usuarios ahora tienen XP (1370 / 300 / 300 / 150).
- **Performance score (#67)**: `max_possible_score = 35` seteado en los 14 registros históricos; `performance/page.tsx` ahora envía `max_possible_score` en futuros exámenes. El ranking ya usaba el fallback correcto.
- **Email confirmation (#72)**: verificación exitosa ahora muestra pantalla con checkmark verde y CTA en lugar de redirigir silenciosamente al ranking.
- **Cards Labs (#73)**: layout `flex flex-col` + `flex-1` para que el footer de cada card quede alineado al fondo.
- **Favicon (#78)**: creado `public/favicon.ico` y corregida configuración en `layout.tsx`.
- **Seguridad (#80)**: `SET search_path = public` en todas las funciones SECURITY DEFINER; vista `ranking_candidatos` como SECURITY INVOKER; política de storage `empresa-logos` restringida.
- **Toast en AllPairs**: reemplazados `alert()` nativos por `showToast()`.

## Test plan

- [ ] Registrar usuario nuevo → confirmar email → verificar que aparece pantalla de éxito verde
- [ ] Rendir examen de performance → verificar score `X/35` en ranking
- [ ] Verificar que los cards de `/labs` tienen altura uniforme
- [ ] Verificar favicon en tab del navegador
- [ ] Verificar que el generador AllPairs muestra toast en lugar de alert al copiar

https://claude.ai/code/session_016SVCFJqLNaUw2wwRd6oy28

---
_Generated by [Claude Code](https://claude.ai/code/session_016SVCFJqLNaUw2wwRd6oy28)_