### PR TITLE
[codex] Add database assessments to Labs

### DIFF
--- a/apps/frontend/src/app/labs/page.tsx
+++ b/apps/frontend/src/app/labs/page.tsx
@@ -105,6 +105,28 @@ export default function LabsPage() {
           featured: true,
           implementedDate: 'Nov 2025',
         },
+        {
+          id: 'database-fundamentals',
+          name: 'Base de Datos — Fundamentos',
+          description:
+            'Prueba técnica teórica sobre modelo relacional, SQL básico, joins, agregaciones y constraints',
+          icon: '🗄️',
+          color: 'from-violet-500 to-fuchsia-600',
+          href: '/assessments/database-fundamentals',
+          featured: true,
+          implementedDate: 'Jun 2026',
+        },
+        {
+          id: 'database-practice',
+          name: 'Base de Datos — Práctica SQL',
+          description:
+            'Challenge práctico con una mini base e-commerce: predecí resultados, detectá bugs y escribí SQL',
+          icon: '🧮',
+          color: 'from-lime-500 to-emerald-600',
+          href: '/assessments/database-practice',
+          featured: true,
+          implementedDate: 'Jun 2026',
+        },
       ],
     },
     {


### PR DESCRIPTION
## Summary

- Adds the new database fundamentals assessment to the Labs listing.
- Adds the new SQL practice assessment to the Labs listing.
- Uses the assessment slugs as tool ids so saved progress can map to exam results.

## Why

PR #123 added the database assessments, but they were not visible from `/labs`. This makes them discoverable from the Labs hub.

## Validation

- `pnpm --filter @aiquaa/frontend lint` passed with existing warnings.
- `pnpm --filter @aiquaa/frontend type-check` passed after restoring missing local dependencies with `pnpm install`.
- Pre-push hook passed frontend/backend type-check and backend unit tests. Docker-dependent integration setup was skipped because Docker was unavailable in the local environment.