### PR TITLE
fix(assessments): podar secciones huérfanas al re-sembrar api-testing-fundamentals

### DIFF
--- a/apps/frontend/src/app/assessments/api-testing-fundamentals/data/assessment-definition.ts
+++ b/apps/frontend/src/app/assessments/api-testing-fundamentals/data/assessment-definition.ts
@@ -3,7 +3,7 @@ import type { AssessmentSeedDefinition } from '../types';
 export const API_TESTING_FUNDAMENTALS_SLUG = 'api-testing-fundamentals';
 
 // Bumpear cuando cambie la definición (secciones/preguntas) para forzar re-seed.
-export const API_TESTING_SEED_VERSION = 3;
+export const API_TESTING_SEED_VERSION = 4;
 
 export const apiTestingFundamentalsDefinition: AssessmentSeedDefinition = {
   slug: API_TESTING_FUNDAMENTALS_SLUG,

--- a/apps/frontend/src/app/assessments/api-testing-fundamentals/lib/seed.ts
+++ b/apps/frontend/src/app/assessments/api-testing-fundamentals/lib/seed.ts
@@ -68,6 +68,26 @@ export async function ensureApiTestingFundamentalsSeeded() {
     );
   }
 
+  // Podar secciones que ya no existen en la definición (las FK en cascada
+  // eliminan sus preguntas, respuestas y scores).
+  const definedSlugs = new Set(
+    apiTestingFundamentalsDefinition.sections.map((section) => section.slug)
+  );
+  const staleSectionIds = sections
+    .filter((section) => !definedSlugs.has(section.slug))
+    .map((section) => section.id);
+
+  if (staleSectionIds.length > 0) {
+    const { error: pruneSectionsError } = await supabase
+      .from('assessment_sections')
+      .delete()
+      .in('id', staleSectionIds);
+
+    if (pruneSectionsError) {
+      throw new Error(pruneSectionsError.message);
+    }
+  }
+
   for (const section of apiTestingFundamentalsDefinition.sections) {
     const seededSection = sections.find((item) => item.slug === section.slug);
 
@@ -99,6 +119,17 @@ export async function ensureApiTestingFundamentalsSeeded() {
 
     if (questionsError) {
       throw new Error(questionsError.message);
+    }
+
+    // Podar preguntas sobrantes si la sección se achicó respecto al seed previo.
+    const { error: pruneQuestionsError } = await supabase
+      .from('assessment_questions')
+      .delete()
+      .eq('section_id', seededSection.id)
+      .gt('order_index', section.questions.length);
+
+    if (pruneQuestionsError) {
+      throw new Error(pruneQuestionsError.message);
     }
   }
 


### PR DESCRIPTION
## Problema
Después del merge de #121, la prueba seguía mostrando 5 cajas: el seed hace upsert por `order_index` pero nunca elimina secciones/preguntas que ya no existen en la definición. Quedaron huérfanas:
- `level-4-response-analysis`: duplicado del nuevo nivel 3
- `level-5-bug-reporting`: preguntas `bug_report` sin formulario (el componente fue eliminado) → solo texto flotante

## Fix
- Seed ahora elimina secciones cuyo slug no está en la definición (las FK CASCADE limpian preguntas, respuestas y scores)
- Seed elimina preguntas con `order_index` mayor al definido por sección (por si una sección se achica)
- Bump seed version a 4

## Limpieza ya aplicada en producción
Las filas huérfanas se eliminaron directo en Supabase. Verificado:
- 3 secciones (level-1, level-2, level-3) con 14+8+8 = 30 preguntas
- Tipos de pregunta correctos en cada sección (sin `test_case_matrix` ni `bug_report` residuales)

## Test plan
- [x] `tsc --noEmit` — 0 errores
- [x] Pre-push hook (type-check + tests backend) pasa
- [x] Query en prod confirma 3 secciones / 30 preguntas
- [ ] Tomar la prueba en aiquaa.com: deben verse solo 3 niveles, todos respondibles

🤖 Generated with [Claude Code](https://claude.com/claude-code)