### PR TITLE
feat(frontend): complete ISTQB result insights

### DIFF
--- a/apps/frontend/src/actions/exams.ts
+++ b/apps/frontend/src/actions/exams.ts
@@ -238,6 +238,35 @@ export async function getIstqbLatamComparisonAction() {
   return { data: comparison };
 }
 
+export async function getIstqbAttemptHistoryAction(limit = 6) {
+  const supabase = createClient();
+  const {
+    data: { user },
+    error: userError,
+  } = await supabase.auth.getUser();
+  if (userError || !user) return { error: 'No autenticado', data: null };
+
+  const { data, error } = await supabase
+    .from('exam_results')
+    .select(
+      'id, score, total_questions, max_possible_score, passed, percentage, time_spent, model, language, created_at'
+    )
+    .eq('user_id', user.id)
+    .eq('exam_type', 'istqb')
+    .eq('exam_mode', 'exam')
+    .order('created_at', { ascending: false })
+    .limit(limit);
+
+  if (error) return { error: error.message, data: null };
+
+  return {
+    data: (data ?? []).sort(
+      (a, b) =>
+        new Date(a.created_at).getTime() - new Date(b.created_at).getTime()
+    ),
+  };
+}
+
 export async function getMyXpProfileAction() {
   const supabase = createClient();
   const {

--- a/apps/frontend/src/app/labs/istqb/__tests__/utils.test.ts
+++ b/apps/frontend/src/app/labs/istqb/__tests__/utils.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest';
+import type { ExamQuestion } from '../types';
+import { exportToCSV, generateExamResult } from '../utils';
+
+const questions: ExamQuestion[] = [
+  {
+    id: 1,
+    questionText: 'What is testing?',
+    options: [
+      { label: 'A', text: 'Finding all bugs' },
+      { label: 'B', text: 'Evaluating work products' },
+    ],
+    correctAnswer: ['B'],
+    learningObjective: 'LO1.1',
+    kLevel: 'K1',
+    points: 1,
+    type: 'single',
+    explanations: {
+      A: { correct: false, explanation: 'Testing cannot find every bug.' },
+      B: { correct: true, explanation: 'Testing evaluates quality.' },
+    },
+  },
+  {
+    id: 2,
+    questionText: 'Which technique is black-box?',
+    options: [
+      { label: 'A', text: 'Equivalence partitioning' },
+      { label: 'B', text: 'Statement coverage' },
+    ],
+    correctAnswer: ['A'],
+    learningObjective: 'LO4.2',
+    kLevel: 'K2',
+    points: 1,
+    type: 'single',
+    explanations: {
+      A: { correct: true, explanation: 'It is a black-box technique.' },
+      B: { correct: false, explanation: 'It is a white-box technique.' },
+    },
+  },
+];
+
+describe('ISTQB result utilities', () => {
+  it('includes per-question time in generated results', () => {
+    const result = generateExamResult(
+      'QA Tester',
+      questions,
+      new Map([
+        [1, ['B']],
+        [2, ['B']],
+      ]),
+      90,
+      2,
+      new Map([
+        [1, 35],
+        [2, 55],
+      ])
+    );
+
+    expect(result.answers.map((answer) => answer.timeSpent)).toEqual([35, 55]);
+    expect(result.learningObjectiveAnalysis).toEqual([
+      {
+        learningObjective: 'LO1.1',
+        totalQuestions: 1,
+        correctAnswers: 1,
+        percentage: 100,
+      },
+      {
+        learningObjective: 'LO4.2',
+        totalQuestions: 1,
+        correctAnswers: 0,
+        percentage: 0,
+      },
+    ]);
+  });
+
+  it('exports per-question time to CSV', () => {
+    const result = generateExamResult(
+      'QA Tester',
+      questions,
+      new Map([[1, ['B']]]),
+      35,
+      1,
+      new Map([[1, 35]])
+    );
+
+    const csv = exportToCSV(result);
+
+    expect(csv).toContain('Tiempo por Pregunta (s)');
+    expect(csv).toContain(',35');
+  });
+});

--- a/apps/frontend/src/app/labs/istqb/components/ExamSimulator.tsx
+++ b/apps/frontend/src/app/labs/istqb/components/ExamSimulator.tsx
@@ -12,8 +12,9 @@ interface ExamSimulatorProps {
   mode: 'exam' | 'training';
   examData: ExamData;
   onReset: () => void;
+  model?: string;
+  processCode?: string;
   language: 'es' | 'en';
-  onExamComplete?: (result: import('../types').ExamResult) => void;
 }
 
 export default function ExamSimulator({
@@ -21,24 +22,30 @@ export default function ExamSimulator({
   mode,
   examData,
   onReset,
+  model,
+  processCode,
   language,
-  onExamComplete,
 }: ExamSimulatorProps) {
   const { isDarkMode } = useTheme();
   const [questions, setQuestions] = useState<ExamQuestion[]>([]);
   const [currentQuestionIndex, setCurrentQuestionIndex] = useState(0);
   const [answers, setAnswers] = useState<Map<number, string[]>>(new Map());
-  const [markedForReview, setMarkedForReview] = useState<Set<number>>(new Set());
+  const [markedForReview, setMarkedForReview] = useState<Set<number>>(
+    new Set()
+  );
   const [timeRemaining, setTimeRemaining] = useState(
-    mode === 'exam' ? examData.examInfo.timeLimit * 60 : 0,
+    mode === 'exam' ? examData.examInfo.timeLimit * 60 : 0
   );
   const [isRunning, setIsRunning] = useState(mode === 'exam');
   const [showSubmitDialog, setShowSubmitDialog] = useState(false);
   const [hasSubmitted, setHasSubmitted] = useState(false);
   const [startTime] = useState(Date.now());
-  const savedRef = useRef(false);
   const questionsInitialized = useRef(false);
+  // eslint-disable-next-line no-unused-vars
   const submitRef = useRef<(autoSubmit?: boolean) => void>(() => {});
+  const activeQuestionIdRef = useRef<number | null>(null);
+  const questionStartedAtRef = useRef(Date.now());
+  const questionDurationsRef = useRef<Map<number, number>>(new Map());
 
   const t = {
     es: {
@@ -59,10 +66,12 @@ export default function ExamSimulator({
       submit: '✓ Enviar Examen',
       submitEarly: 'Enviar examen antes de tiempo',
       submitDialogTitle: '¿Enviar Examen?',
-      submitDialogMessage: 'Está a punto de enviar su examen. Una vez enviado, no podrá realizar cambios.',
+      submitDialogMessage:
+        'Está a punto de enviar su examen. Una vez enviado, no podrá realizar cambios.',
       summary: 'Resumen:',
       marked: 'Marcadas para revisar',
-      unansweredWarning: (count: number) => `Tiene ${count} pregunta(s) sin responder.`,
+      unansweredWarning: (count: number) =>
+        `Tiene ${count} pregunta(s) sin responder.`,
       cancel: 'Cancelar',
       confirm: '✓ Confirmar Envío',
     },
@@ -84,16 +93,33 @@ export default function ExamSimulator({
       submit: '✓ Submit Exam',
       submitEarly: 'Submit exam early',
       submitDialogTitle: 'Submit Exam?',
-      submitDialogMessage: 'You are about to submit your exam. Once submitted, you cannot make changes.',
+      submitDialogMessage:
+        'You are about to submit your exam. Once submitted, you cannot make changes.',
       summary: 'Summary:',
       marked: 'Marked for review',
-      unansweredWarning: (count: number) => `You have ${count} unanswered question(s).`,
+      unansweredWarning: (count: number) =>
+        `You have ${count} unanswered question(s).`,
       cancel: 'Cancel',
       confirm: '✓ Confirm Submit',
     },
   };
 
   const text = t[language as keyof typeof t];
+
+  const recordCurrentQuestionTime = useCallback(() => {
+    const questionId = activeQuestionIdRef.current;
+    if (!questionId) return;
+
+    const elapsed = Math.max(
+      0,
+      Math.round((Date.now() - questionStartedAtRef.current) / 1000)
+    );
+    if (elapsed === 0) return;
+
+    const current = questionDurationsRef.current.get(questionId) ?? 0;
+    questionDurationsRef.current.set(questionId, current + elapsed);
+    questionStartedAtRef.current = Date.now();
+  }, []);
 
   const handleSubmitExam = useCallback(
     (autoSubmit = false) => {
@@ -102,10 +128,11 @@ export default function ExamSimulator({
         return;
       }
 
+      recordCurrentQuestionTime();
       setIsRunning(false);
       setHasSubmitted(true);
     },
-    [],
+    [recordCurrentQuestionTime]
   );
 
   useEffect(() => {
@@ -113,10 +140,11 @@ export default function ExamSimulator({
   });
 
   const confirmSubmit = useCallback(() => {
+    recordCurrentQuestionTime();
     setShowSubmitDialog(false);
     setIsRunning(false);
     setHasSubmitted(true);
-  }, []);
+  }, [recordCurrentQuestionTime]);
 
   const handleAnswerChange = useCallback(
     (questionId: number, selectedAnswers: string[]) => {
@@ -126,7 +154,7 @@ export default function ExamSimulator({
         return newAnswers;
       });
     },
-    [],
+    []
   );
 
   const toggleMarkForReview = useCallback(() => {
@@ -146,15 +174,17 @@ export default function ExamSimulator({
 
   const goToNextQuestion = useCallback(() => {
     if (currentQuestionIndex < questions.length - 1) {
+      recordCurrentQuestionTime();
       setCurrentQuestionIndex((prev: number) => prev + 1);
     }
-  }, [currentQuestionIndex, questions.length]);
+  }, [currentQuestionIndex, questions.length, recordCurrentQuestionTime]);
 
   const goToPreviousQuestion = useCallback(() => {
     if (currentQuestionIndex > 0) {
+      recordCurrentQuestionTime();
       setCurrentQuestionIndex((prev: number) => prev - 1);
     }
-  }, [currentQuestionIndex]);
+  }, [currentQuestionIndex, recordCurrentQuestionTime]);
 
   useEffect(() => {
     if (questionsInitialized.current) return;
@@ -162,7 +192,7 @@ export default function ExamSimulator({
     const preparedQuestions = prepareExamQuestions(
       examData.questions,
       examData.examInfo.totalQuestions,
-      true,
+      true
     );
     setQuestions(preparedQuestions);
   }, [examData]);
@@ -182,6 +212,14 @@ export default function ExamSimulator({
 
     return () => clearInterval(timer);
   }, [isRunning, mode]);
+
+  useEffect(() => {
+    const questionId = questions[currentQuestionIndex]?.id;
+    if (!questionId) return;
+
+    activeQuestionIdRef.current = questionId;
+    questionStartedAtRef.current = Date.now();
+  }, [currentQuestionIndex, questions]);
 
   if (questions.length === 0) {
     return (
@@ -203,14 +241,19 @@ export default function ExamSimulator({
       answers,
       timeSpent,
       examData.examInfo.passingScore,
+      questionDurationsRef.current
     );
 
-    if (onExamComplete && !savedRef.current) {
-      savedRef.current = true;
-      onExamComplete(result);
-    }
-
-    return <ResultsScreen result={result} onReset={onReset} mode={mode} language={language} />;
+    return (
+      <ResultsScreen
+        result={result}
+        onReset={onReset}
+        mode={mode}
+        model={model}
+        processCode={processCode}
+        language={language}
+      />
+    );
   }
 
   const currentQuestion = questions[currentQuestionIndex];
@@ -221,12 +264,16 @@ export default function ExamSimulator({
   const isMarked = markedForReview.has(currentQuestion.id);
 
   return (
-    <div className={`min-h-screen py-8 transition-colors ${isDarkMode ? 'bg-slate-900' : 'bg-gray-50'}`}>
+    <div
+      className={`min-h-screen py-8 transition-colors ${isDarkMode ? 'bg-slate-900' : 'bg-gray-50'}`}
+    >
       <div className="container mx-auto px-4 max-w-6xl">
         <div className="mb-6">
           <div className="flex flex-col md:flex-row justify-between items-start md:items-center gap-4 mb-4">
             <div>
-              <h1 className={`text-2xl font-bold ${isDarkMode ? 'text-white' : 'text-gray-900'}`}>
+              <h1
+                className={`text-2xl font-bold ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
+              >
                 {text.title}
               </h1>
               <p className={isDarkMode ? 'text-slate-400' : 'text-gray-600'}>
@@ -235,24 +282,36 @@ export default function ExamSimulator({
             </div>
 
             {mode === 'exam' && (
-              <div className={`p-4 rounded-lg shadow-lg border-2 ${timeRemaining < 300
-                ? isDarkMode
-                  ? 'bg-red-900/30 border-red-700'
-                  : 'bg-red-50 border-red-300'
-                : isDarkMode
-                  ? 'bg-slate-800 border-slate-700'
-                  : 'bg-white border-gray-200'
-                }`}>
+              <div
+                className={`p-4 rounded-lg shadow-lg border-2 ${
+                  timeRemaining < 300
+                    ? isDarkMode
+                      ? 'bg-red-900/30 border-red-700'
+                      : 'bg-red-50 border-red-300'
+                    : isDarkMode
+                      ? 'bg-slate-800 border-slate-700'
+                      : 'bg-white border-gray-200'
+                }`}
+              >
                 <div className="flex items-center gap-3">
                   <span className="text-3xl">⏱️</span>
                   <div>
-                    <p className={`text-sm font-medium ${isDarkMode ? 'text-slate-400' : 'text-gray-600'}`}>
+                    <p
+                      className={`text-sm font-medium ${isDarkMode ? 'text-slate-400' : 'text-gray-600'}`}
+                    >
                       {text.timeRemaining}
                     </p>
-                    <p className={`text-2xl font-bold ${timeRemaining < 300
-                      ? isDarkMode ? 'text-red-300' : 'text-red-700'
-                      : isDarkMode ? 'text-slate-100' : 'text-gray-900'
-                      }`}>
+                    <p
+                      className={`text-2xl font-bold ${
+                        timeRemaining < 300
+                          ? isDarkMode
+                            ? 'text-red-300'
+                            : 'text-red-700'
+                          : isDarkMode
+                            ? 'text-slate-100'
+                            : 'text-gray-900'
+                      }`}
+                    >
                       {formatTime(timeRemaining)}
                     </p>
                   </div>
@@ -262,20 +321,31 @@ export default function ExamSimulator({
           </div>
 
           <div className="space-y-2">
-            <div className={`flex justify-between text-sm font-medium ${isDarkMode ? 'text-slate-300' : 'text-gray-700'}`}>
+            <div
+              className={`flex justify-between text-sm font-medium ${isDarkMode ? 'text-slate-300' : 'text-gray-700'}`}
+            >
               <span>
-                📝 {text.question} {currentQuestionIndex + 1} {text.of} {questions.length}
+                📝 {text.question} {currentQuestionIndex + 1} {text.of}{' '}
+                {questions.length}
               </span>
               <span>
-                ✓ {text.answered}: <strong>{answeredCount}</strong> | ⏳ {text.unanswered}: <strong>{unansweredCount}</strong>
+                ✓ {text.answered}: <strong>{answeredCount}</strong> | ⏳{' '}
+                {text.unanswered}: <strong>{unansweredCount}</strong>
               </span>
             </div>
-            <div className={`w-full rounded-full h-3 shadow-inner ${isDarkMode ? 'bg-slate-700' : 'bg-gray-200'}`}>
+            <div
+              className={`w-full rounded-full h-3 shadow-inner ${isDarkMode ? 'bg-slate-700' : 'bg-gray-200'}`}
+            >
               <div
-                className={`h-3 rounded-full transition-all duration-300 ${progress === 100
-                  ? isDarkMode ? 'bg-green-500' : 'bg-green-600'
-                  : isDarkMode ? 'bg-amber-500' : 'bg-amber-600'
-                  }`}
+                className={`h-3 rounded-full transition-all duration-300 ${
+                  progress === 100
+                    ? isDarkMode
+                      ? 'bg-green-500'
+                      : 'bg-green-600'
+                    : isDarkMode
+                      ? 'bg-amber-500'
+                      : 'bg-amber-600'
+                }`}
                 style={{ width: `${progress}%` }}
               />
             </div>
@@ -302,20 +372,23 @@ export default function ExamSimulator({
           language={language}
         />
 
-        <div className={`mt-6 rounded-lg shadow-lg border ${isDarkMode ? 'bg-slate-800 border-slate-700' : 'bg-white border-gray-200'}`}>
+        <div
+          className={`mt-6 rounded-lg shadow-lg border ${isDarkMode ? 'bg-slate-800 border-slate-700' : 'bg-white border-gray-200'}`}
+        >
           <div className="p-6">
             <div className="flex flex-col md:flex-row justify-between items-center gap-4">
               <button
                 onClick={goToPreviousQuestion}
                 disabled={currentQuestionIndex === 0}
-                className={`px-5 py-3 rounded-lg font-semibold transition-all w-full md:w-auto ${currentQuestionIndex === 0
-                  ? isDarkMode
-                    ? 'bg-slate-700 text-slate-500 cursor-not-allowed border-2 border-slate-700'
-                    : 'bg-gray-200 text-gray-400 cursor-not-allowed border-2 border-gray-200'
-                  : isDarkMode
-                    ? 'bg-slate-700 hover:bg-slate-600 text-slate-100 border-2 border-slate-600 hover:border-slate-500'
-                    : 'bg-white hover:bg-gray-50 text-gray-900 border-2 border-gray-300 hover:border-gray-400'
-                  }`}
+                className={`px-5 py-3 rounded-lg font-semibold transition-all w-full md:w-auto ${
+                  currentQuestionIndex === 0
+                    ? isDarkMode
+                      ? 'bg-slate-700 text-slate-500 cursor-not-allowed border-2 border-slate-700'
+                      : 'bg-gray-200 text-gray-400 cursor-not-allowed border-2 border-gray-200'
+                    : isDarkMode
+                      ? 'bg-slate-700 hover:bg-slate-600 text-slate-100 border-2 border-slate-600 hover:border-slate-500'
+                      : 'bg-white hover:bg-gray-50 text-gray-900 border-2 border-gray-300 hover:border-gray-400'
+                }`}
               >
                 {text.previous}
               </button>
@@ -323,12 +396,13 @@ export default function ExamSimulator({
               <div className="flex gap-3 w-full md:w-auto">
                 <button
                   onClick={toggleMarkForReview}
-                  className={`px-5 py-3 rounded-lg font-semibold transition-all flex-1 md:flex-none ${isMarked
-                    ? 'bg-gradient-to-r from-amber-600 to-amber-500 hover:from-amber-700 hover:to-amber-600 text-white shadow-lg'
-                    : isDarkMode
-                      ? 'bg-slate-700 hover:bg-slate-600 text-slate-100 border-2 border-slate-600'
-                      : 'bg-white hover:bg-gray-50 text-gray-900 border-2 border-gray-300'
-                    }`}
+                  className={`px-5 py-3 rounded-lg font-semibold transition-all flex-1 md:flex-none ${
+                    isMarked
+                      ? 'bg-gradient-to-r from-amber-600 to-amber-500 hover:from-amber-700 hover:to-amber-600 text-white shadow-lg'
+                      : isDarkMode
+                        ? 'bg-slate-700 hover:bg-slate-600 text-slate-100 border-2 border-slate-600'
+                        : 'bg-white hover:bg-gray-50 text-gray-900 border-2 border-gray-300'
+                  }`}
                 >
                   🚩 {isMarked ? text.unmark : text.mark}
                 </button>
@@ -346,14 +420,15 @@ export default function ExamSimulator({
               <button
                 onClick={goToNextQuestion}
                 disabled={isLastQuestion}
-                className={`px-5 py-3 rounded-lg font-semibold transition-all w-full md:w-auto ${isLastQuestion
-                  ? isDarkMode
-                    ? 'bg-slate-700 text-slate-500 cursor-not-allowed border-2 border-slate-700'
-                    : 'bg-gray-200 text-gray-400 cursor-not-allowed border-2 border-gray-200'
-                  : isDarkMode
-                    ? 'bg-slate-700 hover:bg-slate-600 text-slate-100 border-2 border-slate-600 hover:border-slate-500'
-                    : 'bg-white hover:bg-gray-50 text-gray-900 border-2 border-gray-300 hover:border-gray-400'
-                  }`}
+                className={`px-5 py-3 rounded-lg font-semibold transition-all w-full md:w-auto ${
+                  isLastQuestion
+                    ? isDarkMode
+                      ? 'bg-slate-700 text-slate-500 cursor-not-allowed border-2 border-slate-700'
+                      : 'bg-gray-200 text-gray-400 cursor-not-allowed border-2 border-gray-200'
+                    : isDarkMode
+                      ? 'bg-slate-700 hover:bg-slate-600 text-slate-100 border-2 border-slate-600 hover:border-slate-500'
+                      : 'bg-white hover:bg-gray-50 text-gray-900 border-2 border-gray-300 hover:border-gray-400'
+                }`}
               >
                 {text.next}
               </button>
@@ -374,26 +449,42 @@ export default function ExamSimulator({
 
         {showSubmitDialog && (
           <div className="fixed inset-0 bg-black/70 backdrop-blur-sm flex items-center justify-center z-50 p-4">
-            <div className={`rounded-xl shadow-2xl max-w-md w-full border-2 ${isDarkMode
-              ? 'bg-slate-800 border-slate-700'
-              : 'bg-white border-gray-200'
-              }`}>
+            <div
+              className={`rounded-xl shadow-2xl max-w-md w-full border-2 ${
+                isDarkMode
+                  ? 'bg-slate-800 border-slate-700'
+                  : 'bg-white border-gray-200'
+              }`}
+            >
               <div className="p-6">
                 <div className="flex items-center gap-3 mb-4">
                   <span className="text-3xl">📤</span>
-                  <h2 className={`text-2xl font-bold ${isDarkMode ? 'text-slate-100' : 'text-gray-900'}`}>
+                  <h2
+                    className={`text-2xl font-bold ${isDarkMode ? 'text-slate-100' : 'text-gray-900'}`}
+                  >
                     {text.submitDialogTitle}
                   </h2>
                 </div>
-                <p className={`mb-4 text-base ${isDarkMode ? 'text-slate-300' : 'text-gray-600'}`}>
+                <p
+                  className={`mb-4 text-base ${isDarkMode ? 'text-slate-300' : 'text-gray-600'}`}
+                >
                   {text.submitDialogMessage}
                 </p>
-                <div className={`mb-6 p-4 rounded-lg border ${isDarkMode
-                  ? 'bg-slate-700/50 border-slate-600'
-                  : 'bg-gray-50 border-gray-200'
-                  }`}>
-                  <p className={`font-semibold mb-3 ${isDarkMode ? 'text-slate-200' : 'text-gray-900'}`}>{text.summary}</p>
-                  <ul className={`space-y-2 ${isDarkMode ? 'text-slate-300' : 'text-gray-700'}`}>
+                <div
+                  className={`mb-6 p-4 rounded-lg border ${
+                    isDarkMode
+                      ? 'bg-slate-700/50 border-slate-600'
+                      : 'bg-gray-50 border-gray-200'
+                  }`}
+                >
+                  <p
+                    className={`font-semibold mb-3 ${isDarkMode ? 'text-slate-200' : 'text-gray-900'}`}
+                  >
+                    {text.summary}
+                  </p>
+                  <ul
+                    className={`space-y-2 ${isDarkMode ? 'text-slate-300' : 'text-gray-700'}`}
+                  >
                     <li className="flex items-center gap-2">
                       <span className="text-green-500">✓</span>
                       {text.answered}: <strong>{answeredCount}</strong>
@@ -408,10 +499,13 @@ export default function ExamSimulator({
                     </li>
                   </ul>
                   {unansweredCount > 0 && (
-                    <div className={`mt-4 p-3 rounded-lg border-2 ${isDarkMode
-                      ? 'bg-red-900/30 border-red-700 text-red-300'
-                      : 'bg-red-50 border-red-300 text-red-800'
-                      }`}>
+                    <div
+                      className={`mt-4 p-3 rounded-lg border-2 ${
+                        isDarkMode
+                          ? 'bg-red-900/30 border-red-700 text-red-300'
+                          : 'bg-red-50 border-red-300 text-red-800'
+                      }`}
+                    >
                       <p className="font-semibold flex items-center gap-2">
                         <span>⚠️</span>
                         {text.unansweredWarning(unansweredCount)}
@@ -422,10 +516,11 @@ export default function ExamSimulator({
                 <div className="flex gap-3">
                   <button
                     onClick={() => setShowSubmitDialog(false)}
-                    className={`flex-1 px-4 py-3 rounded-lg font-semibold transition-all ${isDarkMode
-                      ? 'bg-slate-700 hover:bg-slate-600 text-slate-200 border-2 border-slate-600'
-                      : 'bg-gray-200 hover:bg-gray-300 text-gray-800 border-2 border-gray-300'
-                      }`}
+                    className={`flex-1 px-4 py-3 rounded-lg font-semibold transition-all ${
+                      isDarkMode
+                        ? 'bg-slate-700 hover:bg-slate-600 text-slate-200 border-2 border-slate-600'
+                        : 'bg-gray-200 hover:bg-gray-300 text-gray-800 border-2 border-gray-300'
+                    }`}
                   >
                     {text.cancel}
                   </button>

--- a/apps/frontend/src/app/labs/istqb/components/ResultsScreen.tsx
+++ b/apps/frontend/src/app/labs/istqb/components/ResultsScreen.tsx
@@ -2,7 +2,10 @@
 
 import { useEffect, useState } from 'react';
 import { useTheme } from '@/contexts/ThemeContext';
-import { getIstqbLatamComparisonAction } from '@/actions/exams';
+import {
+  getIstqbAttemptHistoryAction,
+  getIstqbLatamComparisonAction,
+} from '@/actions/exams';
 import type { ExamResult } from '../types';
 import { exportToCSV, downloadCSV, formatTime } from '../utils';
 import { generateExamPDF } from '../utils/pdfExport';
@@ -12,6 +15,8 @@ interface ResultsScreenProps {
   result: ExamResult;
   onReset: () => void;
   mode: 'exam' | 'training';
+  model?: string;
+  processCode?: string;
   language: 'es' | 'en';
 }
 
@@ -21,10 +26,106 @@ interface LatamComparison {
   sampleSize: number;
 }
 
+interface AttemptHistory {
+  id: string;
+  score: number;
+  total_questions: number;
+  max_possible_score: number | null;
+  passed: boolean;
+  percentage: number;
+  time_spent: number;
+  model: string | null;
+  language: string | null;
+  created_at: string;
+}
+
+const ISTQB_SYLLABUS_PATH =
+  '/resources/istqb/CTFL-v4.0-ES-Programa-de-Estudio.pdf';
+
+function getStudyRecommendation(
+  learningObjective: string,
+  language: 'es' | 'en'
+) {
+  const chapter = learningObjective.match(/LO\s*(\d+)/i)?.[1];
+  const recommendations = {
+    es: {
+      defaultTitle: 'Repasar el syllabus CTFL v4.0',
+      defaultDescription:
+        'Relee el objetivo, sus palabras clave y los ejemplos oficiales.',
+      chapters: {
+        '1': [
+          'Fundamentos de testing',
+          'Enfocate en objetivos, principios y valor del testing.',
+        ],
+        '2': [
+          'Testing en el ciclo de vida',
+          'Repasa niveles, tipos y enfoques de desarrollo.',
+        ],
+        '3': [
+          'Testing estatico',
+          'Practica revisiones, analisis estatico y defectos tempranos.',
+        ],
+        '4': [
+          'Analisis y diseno de pruebas',
+          'Refuerza tecnicas de caja negra, caja blanca y basadas en experiencia.',
+        ],
+        '5': [
+          'Gestion de actividades de testing',
+          'Revisa planificacion, riesgos, monitoreo y control.',
+        ],
+        '6': [
+          'Herramientas de testing',
+          'Repasa beneficios, riesgos y criterios de adopcion de herramientas.',
+        ],
+      },
+    },
+    en: {
+      defaultTitle: 'Review the CTFL v4.0 syllabus',
+      defaultDescription:
+        'Re-read the objective, keywords, and official examples.',
+      chapters: {
+        '1': [
+          'Testing fundamentals',
+          'Focus on testing objectives, principles, and value.',
+        ],
+        '2': [
+          'Testing through the SDLC',
+          'Review levels, types, and development approaches.',
+        ],
+        '3': [
+          'Static testing',
+          'Practice reviews, static analysis, and early defect detection.',
+        ],
+        '4': [
+          'Test analysis and design',
+          'Strengthen black-box, white-box, and experience-based techniques.',
+        ],
+        '5': [
+          'Managing test activities',
+          'Review planning, risks, monitoring, and control.',
+        ],
+        '6': [
+          'Test tools',
+          'Review benefits, risks, and adoption criteria for tools.',
+        ],
+      },
+    },
+  } as const;
+
+  const localized = recommendations[language];
+  const [title, description] = localized.chapters[
+    chapter as keyof typeof localized.chapters
+  ] ?? [localized.defaultTitle, localized.defaultDescription];
+
+  return { title, description, href: ISTQB_SYLLABUS_PATH };
+}
+
 export default function ResultsScreen({
   result,
   onReset,
   mode,
+  model,
+  processCode,
   language,
 }: ResultsScreenProps) {
   const { isDarkMode } = useTheme();
@@ -36,6 +137,8 @@ export default function ResultsScreen({
   );
   const [latamComparison, setLatamComparison] = useState<LatamComparison[]>([]);
   const [latamLoading, setLatamLoading] = useState(true);
+  const [attemptHistory, setAttemptHistory] = useState<AttemptHistory[]>([]);
+  const [historyLoading, setHistoryLoading] = useState(true);
   const toggleExplanation = (questionId: number) => {
     setExpandedExplanations((prev) => {
       const next = new Set(prev);
@@ -44,7 +147,11 @@ export default function ResultsScreen({
       return next;
     });
   };
-  const { saveError } = useSubmitResults(result, mode);
+  const { isSaved, saveError } = useSubmitResults(result, mode, {
+    model,
+    language,
+    processCode,
+  });
 
   useEffect(() => {
     let active = true;
@@ -65,6 +172,35 @@ export default function ResultsScreen({
       active = false;
     };
   }, []);
+
+  useEffect(() => {
+    let active = true;
+
+    if (mode !== 'exam') {
+      setAttemptHistory([]);
+      setHistoryLoading(false);
+      return () => {
+        active = false;
+      };
+    }
+
+    setHistoryLoading(true);
+    getIstqbAttemptHistoryAction()
+      .then((res) => {
+        if (!active) return;
+        setAttemptHistory((res.data as AttemptHistory[] | null) ?? []);
+      })
+      .catch(() => {
+        if (active) setAttemptHistory([]);
+      })
+      .finally(() => {
+        if (active) setHistoryLoading(false);
+      });
+
+    return () => {
+      active = false;
+    };
+  }, [isSaved, mode]);
 
   const t = {
     es: {
@@ -107,6 +243,20 @@ export default function ResultsScreen({
       latamAverage: 'Promedio LATAM',
       sample: 'muestra',
       saveErrorTitle: 'No pudimos guardar tu resultado',
+      progressHistory: 'Historial de progreso',
+      historyLoading: 'Cargando historial...',
+      historyNoData:
+        'Rendi al menos dos examenes para ver tu curva de aprendizaje.',
+      studyRecommendations: 'Recomendaciones de estudio',
+      studyRecommendationsDesc:
+        'Prioriza estos objetivos antes del proximo intento.',
+      noStudyRecommendations:
+        'No hay recomendaciones urgentes: ningun LO quedo por debajo de 50%.',
+      openSyllabus: 'Abrir syllabus',
+      questionTime: 'Tiempo en pregunta',
+      averageQuestionTime: 'Promedio por pregunta',
+      fastestQuestion: 'Mas rapida',
+      slowestQuestion: 'Mas lenta',
       question: 'Pregunta',
       yourAnswer: 'Tu Respuesta:',
       correctAnswer: 'Respuesta Correcta:',
@@ -155,6 +305,19 @@ export default function ResultsScreen({
       latamAverage: 'LATAM average',
       sample: 'sample',
       saveErrorTitle: 'We could not save your result',
+      progressHistory: 'Progress history',
+      historyLoading: 'Loading history...',
+      historyNoData: 'Take at least two exams to see your learning curve.',
+      studyRecommendations: 'Study recommendations',
+      studyRecommendationsDesc:
+        'Prioritize these objectives before the next attempt.',
+      noStudyRecommendations:
+        'No urgent recommendations: no LO landed below 50%.',
+      openSyllabus: 'Open syllabus',
+      questionTime: 'Question time',
+      averageQuestionTime: 'Average per question',
+      fastestQuestion: 'Fastest',
+      slowestQuestion: 'Slowest',
       question: 'Question',
       yourAnswer: 'Your Answer:',
       correctAnswer: 'Correct Answer:',
@@ -182,6 +345,34 @@ export default function ResultsScreen({
   const hasLatamComparison = result.learningObjectiveAnalysis.some((lo) =>
     latamByLearningObjective.has(lo.learningObjective)
   );
+  const weakLearningObjectives = result.learningObjectiveAnalysis.filter(
+    (lo) => lo.percentage < 50
+  );
+  const questionTimes = result.answers
+    .map((answer) => answer.timeSpent)
+    .filter((time) => time > 0);
+  const averageQuestionTime =
+    questionTimes.length > 0
+      ? Math.round(
+          questionTimes.reduce((total, time) => total + time, 0) /
+            questionTimes.length
+        )
+      : 0;
+  const fastestQuestionTime =
+    questionTimes.length > 0 ? Math.min(...questionTimes) : 0;
+  const slowestQuestionTime =
+    questionTimes.length > 0 ? Math.max(...questionTimes) : 0;
+  const historyPoints =
+    attemptHistory.length > 1
+      ? attemptHistory
+          .map((attempt, index) => {
+            const x = 16 + (index * 288) / (attemptHistory.length - 1);
+            const clamped = Math.min(100, Math.max(0, attempt.percentage));
+            const y = 104 - clamped * 0.88;
+            return `${x},${y}`;
+          })
+          .join(' ')
+      : '';
 
   return (
     <div
@@ -603,6 +794,209 @@ export default function ResultsScreen({
                     </ul>
                   </div>
                 </div>
+
+                <div
+                  className={`p-5 rounded-xl border-2 shadow-sm ${
+                    isDarkMode
+                      ? 'border-blue-700 bg-blue-900/10'
+                      : 'border-blue-200 bg-blue-50/40'
+                  }`}
+                >
+                  <div className="flex flex-col gap-1 md:flex-row md:items-center md:justify-between">
+                    <h4
+                      className={`font-semibold ${
+                        isDarkMode ? 'text-blue-200' : 'text-blue-900'
+                      }`}
+                    >
+                      {text.progressHistory}
+                    </h4>
+                    {historyLoading && (
+                      <span
+                        className={`text-sm ${
+                          isDarkMode ? 'text-slate-300' : 'text-gray-600'
+                        }`}
+                      >
+                        {text.historyLoading}
+                      </span>
+                    )}
+                  </div>
+                  {!historyLoading && attemptHistory.length > 1 ? (
+                    <div className="mt-4">
+                      <svg
+                        viewBox="0 0 320 120"
+                        className="h-40 w-full"
+                        role="img"
+                        aria-label={text.progressHistory}
+                      >
+                        <line
+                          x1="16"
+                          y1="104"
+                          x2="304"
+                          y2="104"
+                          className={
+                            isDarkMode ? 'stroke-slate-600' : 'stroke-gray-300'
+                          }
+                          strokeWidth="1"
+                        />
+                        <line
+                          x1="16"
+                          y1="46.8"
+                          x2="304"
+                          y2="46.8"
+                          className={
+                            isDarkMode ? 'stroke-green-700' : 'stroke-green-300'
+                          }
+                          strokeDasharray="4 4"
+                          strokeWidth="1"
+                        />
+                        <polyline
+                          fill="none"
+                          points={historyPoints}
+                          className={
+                            isDarkMode ? 'stroke-amber-300' : 'stroke-amber-600'
+                          }
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          strokeWidth="3"
+                        />
+                        {attemptHistory.map((attempt, index) => {
+                          const x =
+                            16 + (index * 288) / (attemptHistory.length - 1);
+                          const clamped = Math.min(
+                            100,
+                            Math.max(0, attempt.percentage)
+                          );
+                          const y = 104 - clamped * 0.88;
+
+                          return (
+                            <circle
+                              key={attempt.id}
+                              cx={x}
+                              cy={y}
+                              r="4"
+                              className={
+                                attempt.passed
+                                  ? isDarkMode
+                                    ? 'fill-green-300'
+                                    : 'fill-green-600'
+                                  : isDarkMode
+                                    ? 'fill-red-300'
+                                    : 'fill-red-600'
+                              }
+                            />
+                          );
+                        })}
+                      </svg>
+                      <div className="mt-2 grid grid-cols-2 md:grid-cols-3 gap-2 text-xs">
+                        {attemptHistory.map((attempt) => (
+                          <div
+                            key={attempt.id}
+                            className={
+                              isDarkMode ? 'text-slate-300' : 'text-gray-700'
+                            }
+                          >
+                            {new Date(attempt.created_at).toLocaleDateString(
+                              language === 'es' ? 'es-PY' : 'en-US',
+                              { month: 'short', day: 'numeric' }
+                            )}
+                            : <strong>{attempt.percentage.toFixed(0)}%</strong>
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+                  ) : (
+                    !historyLoading && (
+                      <p
+                        className={`mt-3 text-sm ${
+                          isDarkMode ? 'text-slate-300' : 'text-gray-600'
+                        }`}
+                      >
+                        {text.historyNoData}
+                      </p>
+                    )
+                  )}
+                </div>
+
+                <div
+                  className={`p-5 rounded-xl border-2 shadow-sm ${
+                    isDarkMode
+                      ? 'border-purple-700 bg-purple-900/10'
+                      : 'border-purple-200 bg-purple-50/40'
+                  }`}
+                >
+                  <h4
+                    className={`font-semibold ${
+                      isDarkMode ? 'text-purple-200' : 'text-purple-900'
+                    }`}
+                  >
+                    {text.studyRecommendations}
+                  </h4>
+                  <p
+                    className={`mt-1 text-sm ${
+                      isDarkMode ? 'text-slate-300' : 'text-gray-600'
+                    }`}
+                  >
+                    {text.studyRecommendationsDesc}
+                  </p>
+                  {weakLearningObjectives.length > 0 ? (
+                    <div className="mt-4 space-y-3">
+                      {weakLearningObjectives.map((lo) => {
+                        const recommendation = getStudyRecommendation(
+                          lo.learningObjective,
+                          language
+                        );
+
+                        return (
+                          <div
+                            key={lo.learningObjective}
+                            className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between"
+                          >
+                            <div>
+                              <p
+                                className={`font-semibold ${
+                                  isDarkMode
+                                    ? 'text-slate-100'
+                                    : 'text-gray-900'
+                                }`}
+                              >
+                                {lo.learningObjective} - {recommendation.title}
+                              </p>
+                              <p
+                                className={`text-sm ${
+                                  isDarkMode
+                                    ? 'text-slate-300'
+                                    : 'text-gray-600'
+                                }`}
+                              >
+                                {recommendation.description}
+                              </p>
+                            </div>
+                            <a
+                              href={recommendation.href}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              className={`text-sm font-semibold underline decoration-dotted ${
+                                isDarkMode
+                                  ? 'text-purple-200 hover:text-white'
+                                  : 'text-purple-800 hover:text-purple-950'
+                              }`}
+                            >
+                              {text.openSyllabus}
+                            </a>
+                          </div>
+                        );
+                      })}
+                    </div>
+                  ) : (
+                    <p
+                      className={`mt-4 text-sm ${
+                        isDarkMode ? 'text-slate-300' : 'text-gray-600'
+                      }`}
+                    >
+                      {text.noStudyRecommendations}
+                    </p>
+                  )}
+                </div>
               </div>
             )}
 
@@ -777,6 +1171,37 @@ export default function ResultsScreen({
 
             {activeTab === 'details' && (
               <div className="space-y-4">
+                <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
+                  {[
+                    [text.averageQuestionTime, averageQuestionTime],
+                    [text.fastestQuestion, fastestQuestionTime],
+                    [text.slowestQuestion, slowestQuestionTime],
+                  ].map(([label, value]) => (
+                    <div
+                      key={label}
+                      className={`p-4 rounded-xl border-2 shadow-sm ${
+                        isDarkMode
+                          ? 'border-slate-700 bg-slate-700/40'
+                          : 'border-slate-200 bg-slate-50'
+                      }`}
+                    >
+                      <p
+                        className={`text-sm font-medium ${
+                          isDarkMode ? 'text-slate-300' : 'text-gray-600'
+                        }`}
+                      >
+                        {label}
+                      </p>
+                      <p
+                        className={`mt-1 text-2xl font-bold ${
+                          isDarkMode ? 'text-white' : 'text-gray-900'
+                        }`}
+                      >
+                        {formatTime(Number(value))}
+                      </p>
+                    </div>
+                  ))}
+                </div>
                 {result.answers.map((answer, index) => (
                   <div
                     key={answer.questionId}
@@ -812,7 +1237,7 @@ export default function ResultsScreen({
                             </span>
                           )}
                         </h3>
-                        <div className="flex gap-2 text-sm flex-shrink-0">
+                        <div className="flex flex-wrap justify-end gap-2 text-sm">
                           <span
                             className={`px-3 py-1 rounded-full font-medium border ${
                               isDarkMode
@@ -830,6 +1255,15 @@ export default function ResultsScreen({
                             }`}
                           >
                             {answer.kLevel}
+                          </span>
+                          <span
+                            className={`px-3 py-1 rounded-full font-semibold border ${
+                              isDarkMode
+                                ? 'bg-slate-700 text-slate-200 border-slate-600'
+                                : 'bg-slate-100 text-slate-800 border-slate-200'
+                            }`}
+                          >
+                            {text.questionTime}: {formatTime(answer.timeSpent)}
                           </span>
                         </div>
                       </div>

--- a/apps/frontend/src/app/labs/istqb/hooks/useSubmitResults.ts
+++ b/apps/frontend/src/app/labs/istqb/hooks/useSubmitResults.ts
@@ -5,7 +5,11 @@ import type { ExamResult } from '../types';
 export function useSubmitResults(
   result: ExamResult,
   mode: 'exam' | 'training',
-  processCode?: string
+  options?: {
+    processCode?: string;
+    model?: string;
+    language?: string;
+  }
 ) {
   const [isSaved, setIsSaved] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -31,7 +35,9 @@ export function useSubmitResults(
           time_spent: result.timeSpent,
           answers: result.answers as any,
           learning_objectives: result.learningObjectiveAnalysis as any,
-          process_code: processCode?.trim() || undefined,
+          model: options?.model,
+          language: options?.language,
+          process_code: options?.processCode?.trim() || undefined,
         });
 
         if (res.error) {

--- a/apps/frontend/src/app/labs/istqb/page.tsx
+++ b/apps/frontend/src/app/labs/istqb/page.tsx
@@ -11,10 +11,8 @@ import { loadExamData } from './utils';
 import { SuruFloating } from '@/components/Suru';
 import ExamAuthGate from '@/components/labs/ExamAuthGate';
 import { useSupabaseAuth } from '@/contexts/SupabaseAuthContext';
-import { saveExamResultAction } from '@/actions/exams';
 import { getExamUserDefaults } from '@/lib/exam-user-defaults';
 import ProcessCodeInput from '@/components/labs/ProcessCodeInput';
-import type { ExamResult } from './types';
 
 export default function ISTQBSimulatorPage() {
   const { isDarkMode } = useTheme();
@@ -36,25 +34,6 @@ export default function ISTQBSimulatorPage() {
       setParticipantName(defaults.fullName);
     }
   }, [user, participantName]);
-
-  const handleExamComplete = async (result: ExamResult) => {
-    await saveExamResultAction({
-      exam_type: 'istqb',
-      exam_mode: examMode as 'exam' | 'training',
-      score: result.score,
-      total_questions: result.totalQuestions,
-      correct_answers: result.correctAnswers,
-      incorrect_answers: result.incorrectAnswers,
-      passing_score: 26,
-      passed: result.passed,
-      percentage: result.percentage,
-      time_spent: result.timeSpent,
-      model,
-      language,
-      learning_objectives: result.learningObjectiveAnalysis,
-      process_code: processCode.trim() || undefined,
-    });
-  };
 
   const examId = `${language}-model-${model.toLowerCase()}`;
   const finalExamId = examId === 'es-model-a' ? 'es-model-a' : examId;
@@ -194,8 +173,9 @@ export default function ISTQBSimulatorPage() {
         mode={examMode}
         examData={examData}
         onReset={handleReset}
+        model={model}
+        processCode={processCode}
         language={language}
-        onExamComplete={handleExamComplete}
       />
     );
   }

--- a/apps/frontend/src/app/labs/istqb/types.ts
+++ b/apps/frontend/src/app/labs/istqb/types.ts
@@ -72,6 +72,7 @@ export interface AnswerDetail {
   isCorrect: boolean;
   learningObjective: string;
   kLevel: string;
+  timeSpent: number;
   explanations: Record<string, Explanation>;
 }
 

--- a/apps/frontend/src/app/labs/istqb/utils.ts
+++ b/apps/frontend/src/app/labs/istqb/utils.ts
@@ -43,15 +43,13 @@ export function shuffleArray<T>(array: T[]): T[] {
 
 export function selectRandomQuestions(
   questions: ExamQuestion[],
-  count: number,
+  count: number
 ): ExamQuestion[] {
   const shuffled = shuffleArray(questions);
   return shuffled.slice(0, count);
 }
 
-export function shuffleQuestionOptions(
-  question: ExamQuestion,
-): ExamQuestion {
+export function shuffleQuestionOptions(question: ExamQuestion): ExamQuestion {
   const shuffledOptions = shuffleArray(question.options);
   return {
     ...question,
@@ -62,7 +60,7 @@ export function shuffleQuestionOptions(
 export function prepareExamQuestions(
   questions: ExamQuestion[],
   count: number,
-  shuffleOptions: boolean = true,
+  shuffleOptions: boolean = true
 ): ExamQuestion[] {
   const selected = selectRandomQuestions(questions, count);
 
@@ -75,7 +73,7 @@ export function prepareExamQuestions(
 
 export function checkAnswer(
   userAnswer: string[],
-  correctAnswer: string[],
+  correctAnswer: string[]
 ): boolean {
   if (userAnswer.length !== correctAnswer.length) {
     return false;
@@ -89,7 +87,7 @@ export function checkAnswer(
 
 export function calculateScore(
   questions: ExamQuestion[],
-  answers: Map<number, string[]>,
+  answers: Map<number, string[]>
 ): number {
   let score = 0;
 
@@ -109,6 +107,7 @@ export function generateExamResult(
   answers: Map<number, string[]>,
   timeSpent: number,
   passingScore: number,
+  questionDurations: Map<number, number> = new Map()
 ): ExamResult {
   const answerDetails: AnswerDetail[] = questions.map((question) => {
     const userAnswer = answers.get(question.id) || [];
@@ -122,6 +121,7 @@ export function generateExamResult(
       isCorrect,
       learningObjective: question.learningObjective,
       kLevel: question.kLevel,
+      timeSpent: questionDurations.get(question.id) ?? 0,
       explanations: question.explanations,
     };
   });
@@ -132,9 +132,8 @@ export function generateExamResult(
   const percentage = (score / questions.length) * 100;
   const passed = score >= passingScore;
 
-  const learningObjectiveAnalysis = calculateLearningObjectiveAnalysis(
-    answerDetails,
-  );
+  const learningObjectiveAnalysis =
+    calculateLearningObjectiveAnalysis(answerDetails);
 
   return {
     participantName,
@@ -151,7 +150,7 @@ export function generateExamResult(
 }
 
 export function calculateLearningObjectiveAnalysis(
-  answers: AnswerDetail[],
+  answers: AnswerDetail[]
 ): LearningObjectiveResult[] {
   const loMap = new Map<string, { total: number; correct: number }>();
 
@@ -179,7 +178,7 @@ export function calculateLearningObjectiveAnalysis(
   });
 
   return results.sort((a, b) =>
-    a.learningObjective.localeCompare(b.learningObjective),
+    a.learningObjective.localeCompare(b.learningObjective)
   );
 }
 
@@ -198,6 +197,7 @@ export function exportToCSV(result: ExamResult): string {
     'Correcto',
     'Learning Objective',
     'K-Level',
+    'Tiempo por Pregunta (s)',
   ];
 
   const rows = result.answers.map((answer) => [
@@ -208,6 +208,7 @@ export function exportToCSV(result: ExamResult): string {
     answer.isCorrect ? 'Sí' : 'No',
     answer.learningObjective,
     answer.kLevel,
+    answer.timeSpent.toString(),
   ]);
 
   const csv = [


### PR DESCRIPTION
## Summary

Closes #113.

- Adds ISTQB attempt history for exam-mode results and renders a simple progress curve in the results summary.
- Adds static study recommendations for weak Learning Objectives with links to the CTFL v4.0 syllabus.
- Captures per-question time in the simulator, persists it through `answers`, shows it in question details, and exports it in CSV.
- Consolidates ISTQB result saving into `useSubmitResults` so attempts are not duplicated and save failures remain visible to the user.
- Adds focused unit coverage for result generation and CSV export.

## Verification

- `pnpm --filter @aiquaa/frontend type-check`
- `pnpm --filter @aiquaa/frontend test -- src/app/labs/istqb/__tests__/utils.test.ts`
- `pnpm --filter @aiquaa/frontend exec eslint src/actions/exams.ts src/app/labs/istqb/page.tsx src/app/labs/istqb/components/ExamSimulator.tsx src/app/labs/istqb/components/ResultsScreen.tsx src/app/labs/istqb/hooks/useSubmitResults.ts src/app/labs/istqb/types.ts src/app/labs/istqb/utils.ts src/app/labs/istqb/__tests__/utils.test.ts`
- Pre-push hook: frontend/backend type-check, backend unit tests passed. Frontend full unit suite is still skipped by the hook due pre-existing auth test failures.

## Note on #106

The `get_leaderboard` mutable `search_path` part is already fixed by the merged security migration. The remaining Leaked Password Protection setting is a hosted Supabase Auth configuration requiring Dashboard access or a Supabase Management API token with auth config write permissions, neither of which is present in this workspace, so I did not close #106 from this PR.