### PR TITLE
feat(frontend): show lab progress and ISTQB comparisons

### DIFF
--- a/apps/frontend/src/actions/exams.ts
+++ b/apps/frontend/src/actions/exams.ts
@@ -1,6 +1,7 @@
 'use server';
 
 import { createClient } from '@/lib/supabase/server';
+import { createAdminClient } from '@/lib/supabase/admin';
 
 interface SaveExamResultPayload {
   exam_type:
@@ -86,13 +87,16 @@ export async function getLeaderboardAction(
 export async function getXpRankingAction(page = 1, limit = 20) {
   const supabase = createClient();
   const offset = (page - 1) * limit;
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
 
   // ranking_candidatos view excludes audience='empresa' at DB level
   // and includes achievement_count via subquery in the view
   const { data, error, count } = await supabase
     .from('ranking_candidatos')
     .select(
-      'total_xp, level, current_streak, last_activity_at, display_name, avatar_url, achievement_count, main_badge',
+      'user_id, total_xp, level, current_streak, last_activity_at, display_name, avatar_url, achievement_count, main_badge',
       { count: 'exact' }
     )
     .order('total_xp', { ascending: false })
@@ -110,6 +114,7 @@ export async function getXpRankingAction(page = 1, limit = 20) {
     achievementCount: row.achievement_count ?? 0,
     lastActivityAt: row.last_activity_at,
     mainBadge: row.main_badge ?? null,
+    isCurrentUser: Boolean(user?.id && row.user_id === user.id),
   }));
 
   return {
@@ -131,7 +136,7 @@ export async function getExamResultsAction() {
   const { data, error } = await supabase
     .from('exam_results')
     .select(
-      'id, exam_type, exam_mode, score, total_questions, passing_score, passed, percentage, time_spent, model, language, created_at'
+      'id, exam_type, exam_mode, score, total_questions, max_possible_score, passing_score, passed, percentage, time_spent, model, language, created_at'
     )
     .eq('user_id', user.id)
     .order('created_at', { ascending: false })
@@ -139,6 +144,98 @@ export async function getExamResultsAction() {
 
   if (error) return { error: error.message, data: null };
   return { data };
+}
+
+type LearningObjectiveRow = {
+  learning_objectives: unknown;
+};
+
+type LatamLearningObjectiveAggregate = {
+  totalPercentage: number;
+  sampleSize: number;
+};
+
+function normalizeLearningObjectiveRows(
+  value: unknown
+): Array<{ learningObjective: string; percentage: number }> {
+  if (!value) return [];
+
+  const rows = Array.isArray(value)
+    ? value
+    : typeof value === 'object'
+      ? Object.entries(value as Record<string, unknown>).map(
+          ([learningObjective, item]) => ({
+            learningObjective,
+            ...(typeof item === 'object' && item !== null ? item : {}),
+          })
+        )
+      : [];
+
+  return rows
+    .map((item) => {
+      if (!item || typeof item !== 'object') return null;
+      const row = item as Record<string, unknown>;
+      const learningObjective =
+        typeof row.learningObjective === 'string'
+          ? row.learningObjective
+          : typeof row.learning_objective === 'string'
+            ? row.learning_objective
+            : null;
+      const percentage =
+        typeof row.percentage === 'number'
+          ? row.percentage
+          : typeof row.percentage === 'string'
+            ? Number(row.percentage)
+            : Number.NaN;
+
+      if (!learningObjective || Number.isNaN(percentage)) return null;
+      return { learningObjective, percentage };
+    })
+    .filter(
+      (item): item is { learningObjective: string; percentage: number } =>
+        item !== null
+    );
+}
+
+export async function getIstqbLatamComparisonAction() {
+  const supabase = createAdminClient();
+  const { data, error } = await supabase
+    .from('exam_results')
+    .select('learning_objectives')
+    .eq('exam_type', 'istqb')
+    .eq('exam_mode', 'exam')
+    .not('learning_objectives', 'is', null)
+    .limit(500);
+
+  if (error) return { error: error.message, data: null };
+
+  const aggregates = new Map<string, LatamLearningObjectiveAggregate>();
+
+  for (const result of (data ?? []) as LearningObjectiveRow[]) {
+    for (const row of normalizeLearningObjectiveRows(
+      result.learning_objectives
+    )) {
+      const current = aggregates.get(row.learningObjective) ?? {
+        totalPercentage: 0,
+        sampleSize: 0,
+      };
+      current.totalPercentage += row.percentage;
+      current.sampleSize += 1;
+      aggregates.set(row.learningObjective, current);
+    }
+  }
+
+  const comparison = Array.from(aggregates.entries())
+    .map(([learningObjective, aggregate]) => ({
+      learningObjective,
+      averagePercentage: Math.round(
+        aggregate.totalPercentage / aggregate.sampleSize
+      ),
+      sampleSize: aggregate.sampleSize,
+    }))
+    .sort((a, b) => a.learningObjective.localeCompare(b.learningObjective));
+
+  return { data: comparison };
 }
 
 export async function getMyXpProfileAction() {

--- a/apps/frontend/src/app/labs/istqb/components/ResultsScreen.tsx
+++ b/apps/frontend/src/app/labs/istqb/components/ResultsScreen.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useTheme } from '@/contexts/ThemeContext';
+import { getIstqbLatamComparisonAction } from '@/actions/exams';
 import type { ExamResult } from '../types';
 import { exportToCSV, downloadCSV, formatTime } from '../utils';
 import { generateExamPDF } from '../utils/pdfExport';
@@ -14,6 +15,12 @@ interface ResultsScreenProps {
   language: 'es' | 'en';
 }
 
+interface LatamComparison {
+  learningObjective: string;
+  averagePercentage: number;
+  sampleSize: number;
+}
+
 export default function ResultsScreen({
   result,
   onReset,
@@ -21,8 +28,14 @@ export default function ResultsScreen({
   language,
 }: ResultsScreenProps) {
   const { isDarkMode } = useTheme();
-  const [activeTab, setActiveTab] = useState<'summary' | 'learning-objectives' | 'details'>('summary');
-  const [expandedExplanations, setExpandedExplanations] = useState<Set<number>>(new Set());
+  const [activeTab, setActiveTab] = useState<
+    'summary' | 'learning-objectives' | 'details'
+  >('summary');
+  const [expandedExplanations, setExpandedExplanations] = useState<Set<number>>(
+    new Set()
+  );
+  const [latamComparison, setLatamComparison] = useState<LatamComparison[]>([]);
+  const [latamLoading, setLatamLoading] = useState(true);
   const toggleExplanation = (questionId: number) => {
     setExpandedExplanations((prev) => {
       const next = new Set(prev);
@@ -31,7 +44,27 @@ export default function ResultsScreen({
       return next;
     });
   };
-  useSubmitResults(result, mode);
+  const { saveError } = useSubmitResults(result, mode);
+
+  useEffect(() => {
+    let active = true;
+
+    getIstqbLatamComparisonAction()
+      .then((res) => {
+        if (!active) return;
+        setLatamComparison((res.data as LatamComparison[] | null) ?? []);
+      })
+      .catch(() => {
+        if (active) setLatamComparison([]);
+      })
+      .finally(() => {
+        if (active) setLatamLoading(false);
+      });
+
+    return () => {
+      active = false;
+    };
+  }, []);
 
   const t = {
     es: {
@@ -61,9 +94,19 @@ export default function ResultsScreen({
       strengths: 'Fortalezas Identificadas:',
       noStrengths: 'Ninguna área con desempeño sobresaliente identificada.',
       improvements: 'Áreas de Mejora:',
-      noImprovements: '¡Excelente! No se identificaron áreas débiles significativas.',
+      noImprovements:
+        '¡Excelente! No se identificaron áreas débiles significativas.',
       loAnalysis: 'Análisis por Learning Objective',
-      loDescription: 'Desempeño en cada objetivo de aprendizaje del syllabus ISTQB CTFL v4.0',
+      loDescription:
+        'Desempeño en cada objetivo de aprendizaje del syllabus ISTQB CTFL v4.0',
+      communityComparison: 'Comparativa LATAM',
+      communityLoading: 'Cargando comparativa...',
+      communityNoData:
+        'Aún no hay datos comunitarios suficientes para comparar este resultado.',
+      yourResult: 'Tu resultado',
+      latamAverage: 'Promedio LATAM',
+      sample: 'muestra',
+      saveErrorTitle: 'No pudimos guardar tu resultado',
       question: 'Pregunta',
       yourAnswer: 'Tu Respuesta:',
       correctAnswer: 'Respuesta Correcta:',
@@ -102,7 +145,16 @@ export default function ResultsScreen({
       improvements: 'Areas for Improvement:',
       noImprovements: 'Excellent! No significant weak areas identified.',
       loAnalysis: 'Analysis by Learning Objective',
-      loDescription: 'Performance in each learning objective of the ISTQB CTFL v4.0 syllabus',
+      loDescription:
+        'Performance in each learning objective of the ISTQB CTFL v4.0 syllabus',
+      communityComparison: 'LATAM comparison',
+      communityLoading: 'Loading comparison...',
+      communityNoData:
+        'There is not enough community data yet to compare this result.',
+      yourResult: 'Your result',
+      latamAverage: 'LATAM average',
+      sample: 'sample',
+      saveErrorTitle: 'We could not save your result',
       question: 'Question',
       yourAnswer: 'Your Answer:',
       correctAnswer: 'Correct Answer:',
@@ -124,44 +176,65 @@ export default function ResultsScreen({
   const handleExportPDF = () => {
     generateExamPDF(result, mode);
   };
+  const latamByLearningObjective = new Map(
+    latamComparison.map((item) => [item.learningObjective, item])
+  );
+  const hasLatamComparison = result.learningObjectiveAnalysis.some((lo) =>
+    latamByLearningObjective.has(lo.learningObjective)
+  );
 
   return (
-    <div className={`min-h-screen py-8 transition-colors ${isDarkMode ? 'bg-slate-900' : 'bg-gray-50'}`}>
+    <div
+      className={`min-h-screen py-8 transition-colors ${isDarkMode ? 'bg-slate-900' : 'bg-gray-50'}`}
+    >
       <div className="container mx-auto px-4 max-w-6xl">
         <div className="mb-8 text-center">
-          <h1 className={`text-4xl font-bold mb-2 ${isDarkMode ? 'text-white' : 'text-gray-900'}`}>
+          <h1
+            className={`text-4xl font-bold mb-2 ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
+          >
             {text.title}
           </h1>
-          <p className={isDarkMode ? 'text-slate-400' : 'text-gray-600'}>{text.subtitle}</p>
+          <p className={isDarkMode ? 'text-slate-400' : 'text-gray-600'}>
+            {text.subtitle}
+          </p>
         </div>
 
-        <div className={`rounded-lg shadow-lg mb-6 ${isDarkMode ? 'bg-slate-800' : 'bg-white'}`}>
+        <div
+          className={`rounded-lg shadow-lg mb-6 ${isDarkMode ? 'bg-slate-800' : 'bg-white'}`}
+        >
           <div className="p-6 border-b border-gray-200 dark:border-gray-700">
             <div className="flex flex-col md:flex-row items-start md:items-center justify-between gap-4">
               <div>
-                <h2 className={`text-2xl font-bold ${isDarkMode ? 'text-white' : 'text-gray-900'}`}>
+                <h2
+                  className={`text-2xl font-bold ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
+                >
                   {result.participantName}
                 </h2>
-                <p className={`text-sm ${isDarkMode ? 'text-slate-400' : 'text-gray-600'}`}>
-                  {text.modeLabel}: {mode === 'exam' ? text.modeExam : text.modeTraining}
+                <p
+                  className={`text-sm ${isDarkMode ? 'text-slate-400' : 'text-gray-600'}`}
+                >
+                  {text.modeLabel}:{' '}
+                  {mode === 'exam' ? text.modeExam : text.modeTraining}
                 </p>
               </div>
               <div className="flex gap-2 w-full md:w-auto">
                 <button
                   onClick={handleExportCSV}
-                  className={`px-4 py-2 rounded-lg font-medium transition-colors flex-1 md:flex-none ${isDarkMode
-                    ? 'bg-slate-700 hover:bg-slate-600 text-white border border-slate-600'
-                    : 'bg-white hover:bg-gray-50 text-gray-900 border border-gray-300'
-                    }`}
+                  className={`px-4 py-2 rounded-lg font-medium transition-colors flex-1 md:flex-none ${
+                    isDarkMode
+                      ? 'bg-slate-700 hover:bg-slate-600 text-white border border-slate-600'
+                      : 'bg-white hover:bg-gray-50 text-gray-900 border border-gray-300'
+                  }`}
                 >
                   {text.exportCSV}
                 </button>
                 <button
                   onClick={handleExportPDF}
-                  className={`px-4 py-2 rounded-lg font-medium transition-colors flex-1 md:flex-none ${isDarkMode
-                    ? 'bg-red-700 hover:bg-red-600 text-white border border-red-600'
-                    : 'bg-red-600 hover:bg-red-700 text-white border border-red-700'
-                    }`}
+                  className={`px-4 py-2 rounded-lg font-medium transition-colors flex-1 md:flex-none ${
+                    isDarkMode
+                      ? 'bg-red-700 hover:bg-red-600 text-white border border-red-600'
+                      : 'bg-red-600 hover:bg-red-700 text-white border border-red-700'
+                  }`}
                 >
                   {text.exportPDF}
                 </button>
@@ -175,79 +248,146 @@ export default function ResultsScreen({
             </div>
           </div>
           <div className="p-6">
-            <div className={`mb-6 p-4 rounded-lg border-2 ${result.passed
-              ? isDarkMode
-                ? 'bg-green-900/20 border-green-700'
-                : 'bg-green-50 border-green-300'
-              : isDarkMode
-                ? 'bg-red-900/20 border-red-700'
-                : 'bg-red-50 border-red-300'
-              }`}>
+            <div
+              className={`mb-6 p-4 rounded-lg border-2 ${
+                result.passed
+                  ? isDarkMode
+                    ? 'bg-green-900/20 border-green-700'
+                    : 'bg-green-50 border-green-300'
+                  : isDarkMode
+                    ? 'bg-red-900/20 border-red-700'
+                    : 'bg-red-50 border-red-300'
+              }`}
+            >
               <div className="flex items-center justify-between">
                 <div className="flex items-center gap-2">
                   <span className="text-2xl">{result.passed ? '🏆' : '✗'}</span>
-                  <span className={`text-lg font-semibold ${result.passed
-                    ? isDarkMode ? 'text-green-300' : 'text-green-900'
-                    : isDarkMode ? 'text-red-300' : 'text-red-900'
-                    }`}>
+                  <span
+                    className={`text-lg font-semibold ${
+                      result.passed
+                        ? isDarkMode
+                          ? 'text-green-300'
+                          : 'text-green-900'
+                        : isDarkMode
+                          ? 'text-red-300'
+                          : 'text-red-900'
+                    }`}
+                  >
                     {result.passed ? text.passed : text.failed}
                   </span>
                 </div>
-                <span className={`text-2xl font-bold ${isDarkMode ? 'text-white' : 'text-gray-900'}`}>
+                <span
+                  className={`text-2xl font-bold ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
+                >
                   {result.score} / {result.totalQuestions}
                 </span>
               </div>
             </div>
 
             <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-              <div className={`text-center p-5 rounded-xl border-2 shadow-sm ${isDarkMode
-                ? 'bg-amber-900/30 border-amber-700'
-                : 'bg-amber-50 border-amber-200'
-                }`}>
+              <div
+                className={`text-center p-5 rounded-xl border-2 shadow-sm ${
+                  isDarkMode
+                    ? 'bg-amber-900/30 border-amber-700'
+                    : 'bg-amber-50 border-amber-200'
+                }`}
+              >
                 <span className="text-4xl block mb-2">🏆</span>
-                <p className={`text-sm font-medium mb-1 ${isDarkMode ? 'text-amber-300' : 'text-amber-700'}`}>{text.score}</p>
-                <p className={`text-3xl font-bold ${isDarkMode ? 'text-amber-200' : 'text-amber-900'}`}>{result.score}</p>
+                <p
+                  className={`text-sm font-medium mb-1 ${isDarkMode ? 'text-amber-300' : 'text-amber-700'}`}
+                >
+                  {text.score}
+                </p>
+                <p
+                  className={`text-3xl font-bold ${isDarkMode ? 'text-amber-200' : 'text-amber-900'}`}
+                >
+                  {result.score}
+                </p>
               </div>
 
-              <div className={`text-center p-5 rounded-xl border-2 shadow-sm ${isDarkMode
-                ? 'bg-green-900/30 border-green-700'
-                : 'bg-green-50 border-green-200'
-                }`}>
+              <div
+                className={`text-center p-5 rounded-xl border-2 shadow-sm ${
+                  isDarkMode
+                    ? 'bg-green-900/30 border-green-700'
+                    : 'bg-green-50 border-green-200'
+                }`}
+              >
                 <span className="text-4xl block mb-2">✓</span>
-                <p className={`text-sm font-medium mb-1 ${isDarkMode ? 'text-green-300' : 'text-green-700'}`}>{text.correct}</p>
-                <p className={`text-3xl font-bold ${isDarkMode ? 'text-green-200' : 'text-green-800'}`}>{result.correctAnswers}</p>
+                <p
+                  className={`text-sm font-medium mb-1 ${isDarkMode ? 'text-green-300' : 'text-green-700'}`}
+                >
+                  {text.correct}
+                </p>
+                <p
+                  className={`text-3xl font-bold ${isDarkMode ? 'text-green-200' : 'text-green-800'}`}
+                >
+                  {result.correctAnswers}
+                </p>
               </div>
 
-              <div className={`text-center p-5 rounded-xl border-2 shadow-sm ${isDarkMode
-                ? 'bg-red-900/30 border-red-700'
-                : 'bg-red-50 border-red-200'
-                }`}>
+              <div
+                className={`text-center p-5 rounded-xl border-2 shadow-sm ${
+                  isDarkMode
+                    ? 'bg-red-900/30 border-red-700'
+                    : 'bg-red-50 border-red-200'
+                }`}
+              >
                 <span className="text-4xl block mb-2">✗</span>
-                <p className={`text-sm font-medium mb-1 ${isDarkMode ? 'text-red-300' : 'text-red-700'}`}>{text.incorrect}</p>
-                <p className={`text-3xl font-bold ${isDarkMode ? 'text-red-200' : 'text-red-800'}`}>{result.incorrectAnswers}</p>
+                <p
+                  className={`text-sm font-medium mb-1 ${isDarkMode ? 'text-red-300' : 'text-red-700'}`}
+                >
+                  {text.incorrect}
+                </p>
+                <p
+                  className={`text-3xl font-bold ${isDarkMode ? 'text-red-200' : 'text-red-800'}`}
+                >
+                  {result.incorrectAnswers}
+                </p>
               </div>
 
-              <div className={`text-center p-5 rounded-xl border-2 shadow-sm ${isDarkMode
-                ? 'bg-slate-700 border-slate-600'
-                : 'bg-slate-50 border-slate-200'
-                }`}>
+              <div
+                className={`text-center p-5 rounded-xl border-2 shadow-sm ${
+                  isDarkMode
+                    ? 'bg-slate-700 border-slate-600'
+                    : 'bg-slate-50 border-slate-200'
+                }`}
+              >
                 <span className="text-4xl block mb-2">⏱️</span>
-                <p className={`text-sm font-medium mb-1 ${isDarkMode ? 'text-slate-300' : 'text-slate-700'}`}>{text.time}</p>
-                <p className={`text-3xl font-bold ${isDarkMode ? 'text-slate-200' : 'text-slate-900'}`}>{formatTime(result.timeSpent)}</p>
+                <p
+                  className={`text-sm font-medium mb-1 ${isDarkMode ? 'text-slate-300' : 'text-slate-700'}`}
+                >
+                  {text.time}
+                </p>
+                <p
+                  className={`text-3xl font-bold ${isDarkMode ? 'text-slate-200' : 'text-slate-900'}`}
+                >
+                  {formatTime(result.timeSpent)}
+                </p>
               </div>
             </div>
 
             <div className="mt-6">
-              <div className={`flex justify-between mb-2 text-sm ${isDarkMode ? 'text-slate-300' : 'text-gray-700'}`}>
+              <div
+                className={`flex justify-between mb-2 text-sm ${isDarkMode ? 'text-slate-300' : 'text-gray-700'}`}
+              >
                 <span className="font-semibold">{text.accuracy}</span>
-                <span className="font-bold text-base">{result.percentage.toFixed(2)}%</span>
+                <span className="font-bold text-base">
+                  {result.percentage.toFixed(2)}%
+                </span>
               </div>
-              <div className={`w-full rounded-full h-3 shadow-inner ${isDarkMode ? 'bg-slate-700' : 'bg-gray-200'}`}>
+              <div
+                className={`w-full rounded-full h-3 shadow-inner ${isDarkMode ? 'bg-slate-700' : 'bg-gray-200'}`}
+              >
                 <div
-                  className={`h-3 rounded-full transition-all shadow-sm ${result.passed
-                    ? isDarkMode ? 'bg-green-500' : 'bg-green-600'
-                    : isDarkMode ? 'bg-red-500' : 'bg-red-600'
-                    }`}
+                  className={`h-3 rounded-full transition-all shadow-sm ${
+                    result.passed
+                      ? isDarkMode
+                        ? 'bg-green-500'
+                        : 'bg-green-600'
+                      : isDarkMode
+                        ? 'bg-red-500'
+                        : 'bg-red-600'
+                  }`}
                   style={{ width: `${result.percentage}%` }}
                 />
               </div>
@@ -255,45 +395,64 @@ export default function ResultsScreen({
           </div>
         </div>
 
-        <div className={`rounded-lg shadow-lg ${isDarkMode ? 'bg-slate-800' : 'bg-white'}`}>
+        {saveError && (
+          <div
+            className={`mb-6 rounded-lg border px-4 py-3 ${
+              isDarkMode
+                ? 'border-amber-700 bg-amber-900/20 text-amber-200'
+                : 'border-amber-200 bg-amber-50 text-amber-900'
+            }`}
+            role="alert"
+          >
+            <p className="font-semibold">{text.saveErrorTitle}</p>
+            <p className="mt-1 text-sm opacity-90">{saveError}</p>
+          </div>
+        )}
+
+        <div
+          className={`rounded-lg shadow-lg ${isDarkMode ? 'bg-slate-800' : 'bg-white'}`}
+        >
           <div className="border-b border-gray-200 dark:border-gray-700">
             <div className="flex">
               <button
                 onClick={() => setActiveTab('summary')}
-                className={`flex-1 px-4 py-3 font-medium transition-colors ${activeTab === 'summary'
-                  ? isDarkMode
-                    ? 'bg-slate-700 text-white border-b-2 border-amber-500'
-                    : 'bg-white text-gray-900 border-b-2 border-amber-600'
-                  : isDarkMode
-                    ? 'text-slate-400 hover:text-white'
-                    : 'text-gray-600 hover:text-gray-900'
-                  }`}
+                className={`flex-1 px-4 py-3 font-medium transition-colors ${
+                  activeTab === 'summary'
+                    ? isDarkMode
+                      ? 'bg-slate-700 text-white border-b-2 border-amber-500'
+                      : 'bg-white text-gray-900 border-b-2 border-amber-600'
+                    : isDarkMode
+                      ? 'text-slate-400 hover:text-white'
+                      : 'text-gray-600 hover:text-gray-900'
+                }`}
               >
                 {text.tabSummary}
               </button>
               <button
                 onClick={() => setActiveTab('learning-objectives')}
-                className={`flex-1 px-4 py-3 font-medium transition-colors ${activeTab === 'learning-objectives'
-                  ? isDarkMode
-                    ? 'bg-slate-700 text-white border-b-2 border-amber-500'
-                    : 'bg-white text-gray-900 border-b-2 border-amber-600'
-                  : isDarkMode
-                    ? 'text-slate-400 hover:text-white'
-                    : 'text-gray-600 hover:text-gray-900'
-                  }`}
+                className={`flex-1 px-4 py-3 font-medium transition-colors ${
+                  activeTab === 'learning-objectives'
+                    ? isDarkMode
+                      ? 'bg-slate-700 text-white border-b-2 border-amber-500'
+                      : 'bg-white text-gray-900 border-b-2 border-amber-600'
+                    : isDarkMode
+                      ? 'text-slate-400 hover:text-white'
+                      : 'text-gray-600 hover:text-gray-900'
+                }`}
               >
                 {text.tabLO}
               </button>
               <button
                 onClick={() => setActiveTab('details')}
-                className={`flex-1 px-4 py-3 font-medium transition-colors ${activeTab === 'details'
-                  ? isDarkMode
-                    ? 'bg-slate-700 text-white border-b-2 border-amber-500'
-                    : 'bg-white text-gray-900 border-b-2 border-amber-600'
-                  : isDarkMode
-                    ? 'text-slate-400 hover:text-white'
-                    : 'text-gray-600 hover:text-gray-900'
-                  }`}
+                className={`flex-1 px-4 py-3 font-medium transition-colors ${
+                  activeTab === 'details'
+                    ? isDarkMode
+                      ? 'bg-slate-700 text-white border-b-2 border-amber-500'
+                      : 'bg-white text-gray-900 border-b-2 border-amber-600'
+                    : isDarkMode
+                      ? 'text-slate-400 hover:text-white'
+                      : 'text-gray-600 hover:text-gray-900'
+                }`}
               >
                 {text.tabDetails}
               </button>
@@ -304,24 +463,42 @@ export default function ResultsScreen({
             {activeTab === 'summary' && (
               <div className="space-y-4">
                 <div>
-                  <h3 className={`font-semibold mb-2 ${isDarkMode ? 'text-white' : 'text-gray-900'}`}>{text.resultLabel}</h3>
+                  <h3
+                    className={`font-semibold mb-2 ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
+                  >
+                    {text.resultLabel}
+                  </h3>
                   <p
                     className={isDarkMode ? 'text-slate-400' : 'text-gray-600'}
                     dangerouslySetInnerHTML={{
                       __html: result.passed
-                        ? text.passMessage(result.score, result.totalQuestions, result.percentage.toFixed(2))
-                        : text.failMessage(result.score, result.totalQuestions, result.percentage.toFixed(2)),
+                        ? text.passMessage(
+                            result.score,
+                            result.totalQuestions,
+                            result.percentage.toFixed(2)
+                          )
+                        : text.failMessage(
+                            result.score,
+                            result.totalQuestions,
+                            result.percentage.toFixed(2)
+                          ),
                     }}
                   />
                 </div>
 
                 <div className="grid grid-cols-1 md:grid-cols-2 gap-4 pt-4">
-                  <div className={`p-5 rounded-xl border-2 shadow-sm ${isDarkMode
-                    ? 'border-green-700 bg-green-900/20'
-                    : 'border-green-200 bg-green-50/50'
-                    }`}>
-                    <h4 className={`font-semibold mb-3 flex items-center gap-2 ${isDarkMode ? 'text-green-300' : 'text-green-900'
-                      }`}>
+                  <div
+                    className={`p-5 rounded-xl border-2 shadow-sm ${
+                      isDarkMode
+                        ? 'border-green-700 bg-green-900/20'
+                        : 'border-green-200 bg-green-50/50'
+                    }`}
+                  >
+                    <h4
+                      className={`font-semibold mb-3 flex items-center gap-2 ${
+                        isDarkMode ? 'text-green-300' : 'text-green-900'
+                      }`}
+                    >
                       <span className="text-xl">💪</span>
                       {text.strengths}
                     </h4>
@@ -330,27 +507,56 @@ export default function ResultsScreen({
                         .filter((lo) => lo.percentage >= 70)
                         .slice(0, 5)
                         .map((lo) => (
-                          <li key={lo.learningObjective} className="flex items-center gap-2">
-                            <span className={isDarkMode ? 'text-green-400' : 'text-green-600'}>✓</span>
-                            <span className={isDarkMode ? 'text-slate-300' : 'text-gray-700'}>
-                              {lo.learningObjective}: <strong>{lo.correctAnswers}/{lo.totalQuestions}</strong> ({lo.percentage.toFixed(0)}%)
+                          <li
+                            key={lo.learningObjective}
+                            className="flex items-center gap-2"
+                          >
+                            <span
+                              className={
+                                isDarkMode ? 'text-green-400' : 'text-green-600'
+                              }
+                            >
+                              ✓
+                            </span>
+                            <span
+                              className={
+                                isDarkMode ? 'text-slate-300' : 'text-gray-700'
+                              }
+                            >
+                              {lo.learningObjective}:{' '}
+                              <strong>
+                                {lo.correctAnswers}/{lo.totalQuestions}
+                              </strong>{' '}
+                              ({lo.percentage.toFixed(0)}%)
                             </span>
                           </li>
                         ))}
-                      {result.learningObjectiveAnalysis.filter((lo) => lo.percentage >= 70).length === 0 && (
-                        <li className={isDarkMode ? 'text-slate-400' : 'text-gray-600'}>
+                      {result.learningObjectiveAnalysis.filter(
+                        (lo) => lo.percentage >= 70
+                      ).length === 0 && (
+                        <li
+                          className={
+                            isDarkMode ? 'text-slate-400' : 'text-gray-600'
+                          }
+                        >
                           {text.noStrengths}
                         </li>
                       )}
                     </ul>
                   </div>
 
-                  <div className={`p-5 rounded-xl border-2 shadow-sm ${isDarkMode
-                    ? 'border-amber-700 bg-amber-900/20'
-                    : 'border-amber-200 bg-amber-50/50'
-                    }`}>
-                    <h4 className={`font-semibold mb-3 flex items-center gap-2 ${isDarkMode ? 'text-amber-300' : 'text-amber-900'
-                      }`}>
+                  <div
+                    className={`p-5 rounded-xl border-2 shadow-sm ${
+                      isDarkMode
+                        ? 'border-amber-700 bg-amber-900/20'
+                        : 'border-amber-200 bg-amber-50/50'
+                    }`}
+                  >
+                    <h4
+                      className={`font-semibold mb-3 flex items-center gap-2 ${
+                        isDarkMode ? 'text-amber-300' : 'text-amber-900'
+                      }`}
+                    >
                       <span className="text-xl">📚</span>
                       {text.improvements}
                     </h4>
@@ -359,15 +565,38 @@ export default function ResultsScreen({
                         .filter((lo) => lo.percentage < 70)
                         .slice(0, 5)
                         .map((lo) => (
-                          <li key={lo.learningObjective} className="flex items-center gap-2">
-                            <span className={isDarkMode ? 'text-amber-400' : 'text-amber-600'}>⚠</span>
-                            <span className={isDarkMode ? 'text-slate-300' : 'text-gray-700'}>
-                              {lo.learningObjective}: <strong>{lo.correctAnswers}/{lo.totalQuestions}</strong> ({lo.percentage.toFixed(0)}%)
+                          <li
+                            key={lo.learningObjective}
+                            className="flex items-center gap-2"
+                          >
+                            <span
+                              className={
+                                isDarkMode ? 'text-amber-400' : 'text-amber-600'
+                              }
+                            >
+                              ⚠
+                            </span>
+                            <span
+                              className={
+                                isDarkMode ? 'text-slate-300' : 'text-gray-700'
+                              }
+                            >
+                              {lo.learningObjective}:{' '}
+                              <strong>
+                                {lo.correctAnswers}/{lo.totalQuestions}
+                              </strong>{' '}
+                              ({lo.percentage.toFixed(0)}%)
                             </span>
                           </li>
                         ))}
-                      {result.learningObjectiveAnalysis.filter((lo) => lo.percentage < 70).length === 0 && (
-                        <li className={isDarkMode ? 'text-slate-400' : 'text-gray-600'}>
+                      {result.learningObjectiveAnalysis.filter(
+                        (lo) => lo.percentage < 70
+                      ).length === 0 && (
+                        <li
+                          className={
+                            isDarkMode ? 'text-slate-400' : 'text-gray-600'
+                          }
+                        >
                           {text.noImprovements}
                         </li>
                       )}
@@ -380,42 +609,164 @@ export default function ResultsScreen({
             {activeTab === 'learning-objectives' && (
               <div className="space-y-4">
                 <div className="mb-4">
-                  <h3 className={`text-lg font-bold flex items-center gap-2 ${isDarkMode ? 'text-white' : 'text-gray-900'}`}>
+                  <h3
+                    className={`text-lg font-bold flex items-center gap-2 ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
+                  >
                     <span className="text-2xl">📊</span>
                     {text.loAnalysis}
                   </h3>
-                  <p className={`text-sm mt-1 ${isDarkMode ? 'text-slate-400' : 'text-gray-600'}`}>
+                  <p
+                    className={`text-sm mt-1 ${isDarkMode ? 'text-slate-400' : 'text-gray-600'}`}
+                  >
                     {text.loDescription}
                   </p>
                 </div>
-                {result.learningObjectiveAnalysis.map((lo) => (
-                  <div key={lo.learningObjective} className={`p-4 rounded-xl border-2 shadow-sm space-y-2 ${lo.percentage >= 70
-                    ? isDarkMode ? 'border-green-700 bg-green-900/10' : 'border-green-200 bg-green-50/30'
-                    : lo.percentage >= 50
-                      ? isDarkMode ? 'border-amber-700 bg-amber-900/10' : 'border-amber-200 bg-amber-50/30'
-                      : isDarkMode ? 'border-red-700 bg-red-900/10' : 'border-red-200 bg-red-50/30'
-                    }`}>
-                    <div className="flex justify-between items-center">
-                      <span className={`font-semibold ${isDarkMode ? 'text-slate-100' : 'text-gray-900'}`}>
-                        {lo.learningObjective}
-                      </span>
-                      <span className={`text-sm font-bold px-3 py-1 rounded-full ${lo.percentage >= 70
-                        ? isDarkMode ? 'bg-green-900/40 text-green-300' : 'bg-green-100 text-green-800'
-                        : lo.percentage >= 50
-                          ? isDarkMode ? 'bg-amber-900/40 text-amber-300' : 'bg-amber-100 text-amber-800'
-                          : isDarkMode ? 'bg-red-900/40 text-red-300' : 'bg-red-100 text-red-800'
-                        }`}>
-                        {lo.correctAnswers} / {lo.totalQuestions} ({lo.percentage.toFixed(0)}%)
+                <div
+                  className={`p-4 rounded-xl border-2 shadow-sm ${
+                    isDarkMode
+                      ? 'border-blue-700 bg-blue-900/10'
+                      : 'border-blue-200 bg-blue-50/30'
+                  }`}
+                >
+                  <h4
+                    className={`font-semibold mb-3 flex items-center gap-2 ${
+                      isDarkMode ? 'text-blue-200' : 'text-blue-900'
+                    }`}
+                  >
+                    <span className="text-xl">🌎</span>
+                    {text.communityComparison}
+                  </h4>
+                  {latamLoading ? (
+                    <div className="flex items-center gap-2 text-sm">
+                      <div className="h-4 w-4 animate-spin rounded-full border-2 border-blue-500 border-t-transparent" />
+                      <span
+                        className={
+                          isDarkMode ? 'text-slate-300' : 'text-gray-600'
+                        }
+                      >
+                        {text.communityLoading}
                       </span>
                     </div>
-                    <div className={`w-full rounded-full h-3 shadow-inner ${isDarkMode ? 'bg-slate-700' : 'bg-gray-200'}`}>
+                  ) : hasLatamComparison ? (
+                    <div className="space-y-3">
+                      {result.learningObjectiveAnalysis.map((lo) => {
+                        const comparison = latamByLearningObjective.get(
+                          lo.learningObjective
+                        );
+                        if (!comparison) return null;
+                        const delta =
+                          lo.percentage - comparison.averagePercentage;
+
+                        return (
+                          <div key={lo.learningObjective} className="space-y-1">
+                            <div className="flex flex-wrap items-center justify-between gap-2 text-sm">
+                              <span
+                                className={`font-semibold ${
+                                  isDarkMode
+                                    ? 'text-slate-100'
+                                    : 'text-gray-900'
+                                }`}
+                              >
+                                {lo.learningObjective}
+                              </span>
+                              <span
+                                className={`font-bold ${
+                                  delta >= 0
+                                    ? isDarkMode
+                                      ? 'text-emerald-300'
+                                      : 'text-emerald-700'
+                                    : isDarkMode
+                                      ? 'text-amber-300'
+                                      : 'text-amber-700'
+                                }`}
+                              >
+                                {delta >= 0 ? '+' : ''}
+                                {Math.round(delta)} pts
+                              </span>
+                            </div>
+                            <p
+                              className={`text-xs ${
+                                isDarkMode ? 'text-slate-400' : 'text-gray-600'
+                              }`}
+                            >
+                              {text.yourResult}: {lo.percentage.toFixed(0)}% ·{' '}
+                              {text.latamAverage}:{' '}
+                              {comparison.averagePercentage}% (
+                              {comparison.sampleSize} {text.sample})
+                            </p>
+                          </div>
+                        );
+                      })}
+                    </div>
+                  ) : (
+                    <p
+                      className={`text-sm ${
+                        isDarkMode ? 'text-slate-300' : 'text-gray-600'
+                      }`}
+                    >
+                      {text.communityNoData}
+                    </p>
+                  )}
+                </div>
+                {result.learningObjectiveAnalysis.map((lo) => (
+                  <div
+                    key={lo.learningObjective}
+                    className={`p-4 rounded-xl border-2 shadow-sm space-y-2 ${
+                      lo.percentage >= 70
+                        ? isDarkMode
+                          ? 'border-green-700 bg-green-900/10'
+                          : 'border-green-200 bg-green-50/30'
+                        : lo.percentage >= 50
+                          ? isDarkMode
+                            ? 'border-amber-700 bg-amber-900/10'
+                            : 'border-amber-200 bg-amber-50/30'
+                          : isDarkMode
+                            ? 'border-red-700 bg-red-900/10'
+                            : 'border-red-200 bg-red-50/30'
+                    }`}
+                  >
+                    <div className="flex justify-between items-center">
+                      <span
+                        className={`font-semibold ${isDarkMode ? 'text-slate-100' : 'text-gray-900'}`}
+                      >
+                        {lo.learningObjective}
+                      </span>
+                      <span
+                        className={`text-sm font-bold px-3 py-1 rounded-full ${
+                          lo.percentage >= 70
+                            ? isDarkMode
+                              ? 'bg-green-900/40 text-green-300'
+                              : 'bg-green-100 text-green-800'
+                            : lo.percentage >= 50
+                              ? isDarkMode
+                                ? 'bg-amber-900/40 text-amber-300'
+                                : 'bg-amber-100 text-amber-800'
+                              : isDarkMode
+                                ? 'bg-red-900/40 text-red-300'
+                                : 'bg-red-100 text-red-800'
+                        }`}
+                      >
+                        {lo.correctAnswers} / {lo.totalQuestions} (
+                        {lo.percentage.toFixed(0)}%)
+                      </span>
+                    </div>
+                    <div
+                      className={`w-full rounded-full h-3 shadow-inner ${isDarkMode ? 'bg-slate-700' : 'bg-gray-200'}`}
+                    >
                       <div
-                        className={`h-3 rounded-full transition-all shadow-sm ${lo.percentage >= 70
-                          ? isDarkMode ? 'bg-green-500' : 'bg-green-600'
-                          : lo.percentage >= 50
-                            ? isDarkMode ? 'bg-amber-500' : 'bg-amber-600'
-                            : isDarkMode ? 'bg-red-500' : 'bg-red-600'
-                          }`}
+                        className={`h-3 rounded-full transition-all shadow-sm ${
+                          lo.percentage >= 70
+                            ? isDarkMode
+                              ? 'bg-green-500'
+                              : 'bg-green-600'
+                            : lo.percentage >= 50
+                              ? isDarkMode
+                                ? 'bg-amber-500'
+                                : 'bg-amber-600'
+                              : isDarkMode
+                                ? 'bg-red-500'
+                                : 'bg-red-600'
+                        }`}
                         style={{ width: `${lo.percentage}%` }}
                       />
                     </div>
@@ -429,63 +780,103 @@ export default function ResultsScreen({
                 {result.answers.map((answer, index) => (
                   <div
                     key={answer.questionId}
-                    className={`rounded-xl border-2 shadow-sm ${answer.isCorrect
-                      ? isDarkMode
-                        ? 'border-green-700 bg-green-900/10'
-                        : 'border-green-300 bg-green-50/30'
-                      : isDarkMode
-                        ? 'border-red-700 bg-red-900/10'
-                        : 'border-red-300 bg-red-50/30'
-                      }`}
+                    className={`rounded-xl border-2 shadow-sm ${
+                      answer.isCorrect
+                        ? isDarkMode
+                          ? 'border-green-700 bg-green-900/10'
+                          : 'border-green-300 bg-green-50/30'
+                        : isDarkMode
+                          ? 'border-red-700 bg-red-900/10'
+                          : 'border-red-300 bg-red-50/30'
+                    }`}
                   >
-                    <div className={`p-4 border-b ${isDarkMode ? 'border-slate-700' : 'border-gray-200'}`}>
+                    <div
+                      className={`p-4 border-b ${isDarkMode ? 'border-slate-700' : 'border-gray-200'}`}
+                    >
                       <div className="flex justify-between items-start gap-3">
-                        <h3 className={`text-lg font-bold flex items-center gap-2 ${isDarkMode ? 'text-white' : 'text-gray-900'}`}>
+                        <h3
+                          className={`text-lg font-bold flex items-center gap-2 ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
+                        >
                           {text.question} {index + 1}
                           {answer.isCorrect ? (
-                            <span className={`text-2xl ${isDarkMode ? 'text-green-400' : 'text-green-600'}`}>✓</span>
+                            <span
+                              className={`text-2xl ${isDarkMode ? 'text-green-400' : 'text-green-600'}`}
+                            >
+                              ✓
+                            </span>
                           ) : (
-                            <span className={`text-2xl ${isDarkMode ? 'text-red-400' : 'text-red-600'}`}>✗</span>
+                            <span
+                              className={`text-2xl ${isDarkMode ? 'text-red-400' : 'text-red-600'}`}
+                            >
+                              ✗
+                            </span>
                           )}
                         </h3>
                         <div className="flex gap-2 text-sm flex-shrink-0">
-                          <span className={`px-3 py-1 rounded-full font-medium border ${isDarkMode
-                            ? 'bg-blue-900/40 text-blue-300 border-blue-700'
-                            : 'bg-blue-100 text-blue-800 border-blue-200'
-                            }`}>
+                          <span
+                            className={`px-3 py-1 rounded-full font-medium border ${
+                              isDarkMode
+                                ? 'bg-blue-900/40 text-blue-300 border-blue-700'
+                                : 'bg-blue-100 text-blue-800 border-blue-200'
+                            }`}
+                          >
                             {answer.learningObjective}
                           </span>
-                          <span className={`px-3 py-1 rounded-full font-semibold border ${isDarkMode
-                            ? 'bg-amber-900/40 text-amber-300 border-amber-700'
-                            : 'bg-amber-100 text-amber-800 border-amber-200'
-                            }`}>
+                          <span
+                            className={`px-3 py-1 rounded-full font-semibold border ${
+                              isDarkMode
+                                ? 'bg-amber-900/40 text-amber-300 border-amber-700'
+                                : 'bg-amber-100 text-amber-800 border-amber-200'
+                            }`}
+                          >
                             {answer.kLevel}
                           </span>
                         </div>
                       </div>
                     </div>
                     <div className="p-4 space-y-4">
-                      <p className={`text-base ${isDarkMode ? 'text-white' : 'text-gray-900'}`}>{answer.questionText}</p>
+                      <p
+                        className={`text-base ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
+                      >
+                        {answer.questionText}
+                      </p>
 
                       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                         <div>
-                          <h4 className={`font-semibold mb-2 flex items-center gap-2 ${isDarkMode ? 'text-white' : 'text-gray-900'}`}>
+                          <h4
+                            className={`font-semibold mb-2 flex items-center gap-2 ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
+                          >
                             {answer.isCorrect ? (
-                              <span className={isDarkMode ? 'text-green-400' : 'text-green-600'}>✓</span>
+                              <span
+                                className={
+                                  isDarkMode
+                                    ? 'text-green-400'
+                                    : 'text-green-600'
+                                }
+                              >
+                                ✓
+                              </span>
                             ) : (
-                              <span className={isDarkMode ? 'text-red-400' : 'text-red-600'}>✗</span>
+                              <span
+                                className={
+                                  isDarkMode ? 'text-red-400' : 'text-red-600'
+                                }
+                              >
+                                ✗
+                              </span>
                             )}
                             {text.yourAnswer}
                           </h4>
                           <p
-                            className={`p-3 rounded-lg font-medium border-2 ${answer.isCorrect
-                              ? isDarkMode
-                                ? 'bg-green-900/30 text-green-300 border-green-700'
-                                : 'bg-green-100 text-green-900 border-green-300'
-                              : isDarkMode
-                                ? 'bg-red-900/30 text-red-300 border-red-700'
-                                : 'bg-red-100 text-red-900 border-red-300'
-                              }`}
+                            className={`p-3 rounded-lg font-medium border-2 ${
+                              answer.isCorrect
+                                ? isDarkMode
+                                  ? 'bg-green-900/30 text-green-300 border-green-700'
+                                  : 'bg-green-100 text-green-900 border-green-300'
+                                : isDarkMode
+                                  ? 'bg-red-900/30 text-red-300 border-red-700'
+                                  : 'bg-red-100 text-red-900 border-red-300'
+                            }`}
                           >
                             {answer.userAnswer.join(', ') || text.noAnswer}
                           </p>
@@ -493,14 +884,27 @@ export default function ResultsScreen({
 
                         {!answer.isCorrect && (
                           <div>
-                            <h4 className={`font-semibold mb-2 flex items-center gap-2 ${isDarkMode ? 'text-white' : 'text-gray-900'}`}>
-                              <span className={isDarkMode ? 'text-green-400' : 'text-green-600'}>✓</span>
+                            <h4
+                              className={`font-semibold mb-2 flex items-center gap-2 ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
+                            >
+                              <span
+                                className={
+                                  isDarkMode
+                                    ? 'text-green-400'
+                                    : 'text-green-600'
+                                }
+                              >
+                                ✓
+                              </span>
                               {text.correctAnswer}
                             </h4>
-                            <p className={`p-3 rounded-lg font-medium border-2 ${isDarkMode
-                              ? 'bg-green-900/30 text-green-300 border-green-700'
-                              : 'bg-green-100 text-green-900 border-green-300'
-                              }`}>
+                            <p
+                              className={`p-3 rounded-lg font-medium border-2 ${
+                                isDarkMode
+                                  ? 'bg-green-900/30 text-green-300 border-green-700'
+                                  : 'bg-green-100 text-green-900 border-green-300'
+                              }`}
+                            >
                               {answer.correctAnswer.join(', ')}
                             </p>
                           </div>
@@ -509,38 +913,61 @@ export default function ResultsScreen({
 
                       {(answer.isCorrect
                         ? expandedExplanations.has(answer.questionId)
-                        : true
-                      ) && (
+                        : true) && (
                         <div className="mt-4">
-                          <h4 className={`font-semibold mb-3 flex items-center gap-2 ${isDarkMode ? 'text-white' : 'text-gray-900'}`}>
+                          <h4
+                            className={`font-semibold mb-3 flex items-center gap-2 ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
+                          >
                             <span className="text-xl">💡</span>
                             {text.explanation}
                           </h4>
                           <div className="space-y-2 text-sm">
-                            {Object.entries(answer.explanations).map(([label, exp]) => (
-                              <div
-                                key={label}
-                                className={`p-3 rounded-lg border-l-4 ${exp.correct
-                                  ? isDarkMode
-                                    ? 'bg-green-900/20 border-green-500'
-                                    : 'bg-green-50 border-green-500'
-                                  : isDarkMode
-                                    ? 'bg-slate-700/50 border-slate-600'
-                                    : 'bg-gray-50 border-gray-300'
+                            {Object.entries(answer.explanations).map(
+                              ([label, exp]) => (
+                                <div
+                                  key={label}
+                                  className={`p-3 rounded-lg border-l-4 ${
+                                    exp.correct
+                                      ? isDarkMode
+                                        ? 'bg-green-900/20 border-green-500'
+                                        : 'bg-green-50 border-green-500'
+                                      : isDarkMode
+                                        ? 'bg-slate-700/50 border-slate-600'
+                                        : 'bg-gray-50 border-gray-300'
                                   }`}
-                              >
-                                <span className={`font-semibold ${exp.correct
-                                  ? isDarkMode ? 'text-green-300' : 'text-green-900'
-                                  : isDarkMode ? 'text-slate-200' : 'text-gray-900'
-                                  }`}>
-                                  {text.option} {label}: {exp.correct ? text.correctOption : text.incorrectOption}
-                                </span>
-                                <p className={`mt-1 ${exp.correct
-                                  ? isDarkMode ? 'text-green-200' : 'text-green-800'
-                                  : isDarkMode ? 'text-slate-300' : 'text-gray-700'
-                                  }`}>{exp.explanation}</p>
-                              </div>
-                            ))}
+                                >
+                                  <span
+                                    className={`font-semibold ${
+                                      exp.correct
+                                        ? isDarkMode
+                                          ? 'text-green-300'
+                                          : 'text-green-900'
+                                        : isDarkMode
+                                          ? 'text-slate-200'
+                                          : 'text-gray-900'
+                                    }`}
+                                  >
+                                    {text.option} {label}:{' '}
+                                    {exp.correct
+                                      ? text.correctOption
+                                      : text.incorrectOption}
+                                  </span>
+                                  <p
+                                    className={`mt-1 ${
+                                      exp.correct
+                                        ? isDarkMode
+                                          ? 'text-green-200'
+                                          : 'text-green-800'
+                                        : isDarkMode
+                                          ? 'text-slate-300'
+                                          : 'text-gray-700'
+                                    }`}
+                                  >
+                                    {exp.explanation}
+                                  </p>
+                                </div>
+                              )
+                            )}
                           </div>
                         </div>
                       )}
@@ -550,7 +977,9 @@ export default function ResultsScreen({
                           className={`mt-3 text-xs font-medium flex items-center gap-1 transition-colors ${isDarkMode ? 'text-slate-400 hover:text-slate-200' : 'text-gray-500 hover:text-gray-800'}`}
                         >
                           <span>💡</span>
-                          {expandedExplanations.has(answer.questionId) ? 'Ocultar explicación' : 'Ver explicación'}
+                          {expandedExplanations.has(answer.questionId)
+                            ? 'Ocultar explicación'
+                            : 'Ver explicación'}
                         </button>
                       )}
                     </div>

--- a/apps/frontend/src/app/labs/istqb/hooks/useSubmitResults.ts
+++ b/apps/frontend/src/app/labs/istqb/hooks/useSubmitResults.ts
@@ -9,10 +9,12 @@ export function useSubmitResults(
 ) {
   const [isSaved, setIsSaved] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
 
   useEffect(() => {
     const submit = async () => {
       setIsSubmitting(true);
+      setSaveError(null);
       try {
         const res = await saveExamResultAction({
           exam_type: 'istqb',
@@ -34,11 +36,15 @@ export function useSubmitResults(
 
         if (res.error) {
           console.error('Error guardando resultado ISTQB:', res.error);
+          setSaveError(res.error);
         } else {
           setIsSaved(true);
         }
       } catch (err) {
         console.error('Error guardando resultado ISTQB:', err);
+        setSaveError(
+          err instanceof Error ? err.message : 'No se pudo guardar el resultado'
+        );
       } finally {
         setIsSubmitting(false);
       }
@@ -47,5 +53,5 @@ export function useSubmitResults(
     submit();
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
-  return { isSaved, isSubmitting };
+  return { isSaved, isSubmitting, saveError };
 }

--- a/apps/frontend/src/app/labs/page.tsx
+++ b/apps/frontend/src/app/labs/page.tsx
@@ -1,16 +1,69 @@
 'use client';
 
 import Link from 'next/link';
+import { useEffect, useMemo, useState } from 'react';
 import { useTheme } from '@/contexts/ThemeContext';
 import { useLanguage } from '@/contexts/LanguageContext';
 import { useSupabaseAuth } from '@/contexts/SupabaseAuthContext';
+import { getExamResultsAction } from '@/actions/exams';
 import BugReportWidget from '@/components/BugReportWidget';
 import { SuruFloating } from '@/components/Suru';
+
+interface ExamProgressResult {
+  exam_type: string;
+  exam_mode: string;
+  score: number;
+  total_questions: number;
+  max_possible_score: number | null;
+  passed: boolean;
+  percentage: number;
+  created_at: string;
+}
+
+interface ToolProgress {
+  passed: boolean;
+  bestScore: number;
+  maxScore: number;
+  bestPercentage: number;
+  lastAttemptAt: string;
+}
+
+function formatProgressDate(iso: string) {
+  return new Date(iso).toLocaleDateString('es-PY', {
+    day: '2-digit',
+    month: 'short',
+  });
+}
 
 export default function LabsPage() {
   const { isDarkMode } = useTheme();
   const { t } = useLanguage();
   const { user } = useSupabaseAuth();
+  const [examResults, setExamResults] = useState<ExamProgressResult[]>([]);
+
+  useEffect(() => {
+    let active = true;
+
+    if (!user) {
+      setExamResults([]);
+      return () => {
+        active = false;
+      };
+    }
+
+    getExamResultsAction()
+      .then((res) => {
+        if (!active) return;
+        setExamResults((res.data as ExamProgressResult[] | null) ?? []);
+      })
+      .catch(() => {
+        if (active) setExamResults([]);
+      });
+
+    return () => {
+      active = false;
+    };
+  }, [user]);
 
   const toolCategories = [
     {
@@ -277,6 +330,39 @@ export default function LabsPage() {
     },
   ];
 
+  const progressByTool = useMemo(() => {
+    const progress = new Map<string, ToolProgress>();
+
+    for (const result of examResults) {
+      const maxScore =
+        result.max_possible_score ?? result.total_questions ?? result.score;
+      const current = progress.get(result.exam_type);
+      const currentBest = current?.bestPercentage ?? -1;
+      const isBetter = result.percentage > currentBest;
+
+      progress.set(result.exam_type, {
+        passed:
+          Boolean(current?.passed) ||
+          (result.exam_mode === 'exam' && result.passed),
+        bestScore: isBetter
+          ? result.score
+          : (current?.bestScore ?? result.score),
+        maxScore: isBetter ? maxScore : (current?.maxScore ?? maxScore),
+        bestPercentage: isBetter
+          ? result.percentage
+          : (current?.bestPercentage ?? result.percentage),
+        lastAttemptAt:
+          !current ||
+          new Date(result.created_at).getTime() >
+            new Date(current.lastAttemptAt).getTime()
+            ? result.created_at
+            : current.lastAttemptAt,
+      });
+    }
+
+    return progress;
+  }, [examResults]);
+
   return (
     <div
       className={`min-h-screen py-12 md:py-16 transition-colors duration-300 ${
@@ -382,6 +468,8 @@ export default function LabsPage() {
               .filter((tool) => tool.featured)
               .slice(0, 3)
               .map((tool, index) => {
+                const progress = progressByTool.get(tool.id);
+
                 return (
                   <Link
                     key={tool.id}
@@ -414,6 +502,11 @@ export default function LabsPage() {
                           >
                             {tool.name}
                           </h3>
+                          {progress?.passed && (
+                            <span className="rounded-full bg-emerald-500/15 px-2 py-0.5 text-[10px] font-bold uppercase text-emerald-400">
+                              Aprobado
+                            </span>
+                          )}
                         </div>
                         <p
                           className={`text-xs ${
@@ -422,6 +515,18 @@ export default function LabsPage() {
                         >
                           {tool.description}
                         </p>
+                        {progress && (
+                          <p
+                            className={`mt-2 text-xs font-semibold ${
+                              isDarkMode
+                                ? 'text-emerald-300'
+                                : 'text-emerald-700'
+                            }`}
+                          >
+                            Mejor: {progress.bestScore}/{progress.maxScore} (
+                            {Math.round(progress.bestPercentage)}%)
+                          </p>
+                        )}
                       </div>
                     </div>
                   </Link>
@@ -455,6 +560,8 @@ export default function LabsPage() {
               {/* Tools Grid */}
               <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
                 {category.tools.map((tool) => {
+                  const progress = progressByTool.get(tool.id);
+
                   return (
                     <Link
                       key={tool.id}
@@ -470,6 +577,11 @@ export default function LabsPage() {
                         <div className="flex items-start justify-between gap-2 mb-3">
                           <div className="text-3xl">{tool.icon}</div>
                           <div className="flex flex-col items-end gap-2">
+                            {progress?.passed && (
+                              <span className="px-2 py-1 rounded-full text-xs font-semibold bg-emerald-100 text-emerald-800 border border-emerald-300">
+                                Aprobado
+                              </span>
+                            )}
                             {tool.featured && (
                               <span
                                 className={`px-2 py-1 rounded-full text-xs font-semibold ${
@@ -492,6 +604,28 @@ export default function LabsPage() {
                         <p className="text-white/90 text-sm">
                           {tool.description}
                         </p>
+                        {progress && (
+                          <div className="mt-4 rounded-lg bg-white/15 p-3 text-sm backdrop-blur-sm">
+                            <div className="flex items-center justify-between gap-3 font-semibold">
+                              <span>Mejor puntaje</span>
+                              <span>
+                                {progress.bestScore}/{progress.maxScore}
+                              </span>
+                            </div>
+                            <div className="mt-2 h-2 overflow-hidden rounded-full bg-white/25">
+                              <div
+                                className="h-full rounded-full bg-white"
+                                style={{
+                                  width: `${Math.min(100, Math.max(0, progress.bestPercentage))}%`,
+                                }}
+                              />
+                            </div>
+                            <p className="mt-2 text-xs text-white/85">
+                              Ultimo intento:{' '}
+                              {formatProgressDate(progress.lastAttemptAt)}
+                            </p>
+                          </div>
+                        )}
                       </div>
                       <div className="p-6 shrink-0">
                         <div className="flex items-center justify-between">
@@ -500,7 +634,11 @@ export default function LabsPage() {
                               isDarkMode ? 'text-slate-400' : 'text-brand-muted'
                             }`}
                           >
-                            {t('labs.action')}
+                            {progress?.passed
+                              ? 'Mejorar puntaje'
+                              : progress
+                                ? 'Reintentar'
+                                : t('labs.action')}
                           </span>
                           <svg
                             className={`w-5 h-5 transition-colors ${

--- a/apps/frontend/src/app/ranking/page.tsx
+++ b/apps/frontend/src/app/ranking/page.tsx
@@ -38,6 +38,7 @@ interface XpRankingEntry {
   achievementCount: number;
   lastActivityAt: string | null;
   mainBadge: string | null;
+  isCurrentUser: boolean;
 }
 
 interface XpRankingResponse {
@@ -214,13 +215,7 @@ function LevelBar({
 
 // ── XP Comunidad tab ──────────────────────────────────────────────────────────
 
-function XpComunidadTab({
-  isDarkMode,
-  currentUserName,
-}: {
-  isDarkMode: boolean;
-  currentUserName: string | null;
-}) {
+function XpComunidadTab({ isDarkMode }: { isDarkMode: boolean }) {
   const [data, setData] = useState<XpRankingResponse | null>(null);
   const [loading, setLoading] = useState(true);
   const [page, setPage] = useState(1);
@@ -453,8 +448,7 @@ function XpComunidadTab({
 
         {/* Filas */}
         {(isFirstPage ? rest : data.data).map((entry, i, arr) => {
-          const isCurrentUser =
-            currentUserName !== null && entry.displayName === currentUserName;
+          const isCurrentUser = entry.isCurrentUser;
           return (
             <div
               key={entry.position}
@@ -925,14 +919,7 @@ export default function RankingPage() {
         {isReportes ? (
           <ReportadoresTab isDarkMode={isDarkMode} />
         ) : isXp ? (
-          <XpComunidadTab
-            isDarkMode={isDarkMode}
-            currentUserName={
-              user?.user_metadata?.full_name ||
-              user?.user_metadata?.display_name ||
-              null
-            }
-          />
+          <XpComunidadTab isDarkMode={isDarkMode} />
         ) : isLoading ? (
           <div className="flex justify-center py-16">
             <div className="animate-spin rounded-full h-10 w-10 border-t-2 border-indigo-500" />


### PR DESCRIPTION
## Summary
- Shows user progress badges, best scores, last attempt dates, and retry/improve CTAs in `/labs`.
- Marks the current XP ranking row by server-side user identity instead of display name.
- Adds ISTQB LATAM LO comparison and visible save-error feedback in the results screen.

Closes #111, #112. Partially addresses #113.

## Verification
- `pnpm --filter @aiquaa/frontend type-check` passed.
- Pre-push hook passed: frontend type-check, backend type-check, backend unit tests.
- `pnpm --filter @aiquaa/frontend test` still has pre-existing unrelated auth/register/mock failures under remediation; changed files type-check clean.
- Note: Docker is unavailable locally, so DB-backed integration setup was skipped by the existing backend test harness.