### PR TITLE
feat(api-exams): integrar exámenes de API en ranking, empresa y Labs

### DIFF
--- a/apps/frontend/src/actions/assessments.ts
+++ b/apps/frontend/src/actions/assessments.ts
@@ -1,14 +1,19 @@
 'use server';
 
 import { saveExamResultAction } from '@/actions/exams';
-import { createAdminClient } from '@/lib/supabase/admin';
 import { createClient } from '@/lib/supabase/server';
-import { API_TESTING_FUNDAMENTALS_SLUG } from '@/app/assessments/api-testing-fundamentals/data/assessment-definition';
+import {
+  API_TESTING_FUNDAMENTALS_SLUG,
+  API_TESTING_SEED_VERSION,
+} from '@/app/assessments/api-testing-fundamentals/data/assessment-definition';
 import {
   API_TESTING_GAMIFICATION_RULES,
   buildApiTestingGamificationEvents,
-  calculateXpLevel,
 } from '@/app/assessments/api-testing-fundamentals/lib/gamification';
+import {
+  ensureXpRules,
+  grantGamificationXpEvent,
+} from '@/lib/gamification/grant-xp';
 import {
   buildAssessmentFeedback,
   deriveCandidateLevel,
@@ -31,24 +36,6 @@ import type {
   AssessmentSectionScore,
 } from '@/app/assessments/api-testing-fundamentals/types';
 
-type XpRuleRow = {
-  id: string | number;
-  event_type: string;
-  xp_amount: number;
-  description: string;
-  daily_limit: number | null;
-  is_active: boolean;
-};
-
-type UserXpRow = {
-  id: string;
-  user_id: string;
-  total_xp: number;
-  level: number;
-  current_streak: number | null;
-  longest_streak: number | null;
-};
-
 async function getAuthenticatedUser() {
   const supabase = createClient();
   const {
@@ -63,117 +50,6 @@ async function getAuthenticatedUser() {
   return { supabase, user };
 }
 
-async function ensureApiTestingGamificationRules() {
-  const admin = createAdminClient();
-
-  const payload = API_TESTING_GAMIFICATION_RULES.map((rule) => ({
-    event_type: rule.eventType,
-    xp_amount: rule.xpAmount,
-    description: rule.description,
-    daily_limit: rule.dailyLimit,
-    is_active: true,
-  }));
-
-  const { error } = await admin
-    .from('xp_rules')
-    .upsert(payload, { onConflict: 'event_type' });
-
-  if (error) {
-    throw new Error(error.message);
-  }
-}
-
-async function grantGamificationXpEvent(input: {
-  userId: string;
-  eventType: string;
-  source: string;
-  sourceId: string;
-  metadata: Record<string, unknown>;
-}) {
-  const admin = createAdminClient();
-  const deduplicationKey = `${input.eventType}:${input.sourceId}`;
-
-  const [
-    { data: rule, error: ruleError },
-    { data: existing, error: existingError },
-  ] = await Promise.all([
-    admin
-      .from('xp_rules')
-      .select('id, event_type, xp_amount, description, daily_limit, is_active')
-      .eq('event_type', input.eventType)
-      .eq('is_active', true)
-      .maybeSingle<XpRuleRow>(),
-    admin
-      .from('xp_history')
-      .select('id')
-      .eq('user_id', input.userId)
-      .eq('deduplication_key', deduplicationKey)
-      .maybeSingle(),
-  ]);
-
-  if (ruleError) throw new Error(ruleError.message);
-  if (existingError) throw new Error(existingError.message);
-  if (!rule || existing) return;
-
-  if (rule.daily_limit !== null && rule.daily_limit !== undefined) {
-    const todayStart = new Date();
-    todayStart.setHours(0, 0, 0, 0);
-    const tomorrowStart = new Date(todayStart);
-    tomorrowStart.setDate(tomorrowStart.getDate() + 1);
-
-    const { count, error: countError } = await admin
-      .from('xp_history')
-      .select('id', { count: 'exact', head: true })
-      .eq('user_id', input.userId)
-      .eq('event_type', input.eventType)
-      .gte('created_at', todayStart.toISOString())
-      .lt('created_at', tomorrowStart.toISOString());
-
-    if (countError) throw new Error(countError.message);
-    if ((count ?? 0) >= rule.daily_limit) return;
-  }
-
-  const { data: currentXp, error: currentXpError } = await admin
-    .from('user_xp')
-    .select('id, user_id, total_xp, level, current_streak, longest_streak')
-    .eq('user_id', input.userId)
-    .maybeSingle<UserXpRow>();
-
-  if (currentXpError) throw new Error(currentXpError.message);
-
-  const nextTotalXp = (currentXp?.total_xp ?? 0) + rule.xp_amount;
-  const nextLevel = calculateXpLevel(nextTotalXp);
-  const now = new Date().toISOString();
-
-  const { error: historyError } = await admin.from('xp_history').insert({
-    user_id: input.userId,
-    xp_rule_id: rule.id,
-    event_type: input.eventType,
-    xp_amount: rule.xp_amount,
-    source: input.source,
-    source_id: input.sourceId,
-    deduplication_key: deduplicationKey,
-    metadata: input.metadata,
-  });
-
-  if (historyError) throw new Error(historyError.message);
-
-  const { error: userXpError } = await admin.from('user_xp').upsert(
-    {
-      user_id: input.userId,
-      total_xp: nextTotalXp,
-      level: nextLevel,
-      current_streak: currentXp?.current_streak ?? 0,
-      longest_streak: currentXp?.longest_streak ?? 0,
-      last_activity_at: now,
-      updated_at: now,
-    },
-    { onConflict: 'user_id' }
-  );
-
-  if (userXpError) throw new Error(userXpError.message);
-}
-
 async function awardApiTestingGamification(input: {
   userId: string;
   attemptId: string;
@@ -182,7 +58,7 @@ async function awardApiTestingGamification(input: {
   score: number;
   candidateLevel: string;
 }) {
-  await ensureApiTestingGamificationRules();
+  await ensureXpRules(API_TESTING_GAMIFICATION_RULES);
 
   const events = buildApiTestingGamificationEvents({
     attemptId: input.attemptId,
@@ -204,20 +80,42 @@ async function awardApiTestingGamification(input: {
   }
 }
 
+// Memo por instancia: una vez verificada la versión del seed, las requests
+// siguientes de esa lambda no vuelven a comparar metadata.
+let verifiedSeedVersion: number | null = null;
+
 async function getAssessmentBySlug(slug: string) {
-  if (slug === API_TESTING_FUNDAMENTALS_SLUG) {
-    await ensureApiTestingFundamentalsSeeded();
+  const { supabase } = await getAuthenticatedUser();
+
+  const fetchAssessment = () =>
+    supabase
+      .from('assessments')
+      .select('*')
+      .eq('slug', slug)
+      .eq('is_active', true)
+      .maybeSingle();
+
+  let { data: assessment } = await fetchAssessment();
+
+  if (
+    slug === API_TESTING_FUNDAMENTALS_SLUG &&
+    verifiedSeedVersion !== API_TESTING_SEED_VERSION
+  ) {
+    const seededVersion = (
+      assessment?.metadata as Record<string, unknown> | null
+    )?.seedVersion;
+
+    if (!assessment || seededVersion !== API_TESTING_SEED_VERSION) {
+      await ensureApiTestingFundamentalsSeeded();
+      ({ data: assessment } = await fetchAssessment());
+    }
+
+    if (assessment) {
+      verifiedSeedVersion = API_TESTING_SEED_VERSION;
+    }
   }
 
-  const { supabase } = await getAuthenticatedUser();
-  const { data: assessment, error } = await supabase
-    .from('assessments')
-    .select('*')
-    .eq('slug', slug)
-    .eq('is_active', true)
-    .single();
-
-  if (error || !assessment) {
+  if (!assessment) {
     throw new Error('Assessment no encontrado');
   }
 
@@ -602,7 +500,7 @@ export async function finalizeAssessmentAttemptAction(attemptId: string) {
   const correctAnswers = answers.filter((answer) => answer.is_correct).length;
   const incorrectAnswers = Math.max(0, answers.length - correctAnswers);
 
-  await saveExamResultAction({
+  const examResult = await saveExamResultAction({
     exam_type: 'api-testing-fundamentals',
     exam_mode: 'exam',
     score: totalScore,
@@ -628,6 +526,13 @@ export async function finalizeAssessmentAttemptAction(attemptId: string) {
       recommendations: generatedFeedback.recommendations,
     },
   });
+
+  if (examResult?.error) {
+    console.warn(
+      '[assessments] no se pudo guardar exam_results para api-testing-fundamentals',
+      examResult.error
+    );
+  }
 
   try {
     await awardApiTestingGamification({

--- a/apps/frontend/src/actions/exams.ts
+++ b/apps/frontend/src/actions/exams.ts
@@ -8,7 +8,8 @@ interface SaveExamResultPayload {
     | 'istqb'
     | 'performance'
     | 'test-app'
-    | 'api-testing-fundamentals';
+    | 'api-testing-fundamentals'
+    | 'api-banking';
   exam_mode: 'exam' | 'training';
   participant_name?: string;
   participant_email?: string;
@@ -65,7 +66,12 @@ export async function saveExamResultAction(payload: SaveExamResultPayload) {
 }
 
 export async function getLeaderboardAction(
-  examType: 'git' | 'istqb' | 'performance' | 'api-testing-fundamentals',
+  examType:
+    | 'git'
+    | 'istqb'
+    | 'performance'
+    | 'api-testing-fundamentals'
+    | 'api-banking',
   limit = 20
 ) {
   const supabase = createClient();

--- a/apps/frontend/src/app/api/assessments/[attemptId]/submit/route.ts
+++ b/apps/frontend/src/app/api/assessments/[attemptId]/submit/route.ts
@@ -1,6 +1,15 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createAdminClient } from '@/lib/supabase/admin';
 import { autoScore } from '@/app/assessments/api-banking/lib/scoring';
+import {
+  API_BANKING_GAMIFICATION_RULES,
+  API_BANKING_PASS_THRESHOLD,
+  buildApiBankingGamificationEvents,
+} from '@/app/assessments/api-banking/lib/gamification';
+import {
+  ensureXpRules,
+  grantGamificationXpEvent,
+} from '@/lib/gamification/grant-xp';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -18,7 +27,9 @@ export async function POST(
   // Fetch attempt
   const { data: attempt } = await supabase
     .from('qac_attempts')
-    .select('id, status')
+    .select(
+      'id, status, started_at, aiquaa_user_id, candidate_name, candidate_email, process_code'
+    )
     .eq('id', attemptId)
     .single();
 
@@ -91,16 +102,93 @@ export async function POST(
   });
 
   // Update attempt status
+  const submittedAt = new Date().toISOString();
   await supabase
     .from('qac_attempts')
     .update({
       status: 'submitted',
-      submitted_at: new Date().toISOString(),
+      submitted_at: submittedAt,
       total_score: scoreResult.totalScore,
       summary: summary ?? null,
-      updated_at: new Date().toISOString(),
+      updated_at: submittedAt,
     })
     .eq('id', attemptId);
+
+  // Resultado para ranking/dashboard de empresa + XP (solo usuarios autenticados:
+  // exam_results.user_id es NOT NULL). Nunca debe romper el submit del candidato.
+  if (attempt.aiquaa_user_id) {
+    const totalScore = Math.round(scoreResult.totalScore);
+    const passed = totalScore >= API_BANKING_PASS_THRESHOLD;
+    const timeSpentSeconds = Math.max(
+      60,
+      Math.round(
+        (new Date(submittedAt).getTime() -
+          new Date(attempt.started_at).getTime()) /
+          1000
+      )
+    );
+
+    const { error: examResultError } = await supabase
+      .from('exam_results')
+      .insert({
+        user_id: attempt.aiquaa_user_id,
+        exam_type: 'api-banking',
+        exam_mode: 'exam',
+        score: totalScore,
+        total_questions: scoreResult.bugsTotal,
+        max_possible_score: 100,
+        correct_answers: scoreResult.bugsFound,
+        incorrect_answers: Math.max(
+          0,
+          scoreResult.bugsTotal - scoreResult.bugsFound
+        ),
+        passing_score: API_BANKING_PASS_THRESHOLD,
+        passed,
+        percentage: totalScore,
+        time_spent: timeSpentSeconds,
+        process_code: attempt.process_code ?? null,
+        participant_name: attempt.candidate_name,
+        participant_email: attempt.candidate_email,
+        metadata: {
+          qac_attempt_id: attemptId,
+          test_design_score: scoreResult.testDesignScore,
+          api_validation_score: scoreResult.apiValidationScore,
+          security_score: scoreResult.securityScore,
+          bug_reporting_score: scoreResult.bugReportingScore,
+          executive_summary_score: scoreResult.executiveSummaryScore,
+          bugs_found: scoreResult.bugsFound,
+          bugs_total: scoreResult.bugsTotal,
+        },
+      });
+
+    if (examResultError) {
+      console.warn(
+        '[api-banking] no se pudo guardar exam_results',
+        examResultError.message
+      );
+    }
+
+    try {
+      await ensureXpRules(API_BANKING_GAMIFICATION_RULES);
+      const events = buildApiBankingGamificationEvents({
+        attemptId,
+        totalScore,
+        bugsFound: scoreResult.bugsFound,
+        bugsTotal: scoreResult.bugsTotal,
+      });
+      for (const event of events) {
+        await grantGamificationXpEvent({
+          userId: attempt.aiquaa_user_id,
+          eventType: event.eventType,
+          source: 'API_BANKING',
+          sourceId: event.sourceId,
+          metadata: event.metadata,
+        });
+      }
+    } catch (gamificationError) {
+      console.warn('[api-banking] gamification sync failed', gamificationError);
+    }
+  }
 
   return NextResponse.json({ ok: true, score: scoreResult }, { status: 200 });
 }

--- a/apps/frontend/src/app/api/assessments/start/route.ts
+++ b/apps/frontend/src/app/api/assessments/start/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createAdminClient } from '@/lib/supabase/admin';
+import { createClient } from '@/lib/supabase/server';
 import { signChallengeToken } from '../../challenge/_lib/auth';
 
 export const runtime = 'nodejs';
@@ -8,7 +9,7 @@ export const dynamic = 'force-dynamic';
 export async function POST(req: NextRequest) {
   try {
     const body = await req.json();
-    const { candidateName, candidateEmail, aiquaaUserId } = body ?? {};
+    const { candidateName, candidateEmail, processCode } = body ?? {};
 
     if (!candidateName?.trim()) {
       return NextResponse.json(
@@ -17,7 +18,42 @@ export async function POST(req: NextRequest) {
       );
     }
 
+    // Resolver el usuario server-side (no confiar en el body); null si invitado
+    let aiquaaUserId: string | null = null;
+    try {
+      const authClient = createClient();
+      const {
+        data: { user },
+      } = await authClient.auth.getUser();
+      aiquaaUserId = user?.id ?? null;
+    } catch {
+      aiquaaUserId = null;
+    }
+
     const supabase = createAdminClient();
+
+    // Validar código de proceso si fue provisto
+    let resolvedProcessCode: string | null = null;
+    if (typeof processCode === 'string' && processCode.trim()) {
+      const { data: process } = await supabase
+        .from('hiring_processes')
+        .select('code, status, expires_at')
+        .ilike('code', processCode.trim())
+        .eq('status', 'active')
+        .maybeSingle();
+
+      const expired =
+        process?.expires_at && new Date(process.expires_at) < new Date();
+
+      if (!process || expired) {
+        return NextResponse.json(
+          { error: 'Código de proceso inválido, vencido o cerrado.' },
+          { status: 400 }
+        );
+      }
+
+      resolvedProcessCode = process.code;
+    }
 
     // Find the api-banking assessment
     const { data: assessment, error: aErr } = await supabase
@@ -41,7 +77,8 @@ export async function POST(req: NextRequest) {
         catalog_id: assessment.id,
         candidate_name: candidateName.trim(),
         candidate_email: candidateEmail?.trim() ?? null,
-        aiquaa_user_id: aiquaaUserId ?? null,
+        aiquaa_user_id: aiquaaUserId,
+        process_code: resolvedProcessCode,
         status: 'in_progress',
       })
       .select('id')

--- a/apps/frontend/src/app/assessments/api-banking/__tests__/gamification.test.ts
+++ b/apps/frontend/src/app/assessments/api-banking/__tests__/gamification.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest';
+import {
+  API_BANKING_GAMIFICATION_RULES,
+  API_BANKING_HIGH_SCORE_THRESHOLD,
+  API_BANKING_PASS_THRESHOLD,
+  buildApiBankingGamificationEvents,
+} from '../lib/gamification';
+
+describe('buildApiBankingGamificationEvents', () => {
+  it('always grants completion XP', () => {
+    const events = buildApiBankingGamificationEvents({
+      attemptId: 1,
+      totalScore: 40,
+      bugsFound: 3,
+      bugsTotal: 12,
+    });
+
+    expect(events.map((event) => event.eventType)).toEqual([
+      'API_BANKING_COMPLETED',
+    ]);
+  });
+
+  it('adds passed XP at the pass threshold', () => {
+    const events = buildApiBankingGamificationEvents({
+      attemptId: 2,
+      totalScore: API_BANKING_PASS_THRESHOLD,
+      bugsFound: 7,
+      bugsTotal: 12,
+    });
+
+    expect(events.map((event) => event.eventType)).toEqual([
+      'API_BANKING_COMPLETED',
+      'API_BANKING_PASSED',
+    ]);
+  });
+
+  it('adds high score XP at the high score threshold', () => {
+    const events = buildApiBankingGamificationEvents({
+      attemptId: 3,
+      totalScore: API_BANKING_HIGH_SCORE_THRESHOLD,
+      bugsFound: 11,
+      bugsTotal: 12,
+    });
+
+    expect(events.map((event) => event.eventType)).toEqual([
+      'API_BANKING_COMPLETED',
+      'API_BANKING_PASSED',
+      'API_BANKING_HIGH_SCORE',
+    ]);
+  });
+
+  it('prefixes source ids to avoid dedup collisions with other exams', () => {
+    const [completed] = buildApiBankingGamificationEvents({
+      attemptId: 42,
+      totalScore: 10,
+      bugsFound: 1,
+      bugsTotal: 12,
+    });
+
+    expect(completed.sourceId).toBe('api-banking:42:completed');
+  });
+});
+
+describe('API banking gamification rules', () => {
+  it('defines the expected XP catalog', () => {
+    expect(API_BANKING_GAMIFICATION_RULES).toHaveLength(3);
+    expect(
+      API_BANKING_GAMIFICATION_RULES.find(
+        (rule) => rule.eventType === 'API_BANKING_COMPLETED'
+      )?.xpAmount
+    ).toBe(70);
+    expect(
+      API_BANKING_GAMIFICATION_RULES.find(
+        (rule) => rule.eventType === 'API_BANKING_PASSED'
+      )?.xpAmount
+    ).toBe(120);
+    expect(
+      API_BANKING_GAMIFICATION_RULES.find(
+        (rule) => rule.eventType === 'API_BANKING_HIGH_SCORE'
+      )?.xpAmount
+    ).toBe(160);
+  });
+});

--- a/apps/frontend/src/app/assessments/api-banking/lib/gamification.ts
+++ b/apps/frontend/src/app/assessments/api-banking/lib/gamification.ts
@@ -1,0 +1,78 @@
+import type { XpRuleDefinition } from '@/lib/gamification/grant-xp';
+
+export const API_BANKING_PASS_THRESHOLD = 60;
+export const API_BANKING_HIGH_SCORE_THRESHOLD = 90;
+
+export type ApiBankingGamificationEventType =
+  | 'API_BANKING_COMPLETED'
+  | 'API_BANKING_PASSED'
+  | 'API_BANKING_HIGH_SCORE';
+
+export interface ApiBankingGamificationEvent {
+  eventType: ApiBankingGamificationEventType;
+  sourceId: string;
+  metadata: Record<string, unknown>;
+}
+
+export const API_BANKING_GAMIFICATION_RULES: XpRuleDefinition[] = [
+  {
+    eventType: 'API_BANKING_COMPLETED',
+    xpAmount: 70,
+    description: 'Completar el API Banking Challenge',
+    dailyLimit: 3,
+  },
+  {
+    eventType: 'API_BANKING_PASSED',
+    xpAmount: 120,
+    description: 'Aprobar el API Banking Challenge (score >= 60)',
+    dailyLimit: 3,
+  },
+  {
+    eventType: 'API_BANKING_HIGH_SCORE',
+    xpAmount: 160,
+    description: 'Score sobresaliente en API Banking Challenge (>= 90)',
+    dailyLimit: 3,
+  },
+];
+
+export function buildApiBankingGamificationEvents(input: {
+  attemptId: number;
+  totalScore: number;
+  bugsFound: number;
+  bugsTotal: number;
+}): ApiBankingGamificationEvent[] {
+  const baseMetadata = {
+    assessmentSlug: 'api-banking',
+    totalScore: input.totalScore,
+    bugsFound: input.bugsFound,
+    bugsTotal: input.bugsTotal,
+  };
+
+  // Prefijo "api-banking" en sourceId: los attempt ids de qac son enteros y sin
+  // prefijo podrían colisionar con dedup keys de otros exámenes.
+  const events: ApiBankingGamificationEvent[] = [
+    {
+      eventType: 'API_BANKING_COMPLETED',
+      sourceId: `api-banking:${input.attemptId}:completed`,
+      metadata: baseMetadata,
+    },
+  ];
+
+  if (input.totalScore >= API_BANKING_PASS_THRESHOLD) {
+    events.push({
+      eventType: 'API_BANKING_PASSED',
+      sourceId: `api-banking:${input.attemptId}:passed`,
+      metadata: baseMetadata,
+    });
+  }
+
+  if (input.totalScore >= API_BANKING_HIGH_SCORE_THRESHOLD) {
+    events.push({
+      eventType: 'API_BANKING_HIGH_SCORE',
+      sourceId: `api-banking:${input.attemptId}:high-score`,
+      metadata: baseMetadata,
+    });
+  }
+
+  return events;
+}

--- a/apps/frontend/src/app/assessments/api-banking/start/page.tsx
+++ b/apps/frontend/src/app/assessments/api-banking/start/page.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import { useSupabaseAuth } from '@/contexts/SupabaseAuthContext';
 import { getExamUserDefaults } from '@/lib/exam-user-defaults';
+import ProcessCodeInput from '@/components/labs/ProcessCodeInput';
 import { SESSION_KEYS } from '../types';
 
 export default function StartPage() {
@@ -11,6 +12,7 @@ export default function StartPage() {
   const { user, isLoading: authLoading } = useSupabaseAuth();
   const [name, setName] = useState('');
   const [email, setEmail] = useState('');
+  const [processCode, setProcessCode] = useState('');
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
 
@@ -23,7 +25,19 @@ export default function StartPage() {
     }
   }, [user]);
 
-  async function startChallenge(candidateName: string, candidateEmail: string) {
+  // Pre-fill process code from ?code= (links desde invitaciones/procesos)
+  useEffect(() => {
+    const codeParam = new URLSearchParams(window.location.search).get('code');
+    if (codeParam) setProcessCode(codeParam);
+  }, []);
+
+  async function handleStart(ev: React.FormEvent) {
+    ev.preventDefault();
+    if (!name.trim()) {
+      setError('El nombre es requerido.');
+      return;
+    }
+
     setLoading(true);
     setError(null);
 
@@ -32,9 +46,9 @@ export default function StartPage() {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
-          candidateName: candidateName.trim(),
-          candidateEmail: candidateEmail.trim() || undefined,
-          aiquaaUserId: user?.id ?? undefined,
+          candidateName: name.trim(),
+          candidateEmail: email.trim() || undefined,
+          processCode: processCode.trim() || undefined,
         }),
       });
 
@@ -48,7 +62,7 @@ export default function StartPage() {
 
       sessionStorage.setItem(SESSION_KEYS.attemptId, String(attemptId));
       sessionStorage.setItem(SESSION_KEYS.challengeToken, challengeToken);
-      sessionStorage.setItem(SESSION_KEYS.candidateName, candidateName.trim());
+      sessionStorage.setItem(SESSION_KEYS.candidateName, name.trim());
       sessionStorage.setItem(SESSION_KEYS.startedAt, new Date().toISOString());
 
       router.push('/assessments/api-banking/workspace');
@@ -59,41 +73,19 @@ export default function StartPage() {
     }
   }
 
-  async function handleStart(ev: React.FormEvent) {
-    ev.preventDefault();
-    if (!name.trim()) {
-      setError('El nombre es requerido.');
-      return;
-    }
-    await startChallenge(name, email);
-  }
-
-  // If logged in and we already have name → auto-start
-  useEffect(() => {
-    if (!authLoading && user) {
-      const defaults = getExamUserDefaults(user);
-      if (defaults.fullName) {
-        startChallenge(defaults.fullName, defaults.email);
-      }
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [authLoading, user]);
-
-  // Show spinner while auto-starting
-  if (authLoading || (user && loading)) {
+  if (authLoading) {
     return (
       <main className="min-h-screen bg-slate-50 dark:bg-slate-950 flex items-center justify-center">
         <div className="text-center space-y-3">
           <div className="w-8 h-8 border-2 border-blue-600 border-t-transparent rounded-full animate-spin mx-auto" />
           <p className="text-sm text-slate-500 dark:text-slate-400">
-            Iniciando challenge...
+            Cargando...
           </p>
         </div>
       </main>
     );
   }
 
-  // Guest: show form
   return (
     <main className="min-h-screen bg-slate-50 dark:bg-slate-950 flex items-center justify-center px-4 py-12">
       <div className="w-full max-w-md space-y-6">
@@ -102,7 +94,7 @@ export default function StartPage() {
             Iniciar challenge
           </h1>
           <p className="text-sm text-slate-500 dark:text-slate-400">
-            QA API Challenge — Banking Transactions
+            API Banking — Challenge práctico
           </p>
         </div>
 
@@ -136,6 +128,13 @@ export default function StartPage() {
               disabled={loading}
             />
           </div>
+
+          <ProcessCodeInput
+            value={processCode}
+            onChange={setProcessCode}
+            onNormalizedCode={setProcessCode}
+            autoValidate
+          />
 
           {error && (
             <p className="text-sm text-red-600 dark:text-red-400">{error}</p>

--- a/apps/frontend/src/app/assessments/api-testing-fundamentals/data/assessment-definition.ts
+++ b/apps/frontend/src/app/assessments/api-testing-fundamentals/data/assessment-definition.ts
@@ -2,6 +2,9 @@ import type { AssessmentSeedDefinition } from '../types';
 
 export const API_TESTING_FUNDAMENTALS_SLUG = 'api-testing-fundamentals';
 
+// Bumpear cuando cambie la definición (secciones/preguntas) para forzar re-seed.
+export const API_TESTING_SEED_VERSION = 1;
+
 export const apiTestingFundamentalsDefinition: AssessmentSeedDefinition = {
   slug: API_TESTING_FUNDAMENTALS_SLUG,
   title: 'API Testing Fundamentals Challenge',

--- a/apps/frontend/src/app/assessments/api-testing-fundamentals/lib/seed.ts
+++ b/apps/frontend/src/app/assessments/api-testing-fundamentals/lib/seed.ts
@@ -1,5 +1,8 @@
 import { createAdminClient } from '@/lib/supabase/admin';
-import { apiTestingFundamentalsDefinition } from '../data/assessment-definition';
+import {
+  API_TESTING_SEED_VERSION,
+  apiTestingFundamentalsDefinition,
+} from '../data/assessment-definition';
 
 export async function ensureApiTestingFundamentalsSeeded() {
   const supabase = createAdminClient();
@@ -13,7 +16,10 @@ export async function ensureApiTestingFundamentalsSeeded() {
     duration_minutes: apiTestingFundamentalsDefinition.duration_minutes,
     total_score: apiTestingFundamentalsDefinition.total_score,
     is_active: apiTestingFundamentalsDefinition.is_active,
-    metadata: apiTestingFundamentalsDefinition.metadata ?? {},
+    metadata: {
+      ...(apiTestingFundamentalsDefinition.metadata ?? {}),
+      seedVersion: API_TESTING_SEED_VERSION,
+    },
     updated_at: new Date().toISOString(),
   };
 

--- a/apps/frontend/src/app/assessments/api-testing-fundamentals/start/page.tsx
+++ b/apps/frontend/src/app/assessments/api-testing-fundamentals/start/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useTransition } from 'react';
+import { useEffect, useState, useTransition } from 'react';
 import { useRouter } from 'next/navigation';
 import { useTheme } from '@/contexts/ThemeContext';
 import { startAssessmentAttemptAction } from '@/actions/assessments';
@@ -12,6 +12,12 @@ export default function StartApiTestingFundamentalsPage() {
   const [processCode, setProcessCode] = useState('');
   const [error, setError] = useState('');
   const [isPending, startTransition] = useTransition();
+
+  // Pre-fill desde ?code= (links de invitaciones/procesos de empresa)
+  useEffect(() => {
+    const codeParam = new URLSearchParams(window.location.search).get('code');
+    if (codeParam) setProcessCode(codeParam);
+  }, []);
 
   function handleStart() {
     setError('');

--- a/apps/frontend/src/app/assessments/page.tsx
+++ b/apps/frontend/src/app/assessments/page.tsx
@@ -26,7 +26,7 @@ export default function AssessmentsIndexPage() {
             <div className="flex flex-col gap-6 lg:flex-row lg:items-start lg:justify-between">
               <div className="max-w-3xl">
                 <p className="text-sm font-semibold uppercase tracking-[0.2em] text-amber-300">
-                  Nuevo challenge
+                  Examen teórico · Auto-corregido
                 </p>
                 <h2 className="mt-2 text-3xl font-bold">{overview.title}</h2>
                 <p className="mt-3 text-slate-300">{overview.description}</p>
@@ -80,18 +80,18 @@ export default function AssessmentsIndexPage() {
             <div className="flex flex-col gap-6 lg:flex-row lg:items-start lg:justify-between">
               <div className="max-w-3xl">
                 <p className="text-sm font-semibold uppercase tracking-[0.2em] text-emerald-300">
-                  API Testing · Semi Senior
+                  Challenge práctico · Auto-corregido · Semi Senior
                 </p>
                 <h2 className="mt-2 text-3xl font-bold">
-                  QA API Challenge{' '}
+                  API Banking{' '}
                   <span className="font-normal text-slate-400">
-                    — Banking Transactions
+                    — Challenge práctico (Banking Transactions)
                   </span>
                 </h2>
                 <p className="mt-3 text-slate-300">
-                  Explorá y testeá una API bancaria simulada. Identificá 12
-                  bugs intencionales, diseñá casos de prueba y generá un
-                  reporte profesional. Auto-scoring de 100 pts.
+                  Explorá y testeá una API bancaria simulada. Identificá 12 bugs
+                  intencionales, diseñá casos de prueba y generá un reporte
+                  profesional. Auto-scoring de 100 pts.
                 </p>
                 <div className="mt-5 flex flex-wrap gap-3 text-sm text-slate-300">
                   <span className="rounded-full border border-slate-700 px-3 py-1">
@@ -117,10 +117,26 @@ export default function AssessmentsIndexPage() {
             </div>
             <div className="mt-8 grid gap-4 md:grid-cols-2 xl:grid-cols-5">
               {[
-                { label: 'Diseño de tests', pts: 25, desc: 'Variedad y cobertura' },
-                { label: 'Validación API', pts: 25, desc: 'Bugs funcionales y contrato' },
-                { label: 'Seguridad', pts: 20, desc: 'IDOR, datos sensibles, auth' },
-                { label: 'Bug Reporting', pts: 20, desc: 'Calidad y completitud' },
+                {
+                  label: 'Diseño de tests',
+                  pts: 25,
+                  desc: 'Variedad y cobertura',
+                },
+                {
+                  label: 'Validación API',
+                  pts: 25,
+                  desc: 'Bugs funcionales y contrato',
+                },
+                {
+                  label: 'Seguridad',
+                  pts: 20,
+                  desc: 'IDOR, datos sensibles, auth',
+                },
+                {
+                  label: 'Bug Reporting',
+                  pts: 20,
+                  desc: 'Calidad y completitud',
+                },
                 { label: 'Resumen', pts: 10, desc: 'Síntesis ejecutiva' },
               ].map((cat) => (
                 <div

--- a/apps/frontend/src/app/dashboard/page.tsx
+++ b/apps/frontend/src/app/dashboard/page.tsx
@@ -38,9 +38,14 @@ const LAB_INFO = {
     href: '/labs/performance',
   },
   'api-testing-fundamentals': {
-    emoji: 'API',
-    label: 'API Testing Fundamentals',
+    emoji: '🌐',
+    label: 'API Testing — Fundamentos',
     href: '/assessments/api-testing-fundamentals',
+  },
+  'api-banking': {
+    emoji: '🏦',
+    label: 'API Banking — Challenge práctico',
+    href: '/assessments/api-banking',
   },
 } as const;
 

--- a/apps/frontend/src/app/employer/[code]/page.tsx
+++ b/apps/frontend/src/app/employer/[code]/page.tsx
@@ -17,6 +17,7 @@ const EXAM_LABELS: Record<string, string> = {
   git: 'Git',
   performance: 'Rendimiento',
   'api-testing-fundamentals': 'API Testing Fundamentals',
+  'api-banking': 'API Banking Challenge',
 };
 
 function formatTime(seconds: number) {

--- a/apps/frontend/src/app/employer/nuevo/page.tsx
+++ b/apps/frontend/src/app/employer/nuevo/page.tsx
@@ -13,6 +13,7 @@ const EXAM_OPTIONS = [
   { value: 'git', label: 'Git' },
   { value: 'performance', label: 'Rendimiento / Performance' },
   { value: 'api-testing-fundamentals', label: 'API Testing Fundamentals' },
+  { value: 'api-banking', label: 'API Banking — Challenge práctico' },
 ];
 
 export default function NuevoProcesoPage() {

--- a/apps/frontend/src/app/employer/page.tsx
+++ b/apps/frontend/src/app/employer/page.tsx
@@ -32,6 +32,7 @@ const EXAM_LABELS: Record<string, string> = {
   git: 'Git',
   performance: 'Rendimiento',
   'api-testing-fundamentals': 'API Testing Fundamentals',
+  'api-banking': 'API Banking Challenge',
 };
 
 function formatDate(iso: string) {

--- a/apps/frontend/src/app/empresa/candidatos/page.tsx
+++ b/apps/frontend/src/app/empresa/candidatos/page.tsx
@@ -41,6 +41,7 @@ const EXAM_LABELS: Record<string, string> = {
   git: 'Git',
   performance: 'Performance',
   'api-testing-fundamentals': 'API Testing Fundamentals',
+  'api-banking': 'API Banking Challenge',
 };
 
 type SortKey = 'percentage' | 'created_at' | 'participant_name';

--- a/apps/frontend/src/app/empresa/procesos/[id]/page.tsx
+++ b/apps/frontend/src/app/empresa/procesos/[id]/page.tsx
@@ -91,6 +91,7 @@ const EXAM_LABELS: Record<string, string> = {
   git: 'Git',
   performance: 'Performance',
   'api-testing-fundamentals': 'API Testing Fundamentals',
+  'api-banking': 'API Banking Challenge',
 };
 
 const SOURCES = [

--- a/apps/frontend/src/app/empresa/procesos/nuevo/page.tsx
+++ b/apps/frontend/src/app/empresa/procesos/nuevo/page.tsx
@@ -10,17 +10,32 @@ const EXAM_OPTIONS = [
   {
     id: 'istqb',
     label: 'ISTQB CTFL — Fundamentos de QA',
-    description: 'Conceptos de testing, ciclo de vida del defecto, técnicas de diseño y gestión de pruebas',
+    description:
+      'Conceptos de testing, ciclo de vida del defecto, técnicas de diseño y gestión de pruebas',
   },
   {
     id: 'git',
     label: 'Git — Control de versiones',
-    description: 'Comandos esenciales, branching, merge, rebase y flujos de trabajo colaborativos',
+    description:
+      'Comandos esenciales, branching, merge, rebase y flujos de trabajo colaborativos',
   },
   {
     id: 'performance',
     label: 'Performance Testing — Pruebas de carga',
-    description: 'Conceptos de pruebas de performance, herramientas (JMeter/k6), análisis de resultados',
+    description:
+      'Conceptos de pruebas de performance, herramientas (JMeter/k6), análisis de resultados',
+  },
+  {
+    id: 'api-testing-fundamentals',
+    label: 'API Testing — Fundamentos (Examen teórico)',
+    description:
+      'Conceptos de API, lectura de documentación, diseño de casos y análisis de respuestas — auto-corregido, 5 niveles',
+  },
+  {
+    id: 'api-banking',
+    label: 'API Banking — Challenge práctico',
+    description:
+      'Testear una API bancaria simulada, diseñar casos y reportar bugs — auto-corregido, 100 pts',
   },
 ];
 
@@ -52,8 +67,8 @@ export default function NuevoProcesoPage() {
   const [codeCopied, setCodeCopied] = useState(false);
 
   const toggleExam = (id: string) => {
-    setExamTypes(prev =>
-      prev.includes(id) ? prev.filter(e => e !== id) : [...prev, id]
+    setExamTypes((prev) =>
+      prev.includes(id) ? prev.filter((e) => e !== id) : [...prev, id]
     );
   };
 
@@ -69,7 +84,9 @@ export default function NuevoProcesoPage() {
     setError(null);
 
     const supabase = createClient();
-    const { data: { user } } = await supabase.auth.getUser();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
     if (!user) {
       setError('No estás autenticado.');
       setLoading(false);
@@ -85,7 +102,10 @@ export default function NuevoProcesoPage() {
         .select('code')
         .eq('code', candidate)
         .maybeSingle();
-      if (!existing) { code = candidate; break; }
+      if (!existing) {
+        code = candidate;
+        break;
+      }
     }
     if (!code) {
       setError('No se pudo generar un código único. Intentá de nuevo.');
@@ -135,21 +155,35 @@ export default function NuevoProcesoPage() {
   // Success screen
   if (createdCode) {
     return (
-      <div className={`min-h-screen transition-colors duration-300 ${isDarkMode ? 'bg-dark-bg' : 'bg-gray-50'}`}>
+      <div
+        className={`min-h-screen transition-colors duration-300 ${isDarkMode ? 'bg-dark-bg' : 'bg-gray-50'}`}
+      >
         <div className="max-w-2xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
-          <div className={`rounded-2xl border p-8 text-center ${isDarkMode ? 'bg-dark-secondary border-slate-700' : 'bg-white border-gray-200'}`}>
+          <div
+            className={`rounded-2xl border p-8 text-center ${isDarkMode ? 'bg-dark-secondary border-slate-700' : 'bg-white border-gray-200'}`}
+          >
             <p className="text-5xl mb-4">✅</p>
-            <h1 className={`text-2xl font-bold mb-2 ${isDarkMode ? 'text-white' : 'text-gray-900'}`}>
+            <h1
+              className={`text-2xl font-bold mb-2 ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
+            >
               ¡Proceso creado!
             </h1>
-            <p className={`text-sm mb-6 ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}>
+            <p
+              className={`text-sm mb-6 ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}
+            >
               Compartí este código con los candidatos para que rindan el examen
             </p>
-            <div className={`rounded-xl border-2 border-dashed p-5 mb-6 ${isDarkMode ? 'border-indigo-600 bg-indigo-900/20' : 'border-indigo-300 bg-indigo-50'}`}>
-              <p className={`text-xs font-semibold uppercase tracking-widest mb-2 ${isDarkMode ? 'text-indigo-400' : 'text-indigo-500'}`}>
+            <div
+              className={`rounded-xl border-2 border-dashed p-5 mb-6 ${isDarkMode ? 'border-indigo-600 bg-indigo-900/20' : 'border-indigo-300 bg-indigo-50'}`}
+            >
+              <p
+                className={`text-xs font-semibold uppercase tracking-widest mb-2 ${isDarkMode ? 'text-indigo-400' : 'text-indigo-500'}`}
+              >
                 Código del proceso
               </p>
-              <p className={`text-4xl font-bold font-mono tracking-widest ${isDarkMode ? 'text-indigo-300' : 'text-indigo-700'}`}>
+              <p
+                className={`text-4xl font-bold font-mono tracking-widest ${isDarkMode ? 'text-indigo-300' : 'text-indigo-700'}`}
+              >
                 {createdCode}
               </p>
             </div>
@@ -163,7 +197,9 @@ export default function NuevoProcesoPage() {
                 className={`px-5 py-2.5 rounded-lg text-sm font-semibold border transition-colors ${
                   codeCopied
                     ? 'border-green-400 text-green-600 bg-green-50 dark:bg-green-900/20 dark:text-green-300'
-                    : isDarkMode ? 'border-indigo-500 text-indigo-300 hover:bg-slate-700' : 'border-indigo-400 text-indigo-600 hover:bg-indigo-50'
+                    : isDarkMode
+                      ? 'border-indigo-500 text-indigo-300 hover:bg-slate-700'
+                      : 'border-indigo-400 text-indigo-600 hover:bg-indigo-50'
                 }`}
               >
                 {codeCopied ? '✅ Copiado!' : '📋 Copiar código'}
@@ -190,22 +226,30 @@ export default function NuevoProcesoPage() {
   }
 
   return (
-    <div className={`min-h-screen transition-colors duration-300 ${isDarkMode ? 'bg-dark-bg' : 'bg-gray-50'}`}>
+    <div
+      className={`min-h-screen transition-colors duration-300 ${isDarkMode ? 'bg-dark-bg' : 'bg-gray-50'}`}
+    >
       <div className="max-w-2xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
-
         <div className="mb-8">
-          <h1 className={`text-2xl font-bold ${isDarkMode ? 'text-white' : 'text-gray-900'}`}>
+          <h1
+            className={`text-2xl font-bold ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
+          >
             Nuevo proceso de selección
           </h1>
-          <p className={`text-sm mt-1 ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}>
-            Creá un proceso y compartí el código con los candidatos para que rindan los exámenes
+          <p
+            className={`text-sm mt-1 ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}
+          >
+            Creá un proceso y compartí el código con los candidatos para que
+            rindan los exámenes
           </p>
         </div>
 
         <form
           onSubmit={handleSubmit}
           className={`rounded-xl border p-6 space-y-6 ${
-            isDarkMode ? 'bg-dark-secondary border-slate-700' : 'bg-white border-gray-200'
+            isDarkMode
+              ? 'bg-dark-secondary border-slate-700'
+              : 'bg-white border-gray-200'
           }`}
         >
           {/* Position name */}
@@ -216,7 +260,7 @@ export default function NuevoProcesoPage() {
               className={inputClass}
               placeholder="ej. QA Analyst Jr."
               value={positionName}
-              onChange={e => setPositionName(e.target.value)}
+              onChange={(e) => setPositionName(e.target.value)}
               required
               maxLength={120}
             />
@@ -224,13 +268,18 @@ export default function NuevoProcesoPage() {
 
           {/* Description */}
           <div>
-            <label className={labelClass}>Descripción <span className={isDarkMode ? 'text-slate-500' : 'text-gray-400'}>(opcional)</span></label>
+            <label className={labelClass}>
+              Descripción{' '}
+              <span className={isDarkMode ? 'text-slate-500' : 'text-gray-400'}>
+                (opcional)
+              </span>
+            </label>
             <textarea
               className={`${inputClass} resize-none`}
               rows={3}
               placeholder="Describí brevemente el proceso o los requisitos del puesto"
               value={description}
-              onChange={e => setDescription(e.target.value)}
+              onChange={(e) => setDescription(e.target.value)}
               maxLength={500}
             />
           </div>
@@ -239,13 +288,17 @@ export default function NuevoProcesoPage() {
           <div>
             <label className={labelClass}>Exámenes a rendir *</label>
             <div className="space-y-2">
-              {EXAM_OPTIONS.map(opt => (
+              {EXAM_OPTIONS.map((opt) => (
                 <label
                   key={opt.id}
                   className={`flex items-start gap-3 px-4 py-3 rounded-lg border cursor-pointer transition-colors ${
                     examTypes.includes(opt.id)
-                      ? (isDarkMode ? 'border-indigo-500 bg-indigo-900/30' : 'border-indigo-400 bg-indigo-50')
-                      : (isDarkMode ? 'border-slate-600 hover:border-slate-500' : 'border-gray-200 hover:border-gray-300')
+                      ? isDarkMode
+                        ? 'border-indigo-500 bg-indigo-900/30'
+                        : 'border-indigo-400 bg-indigo-50'
+                      : isDarkMode
+                        ? 'border-slate-600 hover:border-slate-500'
+                        : 'border-gray-200 hover:border-gray-300'
                   }`}
                 >
                   <input
@@ -255,10 +308,14 @@ export default function NuevoProcesoPage() {
                     onChange={() => toggleExam(opt.id)}
                   />
                   <div>
-                    <span className={`text-sm font-medium block ${isDarkMode ? 'text-slate-200' : 'text-gray-800'}`}>
+                    <span
+                      className={`text-sm font-medium block ${isDarkMode ? 'text-slate-200' : 'text-gray-800'}`}
+                    >
                       {opt.label}
                     </span>
-                    <span className={`text-xs ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}>
+                    <span
+                      className={`text-xs ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}
+                    >
                       {opt.description}
                     </span>
                   </div>
@@ -269,12 +326,17 @@ export default function NuevoProcesoPage() {
 
           {/* Expires at */}
           <div>
-            <label className={labelClass}>Fecha de vencimiento <span className={isDarkMode ? 'text-slate-500' : 'text-gray-400'}>(opcional)</span></label>
+            <label className={labelClass}>
+              Fecha de vencimiento{' '}
+              <span className={isDarkMode ? 'text-slate-500' : 'text-gray-400'}>
+                (opcional)
+              </span>
+            </label>
             <input
               type="date"
               className={inputClass}
               value={expiresAt}
-              onChange={e => setExpiresAt(e.target.value)}
+              onChange={(e) => setExpiresAt(e.target.value)}
               min={new Date().toISOString().split('T')[0]}
             />
           </div>
@@ -283,7 +345,7 @@ export default function NuevoProcesoPage() {
           <div>
             <label className={labelClass}>Estado inicial</label>
             <div className="flex gap-3">
-              {(['active', 'draft'] as const).map(s => (
+              {(['active', 'draft'] as const).map((s) => (
                 <button
                   key={s}
                   type="button"
@@ -291,10 +353,14 @@ export default function NuevoProcesoPage() {
                   className={`flex-1 py-2.5 rounded-lg text-sm font-medium border transition-colors ${
                     status === s
                       ? 'border-indigo-500 bg-indigo-600 text-white'
-                      : (isDarkMode ? 'border-slate-600 text-slate-300 hover:border-slate-500' : 'border-gray-300 text-gray-700 hover:border-gray-400')
+                      : isDarkMode
+                        ? 'border-slate-600 text-slate-300 hover:border-slate-500'
+                        : 'border-gray-300 text-gray-700 hover:border-gray-400'
                   }`}
                 >
-                  {s === 'active' ? '✅ Activo (candidatos pueden rendir)' : '📝 Borrador (guardado, no visible)'}
+                  {s === 'active'
+                    ? '✅ Activo (candidatos pueden rendir)'
+                    : '📝 Borrador (guardado, no visible)'}
                 </button>
               ))}
             </div>
@@ -318,14 +384,15 @@ export default function NuevoProcesoPage() {
               type="button"
               onClick={() => router.push('/empresa/procesos')}
               className={`px-5 py-2.5 rounded-lg text-sm font-medium transition-colors ${
-                isDarkMode ? 'text-slate-300 hover:bg-slate-700' : 'text-gray-700 hover:bg-gray-100'
+                isDarkMode
+                  ? 'text-slate-300 hover:bg-slate-700'
+                  : 'text-gray-700 hover:bg-gray-100'
               }`}
             >
               Cancelar
             </button>
           </div>
         </form>
-
       </div>
     </div>
   );

--- a/apps/frontend/src/app/invitacion/[token]/page.tsx
+++ b/apps/frontend/src/app/invitacion/[token]/page.tsx
@@ -8,7 +8,22 @@ const EXAM_LABELS: Record<string, string> = {
   git: 'Git — Control de versiones',
   performance: 'Performance Testing',
   'api-testing-fundamentals': 'API Testing Fundamentals',
+  'api-banking': 'API Banking Challenge',
 };
+
+const EXAM_URLS: Record<string, string> = {
+  istqb: '/labs/istqb',
+  git: '/labs/git',
+  performance: '/labs/performance',
+  'api-testing-fundamentals': '/assessments/api-testing-fundamentals/start',
+  'api-banking': '/assessments/api-banking/start',
+};
+
+function examHref(examType: string, code: string) {
+  const base = EXAM_URLS[examType];
+  if (!base) return null;
+  return `${base}?code=${encodeURIComponent(code)}`;
+}
 
 type Props = { params: Promise<{ token: string }> };
 
@@ -143,15 +158,36 @@ export default async function InvitacionTokenPage({ params }: Props) {
                     <p className="text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-slate-400">
                       Evaluaciones a rendir
                     </p>
-                    {proceso.exam_types.map((et) => (
-                      <div
-                        key={et}
-                        className="flex items-center gap-2 px-3 py-2 rounded-lg bg-indigo-50 dark:bg-indigo-900/30 text-sm font-medium text-indigo-800 dark:text-indigo-200"
-                      >
-                        <span>📋</span>
-                        {EXAM_LABELS[et] ?? et}
-                      </div>
-                    ))}
+                    {proceso.exam_types.map((et) => {
+                      const href = examHref(et, proceso.code);
+                      const chip = (
+                        <>
+                          <span>📋</span>
+                          {EXAM_LABELS[et] ?? et}
+                        </>
+                      );
+                      return href ? (
+                        <Link
+                          key={et}
+                          href={href}
+                          className="flex items-center justify-between gap-2 px-3 py-2 rounded-lg bg-indigo-50 dark:bg-indigo-900/30 text-sm font-medium text-indigo-800 dark:text-indigo-200 hover:bg-indigo-100 dark:hover:bg-indigo-900/50 transition-colors"
+                        >
+                          <span className="flex items-center gap-2">
+                            {chip}
+                          </span>
+                          <span className="text-xs font-semibold">
+                            Rendir →
+                          </span>
+                        </Link>
+                      ) : (
+                        <div
+                          key={et}
+                          className="flex items-center gap-2 px-3 py-2 rounded-lg bg-indigo-50 dark:bg-indigo-900/30 text-sm font-medium text-indigo-800 dark:text-indigo-200"
+                        >
+                          {chip}
+                        </div>
+                      );
+                    })}
                   </div>
                 )}
 

--- a/apps/frontend/src/app/labs/page.tsx
+++ b/apps/frontend/src/app/labs/page.tsx
@@ -12,23 +12,6 @@ export default function LabsPage() {
   const { t } = useLanguage();
   const { user } = useSupabaseAuth();
 
-  const getToolPresentation = <
-    T extends { id: string; icon: string; description: string },
-  >(
-    tool: T
-  ) => {
-    if (tool.id === 'api-testing-fundamentals') {
-      return {
-        ...tool,
-        icon: 'API',
-        description:
-          'Assessment progresivo para validar conceptos de API, diseno de casos, analisis de respuestas y bug reporting',
-      };
-    }
-
-    return tool;
-  };
-
   const toolCategories = [
     {
       id: 'formacion',
@@ -69,14 +52,33 @@ export default function LabsPage() {
           featured: true,
           implementedDate: 'Nov 2025',
         },
+      ],
+    },
+    {
+      id: 'apis',
+      name: '🔌 APIs',
+      description:
+        'Evaluá tus habilidades de API testing: teoría y práctica con corrección automática',
+      tools: [
         {
           id: 'api-testing-fundamentals',
-          name: 'API Testing Fundamentals Challenge',
+          name: 'API Testing — Fundamentos (Examen teórico)',
           description:
-            'Assessment progresivo para validar conceptos de API, diseÃ±o de casos, anÃ¡lisis de respuestas y bug reporting',
-          icon: 'ðŸŒ',
+            'Conceptos de API, lectura de documentación, diseño de casos y análisis de respuestas en 5 niveles progresivos — auto-corregido, 100 pts',
+          icon: '🌐',
           color: 'from-emerald-500 to-teal-600',
           href: '/labs/api-testing-fundamentals',
+          featured: true,
+          implementedDate: 'Jun 2026',
+        },
+        {
+          id: 'api-banking-challenge',
+          name: 'API Banking — Challenge práctico',
+          description:
+            'Testeá una API bancaria simulada: encontrá 12 bugs intencionales, diseñá casos, reportá bugs y recibí un score automático de 100 pts',
+          icon: '🏦',
+          color: 'from-blue-500 to-indigo-600',
+          href: '/assessments/api-banking',
           featured: true,
           implementedDate: 'Jun 2026',
         },
@@ -109,17 +111,6 @@ export default function LabsPage() {
           href: '/labs/test-app/report',
           featured: true,
           implementedDate: 'Nov 2025',
-        },
-        {
-          id: 'api-banking-challenge',
-          name: 'QA API Challenge — Banking',
-          description:
-            'Encontrá 12 bugs intencionales en una API bancaria simulada. Diseñá casos de prueba, reportá bugs y recibí un score automático de 100 pts.',
-          icon: '🏦',
-          color: 'from-emerald-500 to-teal-600',
-          href: '/assessments/api-banking',
-          featured: true,
-          implementedDate: 'Jun 2026',
         },
       ],
     },
@@ -391,8 +382,6 @@ export default function LabsPage() {
               .filter((tool) => tool.featured)
               .slice(0, 3)
               .map((tool, index) => {
-                const presentation = getToolPresentation(tool);
-
                 return (
                   <Link
                     key={tool.id}
@@ -417,13 +406,13 @@ export default function LabsPage() {
                       </div>
                       <div className="flex-1">
                         <div className="flex items-center gap-2 mb-1">
-                          <span className="text-xl">{presentation.icon}</span>
+                          <span className="text-xl">{tool.icon}</span>
                           <h3
                             className={`font-bold ${
                               isDarkMode ? 'text-white' : 'text-brand-text'
                             }`}
                           >
-                            {presentation.name}
+                            {tool.name}
                           </h3>
                         </div>
                         <p
@@ -431,7 +420,7 @@ export default function LabsPage() {
                             isDarkMode ? 'text-slate-400' : 'text-brand-muted'
                           }`}
                         >
-                          {presentation.description}
+                          {tool.description}
                         </p>
                       </div>
                     </div>
@@ -466,8 +455,6 @@ export default function LabsPage() {
               {/* Tools Grid */}
               <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
                 {category.tools.map((tool) => {
-                  const presentation = getToolPresentation(tool);
-
                   return (
                     <Link
                       key={tool.id}
@@ -481,7 +468,7 @@ export default function LabsPage() {
                       >
                         {/* Badges Container */}
                         <div className="flex items-start justify-between gap-2 mb-3">
-                          <div className="text-3xl">{presentation.icon}</div>
+                          <div className="text-3xl">{tool.icon}</div>
                           <div className="flex flex-col items-end gap-2">
                             {tool.featured && (
                               <span
@@ -501,11 +488,9 @@ export default function LabsPage() {
                             )}
                           </div>
                         </div>
-                        <h3 className="text-xl font-bold mb-2">
-                          {presentation.name}
-                        </h3>
+                        <h3 className="text-xl font-bold mb-2">{tool.name}</h3>
                         <p className="text-white/90 text-sm">
-                          {presentation.description}
+                          {tool.description}
                         </p>
                       </div>
                       <div className="p-6 shrink-0">

--- a/apps/frontend/src/app/ranking/page.tsx
+++ b/apps/frontend/src/app/ranking/page.tsx
@@ -73,6 +73,18 @@ const EXAM_TABS = [
     color: 'from-emerald-500 to-teal-600',
   },
   {
+    key: 'api-testing-fundamentals',
+    label: 'API Testing',
+    emoji: '🌐',
+    color: 'from-cyan-500 to-sky-600',
+  },
+  {
+    key: 'api-banking',
+    label: 'API Banking',
+    emoji: '🏦',
+    color: 'from-blue-500 to-indigo-600',
+  },
+  {
     key: 'xp',
     label: 'XP Comunidad',
     emoji: '🚀',
@@ -81,6 +93,14 @@ const EXAM_TABS = [
 ] as const;
 
 type TabKey = (typeof EXAM_TABS)[number]['key'];
+
+const EXAM_TAB_URLS: Record<string, string> = {
+  git: '/labs/git',
+  istqb: '/labs/istqb',
+  performance: '/labs/performance',
+  'api-testing-fundamentals': '/assessments/api-testing-fundamentals',
+  'api-banking': '/assessments/api-banking',
+};
 
 const MEDAL = ['🥇', '🥈', '🥉'];
 
@@ -194,7 +214,13 @@ function LevelBar({
 
 // ── XP Comunidad tab ──────────────────────────────────────────────────────────
 
-function XpComunidadTab({ isDarkMode, currentUserName }: { isDarkMode: boolean; currentUserName: string | null }) {
+function XpComunidadTab({
+  isDarkMode,
+  currentUserName,
+}: {
+  isDarkMode: boolean;
+  currentUserName: string | null;
+}) {
   const [data, setData] = useState<XpRankingResponse | null>(null);
   const [loading, setLoading] = useState(true);
   const [page, setPage] = useState(1);
@@ -255,26 +281,53 @@ function XpComunidadTab({ isDarkMode, currentUserName }: { isDarkMode: boolean; 
   return (
     <div className="space-y-5">
       {/* Cómo ganar XP */}
-      <div className={`rounded-2xl border ${isDarkMode ? 'bg-slate-800 border-slate-700' : 'bg-white border-gray-200 shadow-sm'}`}>
+      <div
+        className={`rounded-2xl border ${isDarkMode ? 'bg-slate-800 border-slate-700' : 'bg-white border-gray-200 shadow-sm'}`}
+      >
         <button
-          onClick={() => setShowHowTo(v => !v)}
+          onClick={() => setShowHowTo((v) => !v)}
           className={`w-full flex items-center justify-between px-5 py-3 text-sm font-semibold ${isDarkMode ? 'text-slate-200' : 'text-gray-700'}`}
         >
           <span>💡 ¿Cómo ganar XP?</span>
           <span>{showHowTo ? '▲' : '▼'}</span>
         </button>
         {showHowTo && (
-          <div className={`px-5 pb-4 space-y-2 border-t ${isDarkMode ? 'border-slate-700' : 'border-gray-100'}`}>
+          <div
+            className={`px-5 pb-4 space-y-2 border-t ${isDarkMode ? 'border-slate-700' : 'border-gray-100'}`}
+          >
             {[
-              { emoji: '📋', action: 'Completar simulacro ISTQB (aprobar)', xp: '+100 XP' },
-              { emoji: '⚡', action: 'Completar examen Performance (aprobar)', xp: '+80 XP' },
-              { emoji: '🌿', action: 'Completar examen GIT (aprobar)', xp: '+60 XP' },
-              { emoji: '🔗', action: 'Generar casos All Pairs (20+ pares)', xp: '+20 XP' },
+              {
+                emoji: '📋',
+                action: 'Completar simulacro ISTQB (aprobar)',
+                xp: '+100 XP',
+              },
+              {
+                emoji: '⚡',
+                action: 'Completar examen Performance (aprobar)',
+                xp: '+80 XP',
+              },
+              {
+                emoji: '🌿',
+                action: 'Completar examen GIT (aprobar)',
+                xp: '+60 XP',
+              },
+              {
+                emoji: '🔗',
+                action: 'Generar casos All Pairs (20+ pares)',
+                xp: '+20 XP',
+              },
               { emoji: '💬', action: 'Crear un post en el foro', xp: '+10 XP' },
               { emoji: '🌅', action: 'Check-in diario', xp: '+5 XP' },
             ].map(({ emoji, action, xp }) => (
-              <div key={action} className="flex items-center justify-between text-sm pt-2">
-                <span className={isDarkMode ? 'text-slate-300' : 'text-gray-600'}>{emoji} {action}</span>
+              <div
+                key={action}
+                className="flex items-center justify-between text-sm pt-2"
+              >
+                <span
+                  className={isDarkMode ? 'text-slate-300' : 'text-gray-600'}
+                >
+                  {emoji} {action}
+                </span>
                 <span className="font-bold text-purple-500">{xp}</span>
               </div>
             ))}
@@ -400,82 +453,85 @@ function XpComunidadTab({ isDarkMode, currentUserName }: { isDarkMode: boolean; 
 
         {/* Filas */}
         {(isFirstPage ? rest : data.data).map((entry, i, arr) => {
-          const isCurrentUser = currentUserName !== null && entry.displayName === currentUserName;
+          const isCurrentUser =
+            currentUserName !== null && entry.displayName === currentUserName;
           return (
-          <div
-            key={entry.position}
-            className={`flex items-center gap-3 px-5 py-4 ${
-              i < arr.length - 1
-                ? isDarkMode
-                  ? 'border-b border-slate-700'
-                  : 'border-b border-gray-100'
-                : ''
-            } ${isCurrentUser ? 'border-l-4 border-purple-500' : ''} ${isDarkMode ? 'hover:bg-slate-700/40' : 'hover:bg-gray-50'} transition-colors`}
-          >
-            {/* Posición */}
-            <span
-              className={`w-8 text-center text-sm font-bold shrink-0 ${isDarkMode ? 'text-slate-400' : 'text-gray-400'}`}
+            <div
+              key={entry.position}
+              className={`flex items-center gap-3 px-5 py-4 ${
+                i < arr.length - 1
+                  ? isDarkMode
+                    ? 'border-b border-slate-700'
+                    : 'border-b border-gray-100'
+                  : ''
+              } ${isCurrentUser ? 'border-l-4 border-purple-500' : ''} ${isDarkMode ? 'hover:bg-slate-700/40' : 'hover:bg-gray-50'} transition-colors`}
             >
-              {entry.position}
-            </span>
-
-            {/* Avatar + badge */}
-            <div className="relative shrink-0">
-              <MiniAvatar
-                name={entry.displayName}
-                avatarUrl={entry.avatarUrl}
-              />
-              {entry.mainBadge && (
-                <span className="absolute -top-1 -right-1 text-sm leading-none">
-                  {entry.mainBadge}
-                </span>
-              )}
-            </div>
-
-            {/* Info */}
-            <div className="flex-1 min-w-0 space-y-1">
-              <p
-                className={`text-sm font-semibold truncate flex items-center gap-1.5 ${isDarkMode ? 'text-slate-200' : 'text-gray-800'}`}
+              {/* Posición */}
+              <span
+                className={`w-8 text-center text-sm font-bold shrink-0 ${isDarkMode ? 'text-slate-400' : 'text-gray-400'}`}
               >
-                {isCurrentUser && <span>🫵</span>}
-                {entry.displayName}
-                {isCurrentUser && (
-                  <span className="ml-1 px-1.5 py-0.5 rounded-full text-xs font-bold bg-purple-500 text-white shrink-0">Tú</span>
+                {entry.position}
+              </span>
+
+              {/* Avatar + badge */}
+              <div className="relative shrink-0">
+                <MiniAvatar
+                  name={entry.displayName}
+                  avatarUrl={entry.avatarUrl}
+                />
+                {entry.mainBadge && (
+                  <span className="absolute -top-1 -right-1 text-sm leading-none">
+                    {entry.mainBadge}
+                  </span>
                 )}
-              </p>
-              <LevelBar
-                level={entry.level}
-                totalXp={entry.totalXp}
-                isDarkMode={isDarkMode}
-              />
-              <p
-                className={`text-xs ${isDarkMode ? 'text-slate-500' : 'text-gray-400'}`}
-              >
-                {formatRelative(entry.lastActivityAt)}
-              </p>
-            </div>
+              </div>
 
-            {/* XP + stats */}
-            <div className="text-right shrink-0 space-y-0.5">
-              <p
-                className={`text-sm font-extrabold ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
-              >
-                {entry.totalXp.toLocaleString()} XP
-              </p>
-              <p
-                className={`text-xs ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}
-              >
-                Nv. {entry.level}
-              </p>
-              {entry.achievementCount > 0 && (
+              {/* Info */}
+              <div className="flex-1 min-w-0 space-y-1">
+                <p
+                  className={`text-sm font-semibold truncate flex items-center gap-1.5 ${isDarkMode ? 'text-slate-200' : 'text-gray-800'}`}
+                >
+                  {isCurrentUser && <span>🫵</span>}
+                  {entry.displayName}
+                  {isCurrentUser && (
+                    <span className="ml-1 px-1.5 py-0.5 rounded-full text-xs font-bold bg-purple-500 text-white shrink-0">
+                      Tú
+                    </span>
+                  )}
+                </p>
+                <LevelBar
+                  level={entry.level}
+                  totalXp={entry.totalXp}
+                  isDarkMode={isDarkMode}
+                />
                 <p
                   className={`text-xs ${isDarkMode ? 'text-slate-500' : 'text-gray-400'}`}
                 >
-                  🏅 {entry.achievementCount}
+                  {formatRelative(entry.lastActivityAt)}
                 </p>
-              )}
+              </div>
+
+              {/* XP + stats */}
+              <div className="text-right shrink-0 space-y-0.5">
+                <p
+                  className={`text-sm font-extrabold ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
+                >
+                  {entry.totalXp.toLocaleString()} XP
+                </p>
+                <p
+                  className={`text-xs ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}
+                >
+                  Nv. {entry.level}
+                </p>
+                {entry.achievementCount > 0 && (
+                  <p
+                    className={`text-xs ${isDarkMode ? 'text-slate-500' : 'text-gray-400'}`}
+                  >
+                    🏅 {entry.achievementCount}
+                  </p>
+                )}
+              </div>
             </div>
-          </div>
           );
         })}
       </div>
@@ -725,11 +781,15 @@ export default function RankingPage() {
     git: [],
     istqb: [],
     performance: [],
+    'api-testing-fundamentals': [],
+    'api-banking': [],
   });
   const [examLoading, setExamLoading] = useState<Record<string, boolean>>({
     git: true,
     istqb: true,
     performance: true,
+    'api-testing-fundamentals': true,
+    'api-banking': true,
   });
   const [showWelcome, setShowWelcome] = useState(false);
 
@@ -745,7 +805,15 @@ export default function RankingPage() {
   }, [isWelcome, router]);
 
   useEffect(() => {
-    (['git', 'istqb', 'performance'] as const).forEach((key) => {
+    (
+      [
+        'git',
+        'istqb',
+        'performance',
+        'api-testing-fundamentals',
+        'api-banking',
+      ] as const
+    ).forEach((key) => {
       getLeaderboardAction(key, 20)
         .then((res) => {
           setExamData((prev) => ({
@@ -857,7 +925,14 @@ export default function RankingPage() {
         {isReportes ? (
           <ReportadoresTab isDarkMode={isDarkMode} />
         ) : isXp ? (
-          <XpComunidadTab isDarkMode={isDarkMode} currentUserName={user?.user_metadata?.full_name || user?.user_metadata?.display_name || null} />
+          <XpComunidadTab
+            isDarkMode={isDarkMode}
+            currentUserName={
+              user?.user_metadata?.full_name ||
+              user?.user_metadata?.display_name ||
+              null
+            }
+          />
         ) : isLoading ? (
           <div className="flex justify-center py-16">
             <div className="animate-spin rounded-full h-10 w-10 border-t-2 border-indigo-500" />
@@ -878,13 +953,7 @@ export default function RankingPage() {
               ¡Sé el primero en completar el examen y aparecer acá!
             </p>
             <a
-              href={
-                activeTab === 'git'
-                  ? '/labs/git'
-                  : activeTab === 'istqb'
-                    ? '/labs/istqb'
-                    : '/labs/performance'
-              }
+              href={EXAM_TAB_URLS[activeTab] ?? '/labs'}
               className="inline-block mt-4 px-5 py-2 bg-indigo-600 hover:bg-indigo-700 text-white text-sm font-semibold rounded-lg transition-colors"
             >
               {tab.emoji} Ir al examen
@@ -919,7 +988,8 @@ export default function RankingPage() {
                         <p
                           className={`text-xs ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}
                         >
-                          {entry.best_score}/{entry.max_possible_score ?? entry.total_questions}
+                          {entry.best_score}/
+                          {entry.max_possible_score ?? entry.total_questions}
                         </p>
                         <div
                           className={`w-full rounded-t-lg flex items-center justify-center text-2xl ${heights[podiumRank]} ${
@@ -986,7 +1056,8 @@ export default function RankingPage() {
                       <p
                         className={`text-sm font-bold ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
                       >
-                        {entry.best_score}/{entry.max_possible_score ?? entry.total_questions}
+                        {entry.best_score}/
+                        {entry.max_possible_score ?? entry.total_questions}
                       </p>
                       <p
                         className={`text-xs ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}
@@ -1012,23 +1083,24 @@ export default function RankingPage() {
               </div>
             )}
 
-            <div className={`rounded-2xl p-4 flex items-center justify-between gap-4 ${isDarkMode ? 'bg-amber-900/20 border border-amber-700/50' : 'bg-amber-50 border border-amber-200'}`}>
+            <div
+              className={`rounded-2xl p-4 flex items-center justify-between gap-4 ${isDarkMode ? 'bg-amber-900/20 border border-amber-700/50' : 'bg-amber-50 border border-amber-200'}`}
+            >
               <div>
-                <p className={`text-sm font-semibold ${isDarkMode ? 'text-amber-200' : 'text-amber-900'}`}>
+                <p
+                  className={`text-sm font-semibold ${isDarkMode ? 'text-amber-200' : 'text-amber-900'}`}
+                >
                   ¿Querés mejorar tu posición?
                 </p>
-                <p className={`text-xs mt-0.5 ${isDarkMode ? 'text-amber-400/80' : 'text-amber-700'}`}>
-                  Practicá con Modo Entrenamiento antes de rendir el examen oficial.
+                <p
+                  className={`text-xs mt-0.5 ${isDarkMode ? 'text-amber-400/80' : 'text-amber-700'}`}
+                >
+                  Practicá con Modo Entrenamiento antes de rendir el examen
+                  oficial.
                 </p>
               </div>
               <a
-                href={
-                  activeTab === 'git'
-                    ? '/labs/git'
-                    : activeTab === 'istqb'
-                      ? '/labs/istqb'
-                      : '/labs/performance'
-                }
+                href={EXAM_TAB_URLS[activeTab] ?? '/labs'}
                 className="shrink-0 px-4 py-2 bg-amber-600 hover:bg-amber-700 text-white text-xs font-semibold rounded-lg transition-colors"
               >
                 Practicar →

--- a/apps/frontend/src/lib/gamification/grant-xp.ts
+++ b/apps/frontend/src/lib/gamification/grant-xp.ts
@@ -1,0 +1,138 @@
+import { createAdminClient } from '@/lib/supabase/admin';
+import { calculateXpLevel } from '@/app/assessments/api-testing-fundamentals/lib/gamification';
+
+export type XpRuleDefinition = {
+  eventType: string;
+  xpAmount: number;
+  description: string;
+  dailyLimit: number | null;
+};
+
+type XpRuleRow = {
+  id: string | number;
+  event_type: string;
+  xp_amount: number;
+  description: string;
+  daily_limit: number | null;
+  is_active: boolean;
+};
+
+type UserXpRow = {
+  id: string;
+  user_id: string;
+  total_xp: number;
+  level: number;
+  current_streak: number | null;
+  longest_streak: number | null;
+};
+
+export async function ensureXpRules(rules: XpRuleDefinition[]) {
+  const admin = createAdminClient();
+
+  const payload = rules.map((rule) => ({
+    event_type: rule.eventType,
+    xp_amount: rule.xpAmount,
+    description: rule.description,
+    daily_limit: rule.dailyLimit,
+    is_active: true,
+  }));
+
+  const { error } = await admin
+    .from('xp_rules')
+    .upsert(payload, { onConflict: 'event_type' });
+
+  if (error) {
+    throw new Error(error.message);
+  }
+}
+
+export async function grantGamificationXpEvent(input: {
+  userId: string;
+  eventType: string;
+  source: string;
+  sourceId: string;
+  metadata: Record<string, unknown>;
+}) {
+  const admin = createAdminClient();
+  const deduplicationKey = `${input.eventType}:${input.sourceId}`;
+
+  const [
+    { data: rule, error: ruleError },
+    { data: existing, error: existingError },
+  ] = await Promise.all([
+    admin
+      .from('xp_rules')
+      .select('id, event_type, xp_amount, description, daily_limit, is_active')
+      .eq('event_type', input.eventType)
+      .eq('is_active', true)
+      .maybeSingle<XpRuleRow>(),
+    admin
+      .from('xp_history')
+      .select('id')
+      .eq('user_id', input.userId)
+      .eq('deduplication_key', deduplicationKey)
+      .maybeSingle(),
+  ]);
+
+  if (ruleError) throw new Error(ruleError.message);
+  if (existingError) throw new Error(existingError.message);
+  if (!rule || existing) return;
+
+  if (rule.daily_limit !== null && rule.daily_limit !== undefined) {
+    const todayStart = new Date();
+    todayStart.setHours(0, 0, 0, 0);
+    const tomorrowStart = new Date(todayStart);
+    tomorrowStart.setDate(tomorrowStart.getDate() + 1);
+
+    const { count, error: countError } = await admin
+      .from('xp_history')
+      .select('id', { count: 'exact', head: true })
+      .eq('user_id', input.userId)
+      .eq('event_type', input.eventType)
+      .gte('created_at', todayStart.toISOString())
+      .lt('created_at', tomorrowStart.toISOString());
+
+    if (countError) throw new Error(countError.message);
+    if ((count ?? 0) >= rule.daily_limit) return;
+  }
+
+  const { data: currentXp, error: currentXpError } = await admin
+    .from('user_xp')
+    .select('id, user_id, total_xp, level, current_streak, longest_streak')
+    .eq('user_id', input.userId)
+    .maybeSingle<UserXpRow>();
+
+  if (currentXpError) throw new Error(currentXpError.message);
+
+  const nextTotalXp = (currentXp?.total_xp ?? 0) + rule.xp_amount;
+  const nextLevel = calculateXpLevel(nextTotalXp);
+  const now = new Date().toISOString();
+
+  const { error: historyError } = await admin.from('xp_history').insert({
+    user_id: input.userId,
+    xp_rule_id: rule.id,
+    event_type: input.eventType,
+    xp_amount: rule.xp_amount,
+    source: input.source,
+    source_id: input.sourceId,
+    deduplication_key: deduplicationKey,
+    metadata: input.metadata,
+  });
+
+  if (historyError) throw new Error(historyError.message);
+
+  const { error: userXpError } = await admin.from('user_xp').upsert(
+    {
+      user_id: input.userId,
+      total_xp: nextTotalXp,
+      level: nextLevel,
+      current_streak: currentXp?.current_streak ?? 0,
+      longest_streak: currentXp?.longest_streak ?? 0,
+      last_activity_at: now,
+      updated_at: now,
+    },
+    { onConflict: 'user_id' }
+  );
+
+  if (userXpError) throw new Error(userXpError.message);
+}

--- a/supabase/migrations/20260611_000000_api_exams_ranking_and_codes.sql
+++ b/supabase/migrations/20260611_000000_api_exams_ranking_and_codes.sql
@@ -1,0 +1,46 @@
+-- Habilita los exámenes de API en el ecosistema de resultados/ranking/empresa:
+-- 1. Amplía el CHECK de exam_results.exam_type (hoy solo permite git/istqb/performance,
+--    por lo que los inserts de api-testing-fundamentals fallaban en silencio).
+-- 2. Agrega process_code a qac_attempts para rendir API Banking con código de empresa.
+-- 3. Reglas XP para API Banking Challenge (espejo de api-testing-fundamentals).
+
+-- 1. exam_results.exam_type
+ALTER TABLE public.exam_results
+  DROP CONSTRAINT IF EXISTS exam_results_exam_type_check;
+
+ALTER TABLE public.exam_results
+  ADD CONSTRAINT exam_results_exam_type_check
+  CHECK (
+    exam_type = ANY (
+      ARRAY[
+        'git'::text,
+        'istqb'::text,
+        'performance'::text,
+        'test-app'::text,
+        'api-testing-fundamentals'::text,
+        'api-banking'::text
+      ]
+    )
+  );
+
+-- 2. qac_attempts.process_code
+ALTER TABLE public.qac_attempts
+  ADD COLUMN IF NOT EXISTS process_code TEXT
+    REFERENCES public.hiring_processes(code) ON DELETE SET NULL;
+
+CREATE INDEX IF NOT EXISTS idx_qac_attempts_process_code
+  ON public.qac_attempts (process_code)
+  WHERE process_code IS NOT NULL;
+
+-- 3. Reglas XP para API Banking
+INSERT INTO public.xp_rules (event_type, xp_amount, description, daily_limit, is_active)
+VALUES
+  ('API_BANKING_COMPLETED', 70, 'Completar el API Banking Challenge', 3, true),
+  ('API_BANKING_PASSED', 120, 'Aprobar el API Banking Challenge (score >= 60)', 3, true),
+  ('API_BANKING_HIGH_SCORE', 160, 'Score sobresaliente en API Banking Challenge (>= 90)', 3, true)
+ON CONFLICT (event_type) DO UPDATE SET
+  xp_amount = EXCLUDED.xp_amount,
+  description = EXCLUDED.description,
+  daily_limit = EXCLUDED.daily_limit,
+  is_active = EXCLUDED.is_active,
+  updated_at = now();


### PR DESCRIPTION
- Fix crítico: amplía CHECK constraint de exam_results.exam_type para incluir api-testing-fundamentals y api-banking (fallaban en silencio)
- Fix performance: seed de api-testing-fundamentals solo corre si la versión en metadata difiere; memo por instancia elimina round trips extra
- api-banking: agrega ProcessCodeInput, validación server-side de código, guarda process_code en qac_attempts, escribe exam_results y otorga XP (70/120/160 completar/aprobar/sobresaliente) al submit
- api-testing-fundamentals: prefill ?code= en start page, regresión de exam_results ahora funciona gracias a migración DB
- Empresa: ambos exámenes de API seleccionables en nuevo proceso; invitaciones con botón "Rendir →" directo al examen con código
- Ranking: nuevos tabs API Testing 🌐 y API Banking 🏦
- Labs: nueva categoría APIs con ambos exámenes, nombres que distinguen teoría vs práctica; corrige mojibake histórico en la página
- Refactor: helper compartido grant-xp.ts para XP events reutilizable