### PR TITLE
fix(labs): alinear sección "Hacer clic para usar" en todas las tarjetas

### DIFF
--- a/apps/frontend/src/app/labs/page.tsx
+++ b/apps/frontend/src/app/labs/page.tsx
@@ -424,12 +424,12 @@ export default function LabsPage() {
                   <Link
                     key={tool.id}
                     href={tool.href}
-                    className={`group block rounded-lg shadow-lg overflow-hidden hover:shadow-xl transition-all duration-300 hover:-translate-y-1 ${
+                    className={`group flex flex-col rounded-lg shadow-lg overflow-hidden hover:shadow-xl transition-all duration-300 hover:-translate-y-1 ${
                       isDarkMode ? 'bg-slate-800' : 'bg-white'
                     }`}
                   >
                     <div
-                      className={`bg-gradient-to-r ${tool.color} p-6 text-white relative`}
+                      className={`flex-1 bg-gradient-to-r ${tool.color} p-6 text-white relative`}
                     >
                       {/* Badges Container */}
                       <div className="flex items-start justify-between gap-2 mb-3">


### PR DESCRIPTION
Cambia `block` por `flex flex-col` en la tarjeta y agrega `flex-1` al área de gradiente para que absorba el espacio variable del contenido (descripciones largas, badges opcionales). Así el footer queda siempre a la misma altura en cada fila del grid.

Closes #73

https://claude.ai/code/session_01AXGSqY6pAjw7ihmkB86QxD