### PR TITLE
fix(assessments): corregir crash en level-2 ApiDocCard

### DIFF
--- a/apps/frontend/src/app/assessments/api-testing-fundamentals/data/assessment-definition.ts
+++ b/apps/frontend/src/app/assessments/api-testing-fundamentals/data/assessment-definition.ts
@@ -3,7 +3,7 @@ import type { AssessmentSeedDefinition } from '../types';
 export const API_TESTING_FUNDAMENTALS_SLUG = 'api-testing-fundamentals';
 
 // Bumpear cuando cambie la definición (secciones/preguntas) para forzar re-seed.
-export const API_TESTING_SEED_VERSION = 1;
+export const API_TESTING_SEED_VERSION = 2;
 
 export const apiTestingFundamentalsDefinition: AssessmentSeedDefinition = {
   slug: API_TESTING_FUNDAMENTALS_SLUG,
@@ -270,18 +270,19 @@ export const apiTestingFundamentalsDefinition: AssessmentSeedDefinition = {
       max_score: 20,
       metadata: {
         apiDoc: {
+          method: 'GET',
           endpoint: 'GET /api/products/{id}',
           description: 'Obtiene el detalle de un producto.',
           headers: ['Authorization: Bearer token'],
           pathParams: [{ name: 'id', type: 'string', required: true }],
-          response200: {
+          successResponse: {
             id: 'prod_001',
             name: 'Notebook',
             price: 5000000,
             stock: 10,
             active: true,
           },
-          errors: [
+          expectedErrors: [
             { status: 401, message: 'si no envía token' },
             { status: 404, message: 'si el producto no existe' },
             { status: 500, message: 'si ocurre error interno' },


### PR DESCRIPTION
## Summary

- Fix crash en `/assessments/api-testing-fundamentals/section/level-2-doc-interpretation` — la metadata de la sección usaba nombres de propiedades distintos (`response200`/`errors`) a los que el tipo `ApiDocScenario` y el componente `ApiDocCard` esperan (`successResponse`/`expectedErrors`/`method`). Llamar `.map()` sobre `undefined` → TypeError.
- Bump `API_TESTING_SEED_VERSION` de 1 a 2 para forzar re-seed con los nombres correctos en el primer request post-deploy.

## Test plan

- [ ] Navegar a `/assessments/api-testing-fundamentals`, iniciar intento, avanzar hasta level-2 → ya no crashea, muestra ApiDocCard con endpoint, headers, response y errores
- [ ] Tests de assessments pasan: `pnpm --filter @aiquaa/frontend test` (16/16 en assessments)

🤖 Generated with [Claude Code](https://claude.com/claude-code)