### PR TITLE
fix: corregir display de score en Performance y altura de tarjetas Labs

### DIFF
--- a/apps/frontend/src/actions/exams.ts
+++ b/apps/frontend/src/actions/exams.ts
@@ -111,7 +111,7 @@ export async function getExamResultsAction() {
   const { data, error } = await supabase
     .from('exam_results')
     .select(
-      'id, exam_type, exam_mode, score, total_questions, passing_score, passed, percentage, time_spent, model, language, created_at'
+      'id, exam_type, exam_mode, score, total_questions, max_possible_score, passing_score, passed, percentage, time_spent, model, language, created_at'
     )
     .eq('user_id', user.id)
     .order('created_at', { ascending: false })

--- a/apps/frontend/src/app/dashboard/page.tsx
+++ b/apps/frontend/src/app/dashboard/page.tsx
@@ -12,6 +12,7 @@ interface ExamResult {
   exam_mode: string;
   score: number;
   total_questions: number;
+  max_possible_score: number | null;
   passed: boolean;
   percentage: number;
   time_spent: number | null;
@@ -272,7 +273,7 @@ export default function DashboardPage() {
                     </div>
                     <div className="text-right shrink-0">
                       <p className={`text-sm font-bold ${isDarkMode ? 'text-white' : 'text-gray-900'}`}>
-                        {result.score}/{result.total_questions}
+                        {result.score}/{result.max_possible_score ?? result.total_questions}
                       </p>
                       <p className={`text-xs ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}>
                         {Number(result.percentage).toFixed(0)}%

--- a/apps/frontend/src/app/labs/page.tsx
+++ b/apps/frontend/src/app/labs/page.tsx
@@ -424,12 +424,12 @@ export default function LabsPage() {
                   <Link
                     key={tool.id}
                     href={tool.href}
-                    className={`group block rounded-lg shadow-lg overflow-hidden hover:shadow-xl transition-all duration-300 hover:-translate-y-1 ${
+                    className={`group flex flex-col rounded-lg shadow-lg overflow-hidden hover:shadow-xl transition-all duration-300 hover:-translate-y-1 ${
                       isDarkMode ? 'bg-slate-800' : 'bg-white'
                     }`}
                   >
                     <div
-                      className={`bg-gradient-to-r ${tool.color} p-6 text-white relative`}
+                      className={`flex-1 bg-gradient-to-r ${tool.color} p-6 text-white relative`}
                     >
                       {/* Badges Container */}
                       <div className="flex items-start justify-between gap-2 mb-3">

--- a/apps/frontend/src/app/perfil/page.tsx
+++ b/apps/frontend/src/app/perfil/page.tsx
@@ -18,6 +18,7 @@ interface ExamResultRow {
   exam_mode: 'exam' | 'training';
   score: number;
   total_questions: number;
+  max_possible_score: number | null;
   passing_score: number;
   passed: boolean;
   percentage: number;
@@ -770,7 +771,7 @@ export default function PerfilPage() {
                       <p
                         className={`text-sm font-bold ${isDarkMode ? 'text-slate-200' : 'text-gray-800'}`}
                       >
-                        {r.score}/{r.total_questions}
+                        {r.score}/{r.max_possible_score ?? r.total_questions}
                       </p>
                       <p
                         className={`text-xs ${isDarkMode ? 'text-slate-500' : 'text-gray-400'}`}


### PR DESCRIPTION
- Labs page: cambiar `block` a `flex flex-col` en tarjetas de herramientas para que el área "Hacer clic para usar" quede siempre alineada al fondo (fix issue #73)
- getExamResultsAction: incluir `max_possible_score` en la query de Supabase
- Dashboard y Perfil: mostrar `score/max_possible_score` en lugar de `score/total_questions` para evitar el display "31/27" en Performance (fix parte visual de issue #66/#67)

https://claude.ai/code/session_012SYkkSKLAWwkK1nGjpB7sv