### PR TITLE
fix/feat: auditoría QA — logout, candidatos, test-app UX y gráficos analíticos

### DIFF
--- a/apps/frontend/src/actions/exams.ts
+++ b/apps/frontend/src/actions/exams.ts
@@ -41,9 +41,19 @@ export async function saveExamResultAction(payload: SaveExamResultPayload) {
   } = await supabase.auth.getUser();
   if (userError || !user) return { error: 'No autenticado' };
 
+  const resolvedName =
+    payload.participant_name?.trim() ||
+    user.user_metadata?.full_name?.trim() ||
+    null;
+
+  const resolvedEmail =
+    payload.participant_email?.trim() || user.email || null;
+
   const { error } = await supabase.from('exam_results').insert({
     user_id: user.id,
     ...payload,
+    participant_name: resolvedName,
+    participant_email: resolvedEmail,
   });
 
   if (error) return { error: error.message };

--- a/apps/frontend/src/app/empresa/candidatos/page.tsx
+++ b/apps/frontend/src/app/empresa/candidatos/page.tsx
@@ -654,7 +654,7 @@ export default function CandidatosPage() {
                       fontSize: 12,
                     }}
                     labelStyle={{ color: isDarkMode ? '#e2e8f0' : '#374151', fontWeight: 600 }}
-                    formatter={(v: unknown) => [v, 'Exámenes']}
+                    formatter={(v: number | string) => [v, 'Exámenes']}
                   />
                   <Bar dataKey="examenes" fill="#6366f1" fillOpacity={0.72} radius={[3, 3, 0, 0]} />
                 </BarChart>

--- a/apps/frontend/src/app/empresa/candidatos/page.tsx
+++ b/apps/frontend/src/app/empresa/candidatos/page.tsx
@@ -84,6 +84,28 @@ export default function CandidatosPage() {
     [results]
   );
 
+  // For each result, compute its attempt index and total attempts for that candidate+exam combo
+  const attemptInfo = useMemo(() => {
+    const groups = new Map<string, ExamResult[]>();
+    for (const r of results) {
+      const key = `${r.participant_email ?? r.participant_name ?? r.id}|${r.exam_type}`;
+      if (!groups.has(key)) groups.set(key, []);
+      groups.get(key)!.push(r);
+    }
+    const indexMap = new Map<string, number>();   // resultId -> attempt number (1-based)
+    const totalMap = new Map<string, number>();   // resultId -> total attempts
+    for (const group of groups.values()) {
+      const sorted = [...group].sort(
+        (a, b) => new Date(a.created_at).getTime() - new Date(b.created_at).getTime()
+      );
+      sorted.forEach((r, i) => {
+        indexMap.set(r.id, i + 1);
+        totalMap.set(r.id, sorted.length);
+      });
+    }
+    return { indexMap, totalMap };
+  }, [results]);
+
   const filtered = useMemo(() => {
     const q = search.toLowerCase();
     return results
@@ -374,19 +396,22 @@ export default function CandidatosPage() {
                         }`}
                       >
                         <td className="px-5 py-3">
-                          <div
-                            className={`font-medium ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
-                          >
-                            {r.participant_name || r.participant_email || (
-                              <span className={`italic ${isDarkMode ? 'text-slate-500' : 'text-gray-400'}`}>
-                                Sin nombre
+                          <div className="flex items-center gap-2 flex-wrap">
+                            <span className={`font-medium ${isDarkMode ? 'text-white' : 'text-gray-900'}`}>
+                              {r.participant_name || (
+                                <span className={`italic ${isDarkMode ? 'text-slate-500' : 'text-gray-400'}`}>
+                                  Sin nombre
+                                </span>
+                              )}
+                            </span>
+                            {(attemptInfo.totalMap.get(r.id) ?? 1) > 1 && (
+                              <span className={`text-xs px-1.5 py-0.5 rounded font-mono ${isDarkMode ? 'bg-slate-700 text-slate-300' : 'bg-gray-100 text-gray-500'}`}>
+                                intento {attemptInfo.indexMap.get(r.id)}/{attemptInfo.totalMap.get(r.id)}
                               </span>
                             )}
                           </div>
-                          {r.participant_name && r.participant_email && (
-                            <div
-                              className={`text-xs ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}
-                            >
+                          {r.participant_email && (
+                            <div className={`text-xs mt-0.5 ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}>
                               {r.participant_email}
                             </div>
                           )}

--- a/apps/frontend/src/app/empresa/candidatos/page.tsx
+++ b/apps/frontend/src/app/empresa/candidatos/page.tsx
@@ -4,6 +4,17 @@ import Link from 'next/link';
 import { useEffect, useState, useMemo } from 'react';
 import { useTheme } from '@/contexts/ThemeContext';
 import { createClient } from '@/lib/supabase/client';
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Cell,
+  Legend,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
 
 type ExamResult = {
   id: string;
@@ -145,6 +156,69 @@ export default function CandidatosPage() {
     sortKey,
     sortDir,
   ]);
+
+  // --- Chart data (all based on `filtered` so they respect active filters) ---
+
+  const topCandidatesData = useMemo(() => {
+    const best = new Map<string, { label: string; percentage: number; passed: boolean }>();
+    for (const r of filtered) {
+      const key = r.participant_email ?? r.participant_name ?? r.id;
+      const label = r.participant_name || r.participant_email || 'Sin nombre';
+      const cur = best.get(key);
+      if (!cur || r.percentage > cur.percentage) {
+        best.set(key, { label, percentage: r.percentage, passed: r.passed });
+      }
+    }
+    return [...best.values()]
+      .sort((a, b) => b.percentage - a.percentage)
+      .slice(0, 10)
+      .map((c) => ({
+        name: c.label.length > 22 ? c.label.slice(0, 20) + '…' : c.label,
+        puntaje: c.percentage,
+        passed: c.passed,
+      }));
+  }, [filtered]);
+
+  const byWeekData = useMemo(() => {
+    function isoWeek(date: Date): string {
+      const d = new Date(date.getTime());
+      d.setHours(0, 0, 0, 0);
+      d.setDate(d.getDate() + 3 - ((d.getDay() + 6) % 7));
+      const jan4 = new Date(d.getFullYear(), 0, 4);
+      const week =
+        1 +
+        Math.round(
+          ((d.getTime() - jan4.getTime()) / 86400000 -
+            3 +
+            ((jan4.getDay() + 6) % 7)) /
+            7
+        );
+      return `${d.getFullYear()}-W${String(week).padStart(2, '0')}`;
+    }
+    const groups = new Map<string, { total: number; aprobados: number }>();
+    for (const r of filtered) {
+      const w = isoWeek(new Date(r.created_at));
+      const cur = groups.get(w) ?? { total: 0, aprobados: 0 };
+      groups.set(w, { total: cur.total + 1, aprobados: cur.aprobados + (r.passed ? 1 : 0) });
+    }
+    return [...groups.entries()]
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([w, d]) => ({ semana: w.replace(/^\d{4}-/, ''), total: d.total, aprobados: d.aprobados }));
+  }, [filtered]);
+
+  const byHourData = useMemo(() => {
+    const counts = new Array(24).fill(0) as number[];
+    const fmt = new Intl.DateTimeFormat('es-PY', {
+      hour: 'numeric',
+      hour12: false,
+      timeZone: 'America/Asuncion',
+    });
+    for (const r of filtered) {
+      const h = parseInt(fmt.format(new Date(r.created_at)), 10) % 24;
+      counts[h] += 1;
+    }
+    return counts.map((cnt, h) => ({ hora: `${String(h).padStart(2, '0')}h`, examenes: cnt }));
+  }, [filtered]);
 
   const toggleSort = (key: SortKey) => {
     if (sortKey === key) setSortDir((d) => (d === 'asc' ? 'desc' : 'asc'));
@@ -476,6 +550,118 @@ export default function CandidatosPage() {
                   })}
                 </tbody>
               </table>
+            </div>
+          </div>
+        )}
+
+        {/* Charts */}
+        {!loading && filtered.length > 0 && (
+          <div className="space-y-6">
+            <h2 className={`text-base font-semibold ${isDarkMode ? 'text-white' : 'text-gray-900'}`}>
+              Análisis visual
+            </h2>
+
+            {/* Top candidates */}
+            <div className={`rounded-xl border p-5 ${card}`}>
+              <p className={`text-sm font-semibold mb-4 ${isDarkMode ? 'text-slate-300' : 'text-gray-700'}`}>
+                Mejores candidatos (puntaje más alto)
+              </p>
+              <ResponsiveContainer width="100%" height={250}>
+                <BarChart data={topCandidatesData} margin={{ top: 4, right: 16, bottom: 48, left: 0 }}>
+                  <CartesianGrid strokeDasharray="3 3" stroke={isDarkMode ? '#334155' : '#e5e7eb'} vertical={false} />
+                  <XAxis
+                    dataKey="name"
+                    tick={{ fill: isDarkMode ? '#94a3b8' : '#6b7280', fontSize: 11 }}
+                    angle={-35}
+                    textAnchor="end"
+                    interval={0}
+                  />
+                  <YAxis
+                    domain={[0, 100]}
+                    tick={{ fill: isDarkMode ? '#94a3b8' : '#6b7280', fontSize: 11 }}
+                    unit="%"
+                    width={36}
+                  />
+                  <Tooltip
+                    contentStyle={{
+                      background: isDarkMode ? '#1e293b' : '#fff',
+                      border: `1px solid ${isDarkMode ? '#475569' : '#e5e7eb'}`,
+                      borderRadius: 8,
+                      fontSize: 12,
+                    }}
+                    labelStyle={{ color: isDarkMode ? '#e2e8f0' : '#374151', fontWeight: 600 }}
+                    formatter={(v: unknown) => [`${v}%`, 'Puntaje']}
+                  />
+                  <Bar dataKey="puntaje" radius={[4, 4, 0, 0]} maxBarSize={40}>
+                    {topCandidatesData.map((entry, i) => (
+                      <Cell key={i} fill={entry.passed ? '#22c55e' : '#ef4444'} fillOpacity={0.82} />
+                    ))}
+                  </Bar>
+                </BarChart>
+              </ResponsiveContainer>
+              <p className={`text-xs mt-1 ${isDarkMode ? 'text-slate-500' : 'text-gray-400'}`}>
+                Verde = aprobado · Rojo = no aprobado
+              </p>
+            </div>
+
+            {/* By week */}
+            {byWeekData.length > 1 && (
+              <div className={`rounded-xl border p-5 ${card}`}>
+                <p className={`text-sm font-semibold mb-4 ${isDarkMode ? 'text-slate-300' : 'text-gray-700'}`}>
+                  Actividad por semana
+                </p>
+                <ResponsiveContainer width="100%" height={220}>
+                  <BarChart data={byWeekData} margin={{ top: 4, right: 16, bottom: 16, left: 0 }}>
+                    <CartesianGrid strokeDasharray="3 3" stroke={isDarkMode ? '#334155' : '#e5e7eb'} vertical={false} />
+                    <XAxis dataKey="semana" tick={{ fill: isDarkMode ? '#94a3b8' : '#6b7280', fontSize: 11 }} />
+                    <YAxis allowDecimals={false} tick={{ fill: isDarkMode ? '#94a3b8' : '#6b7280', fontSize: 11 }} width={28} />
+                    <Tooltip
+                      contentStyle={{
+                        background: isDarkMode ? '#1e293b' : '#fff',
+                        border: `1px solid ${isDarkMode ? '#475569' : '#e5e7eb'}`,
+                        borderRadius: 8,
+                        fontSize: 12,
+                      }}
+                      labelStyle={{ color: isDarkMode ? '#e2e8f0' : '#374151', fontWeight: 600 }}
+                    />
+                    <Legend wrapperStyle={{ fontSize: 12, color: isDarkMode ? '#94a3b8' : '#6b7280' }} />
+                    <Bar dataKey="total" name="Total" fill="#6366f1" fillOpacity={0.8} radius={[3, 3, 0, 0]} maxBarSize={32} />
+                    <Bar dataKey="aprobados" name="Aprobados" fill="#22c55e" fillOpacity={0.8} radius={[3, 3, 0, 0]} maxBarSize={32} />
+                  </BarChart>
+                </ResponsiveContainer>
+              </div>
+            )}
+
+            {/* By hour */}
+            <div className={`rounded-xl border p-5 ${card}`}>
+              <p className={`text-sm font-semibold mb-4 ${isDarkMode ? 'text-slate-300' : 'text-gray-700'}`}>
+                Distribución por hora del día
+              </p>
+              <ResponsiveContainer width="100%" height={200}>
+                <BarChart data={byHourData} margin={{ top: 4, right: 16, bottom: 0, left: 0 }}>
+                  <CartesianGrid strokeDasharray="3 3" stroke={isDarkMode ? '#334155' : '#e5e7eb'} vertical={false} />
+                  <XAxis
+                    dataKey="hora"
+                    tick={{ fill: isDarkMode ? '#94a3b8' : '#6b7280', fontSize: 10 }}
+                    interval={3}
+                  />
+                  <YAxis allowDecimals={false} tick={{ fill: isDarkMode ? '#94a3b8' : '#6b7280', fontSize: 11 }} width={28} />
+                  <Tooltip
+                    contentStyle={{
+                      background: isDarkMode ? '#1e293b' : '#fff',
+                      border: `1px solid ${isDarkMode ? '#475569' : '#e5e7eb'}`,
+                      borderRadius: 8,
+                      fontSize: 12,
+                    }}
+                    labelStyle={{ color: isDarkMode ? '#e2e8f0' : '#374151', fontWeight: 600 }}
+                    formatter={(v: unknown) => [v, 'Exámenes']}
+                  />
+                  <Bar dataKey="examenes" fill="#6366f1" fillOpacity={0.72} radius={[3, 3, 0, 0]} />
+                </BarChart>
+              </ResponsiveContainer>
+              <p className={`text-xs mt-1 ${isDarkMode ? 'text-slate-500' : 'text-gray-400'}`}>
+                Hora en zona horaria Paraguay (UTC−4)
+              </p>
             </div>
           </div>
         )}

--- a/apps/frontend/src/app/empresa/candidatos/page.tsx
+++ b/apps/frontend/src/app/empresa/candidatos/page.tsx
@@ -377,9 +377,13 @@ export default function CandidatosPage() {
                           <div
                             className={`font-medium ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
                           >
-                            {r.participant_name || '—'}
+                            {r.participant_name || r.participant_email || (
+                              <span className={`italic ${isDarkMode ? 'text-slate-500' : 'text-gray-400'}`}>
+                                Sin nombre
+                              </span>
+                            )}
                           </div>
-                          {r.participant_email && (
+                          {r.participant_name && r.participant_email && (
                             <div
                               className={`text-xs ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}
                             >


### PR DESCRIPTION
## Resumen

Este PR agrupa las mejoras identificadas en un ciclo de auditoría QA completo sobre la plataforma. Incluye correcciones de bugs críticos, mejoras de UX y nuevas funcionalidades de análisis para el panel empresa.

---

## 🐛 Bugs corregidos

### 1. Cierre de sesión no limpiaba el estado del cliente
**Problema:** Al hacer logout, la foto de perfil y el nombre del usuario persistían en el header porque la acción de servidor (`signOut`) no disparaba el listener `onAuthStateChange` del cliente Supabase.

**Solución:**
- Se agregó `signOut()` al `SupabaseAuthContext` que llama directamente al cliente browser de Supabase y limpia `user`/`session` en el estado React de forma inmediata.
- `Header.tsx` y `UserMenu.tsx` ahora usan `signOut` del contexto en lugar de una server action, garantizando que el estado local se limpie antes de redirigir a `/login`.

### 2. Candidatos aparecían sin nombre en el panel empresa
**Problema:** Muchos registros en `exam_results` quedaban con `participant_name = null` porque los exámenes no siempre enviaban el nombre explícitamente.

**Solución en dos capas:**
- **Al guardar** (`actions/exams.ts`): se usa `user.user_metadata.full_name` del perfil de Supabase como fallback si el payload no trae nombre, y `user.email` como fallback para el email.
- **Al mostrar** (`empresa/candidatos`): se muestra el nombre si existe, o un italic "Sin nombre" en su defecto. El email siempre se muestra debajo del nombre.

### 3. Email de reporte de bugs del Test App apuntaba al servidor incorrecto
**Problema:** El endpoint de envío de reporte usaba una ruta relativa que apuntaba a Next.js en lugar del backend NestJS.

**Solución:** Se usa `NEXT_PUBLIC_API_URL` como base para construir la URL correcta hacia `/api/v1/labs/test-app/send-bug-report`.

---

## ✨ Mejoras de UX

### Panel de candidatos — identificación de intentos múltiples
Cuando un candidato rinde el mismo examen más de una vez, ahora se muestra un badge `intento X/N` junto a su nombre, ordenado cronológicamente. El email siempre es visible debajo del nombre para facilitar la identificación.

### Test App — indicador de bugs activos
Se agregó un badge en el header del Test App mostrando cuántos bugs están activos para la sesión actual (`🎯 X bugs activos`), para que el candidato sepa cuántos defectos inyectados debe encontrar.

### Fórmula XP centralizada
Se creó `lib/xp.ts` como única fuente de verdad para la fórmula de nivel (`50 * level * (level - 1)`), eliminando la duplicación que existía en `dashboard`, `ranking` y `perfil`.

### Fechas en zona horaria de Paraguay
Se aplicó `timeZone: 'America/Asuncion'` en todas las fechas formateadas con `toLocaleDateString` en las páginas de perfil, dashboard y candidatos.

---

## 📊 Nuevos gráficos analíticos en `/empresa/candidatos`

Se agregaron tres gráficos Recharts debajo de la tabla, reactivos a los filtros activos:

| Gráfico | Descripción |
|---|---|
| **Mejores candidatos** | Top 10 por puntaje máximo. Barras verdes = aprobado, rojas = no aprobado |
| **Actividad por semana** | Barras agrupadas por semana ISO: total de exámenes vs aprobados |
| **Distribución por hora** | Histograma de 24 horas mostrando en qué horarios se rinden los exámenes (timezone Paraguay) |

Todos los gráficos respetan el tema claro/oscuro del sistema.

---

## Archivos clave modificados

| Archivo | Cambio |
|---|---|
| `contexts/SupabaseAuthContext.tsx` | Agrega `signOut()` al contexto |
| `components/Header.tsx` / `UserMenu.tsx` | Usa `signOut` del contexto |
| `actions/exams.ts` | Fallback de nombre/email al guardar resultados |
| `app/empresa/candidatos/page.tsx` | Badges de intento, email visible, 3 gráficos |
| `app/labs/test-app/components/TestAppLayout.tsx` | Badge de bugs activos |
| `app/labs/test-app/report/page.tsx` | Fix URL de endpoint NestJS |
| `lib/xp.ts` | Nueva utilidad compartida para fórmula XP |
| `app/dashboard/page.tsx`, `ranking/page.tsx`, `perfil/page.tsx` | Usa `xpForLevel` de `lib/xp` + timezone Paraguay |

## Plan de pruebas

- [ ] Iniciar sesión → verificar que foto y nombre aparecen en header
- [ ] Cerrar sesión → verificar que header queda limpio sin foto ni nombre
- [ ] Rendir un examen con proceso asignado → verificar que aparece con nombre en `/empresa/candidatos`
- [ ] Rendir el mismo examen dos veces → verificar badge `intento 1/2` y `intento 2/2`
- [ ] Verificar que email siempre aparece debajo del nombre en la tabla
- [ ] Con datos en la tabla → verificar los 3 gráficos debajo
- [ ] Cambiar filtros → verificar que los gráficos se actualizan
- [ ] Alternar dark/light mode → verificar que los gráficos adaptan colores
- [ ] En Test App → verificar badge `🎯 X bugs activos` en el header

https://claude.ai/code/session_01QGG2UuuZZfQa8TwHgSnnGz

---
_Generated by [Claude Code](https://claude.ai/code/session_01QGG2UuuZZfQa8TwHgSnnGz)_