### PR TITLE
[codex] Require login for assessment bootcamp codes

### DIFF
--- a/apps/frontend/src/actions/assessments.ts
+++ b/apps/frontend/src/actions/assessments.ts
@@ -205,6 +205,29 @@ function getSectionScoringMode(): AssessmentSectionScore['scoring_mode'] {
   return 'automatic';
 }
 
+async function resolveProcessCode(
+  supabase: Awaited<ReturnType<typeof getAuthenticatedUser>>['supabase'],
+  processCode?: string
+) {
+  if (!processCode?.trim()) return null;
+
+  const { data: process } = await supabase
+    .from('hiring_processes')
+    .select('code, status, expires_at')
+    .ilike('code', processCode.trim())
+    .eq('status', 'active')
+    .maybeSingle();
+
+  const expired =
+    process?.expires_at && new Date(process.expires_at) < new Date();
+
+  if (!process || expired) {
+    throw new Error('Código de proceso inválido, vencido o cerrado.');
+  }
+
+  return process.code as string;
+}
+
 export async function getAssessmentOverviewAction(
   slug = DEFAULT_ASSESSMENT_SLUG
 ): Promise<AssessmentOverview> {
@@ -223,6 +246,10 @@ export async function startAssessmentAttemptAction(input?: {
   const sections = await getAssessmentSections(assessment.id);
   const firstSectionSlug = sections[0]?.slug ?? null;
   const { supabase, user } = await getAuthenticatedUser();
+  const resolvedProcessCode = await resolveProcessCode(
+    supabase,
+    input?.processCode
+  );
 
   const { data: existingAttempt } = await supabase
     .from('assessment_attempts')
@@ -235,10 +262,36 @@ export async function startAssessmentAttemptAction(input?: {
     .maybeSingle();
 
   if (existingAttempt) {
+    let attemptToReturn = existingAttempt;
+    if (resolvedProcessCode) {
+      const metadata =
+        existingAttempt.metadata &&
+        typeof existingAttempt.metadata === 'object' &&
+        !Array.isArray(existingAttempt.metadata)
+          ? (existingAttempt.metadata as Record<string, unknown>)
+          : {};
+      const { data: updatedAttempt } = await supabase
+        .from('assessment_attempts')
+        .update({
+          metadata: {
+            ...metadata,
+            processCode: resolvedProcessCode,
+          },
+          updated_at: new Date().toISOString(),
+        })
+        .eq('id', existingAttempt.id)
+        .select('*')
+        .single();
+
+      if (updatedAttempt) {
+        attemptToReturn = updatedAttempt;
+      }
+    }
+
     const savedSlug = existingAttempt.current_section_slug;
     const slugValid = sections.some((s) => s.slug === savedSlug);
     return {
-      attempt: mapAttempt(existingAttempt),
+      attempt: mapAttempt(attemptToReturn),
       sectionSlug: slugValid
         ? savedSlug
         : firstSectionSlug || sections[0]?.slug,
@@ -254,7 +307,7 @@ export async function startAssessmentAttemptAction(input?: {
       current_section_slug: firstSectionSlug,
       max_score: assessment.total_score,
       metadata: {
-        processCode: input?.processCode?.trim().toUpperCase() || null,
+        processCode: resolvedProcessCode,
       },
     })
     .select('*')

--- a/apps/frontend/src/app/api/assessments/start/route.ts
+++ b/apps/frontend/src/app/api/assessments/start/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createAdminClient } from '@/lib/supabase/admin';
 import { createClient } from '@/lib/supabase/server';
+import { getExamUserDefaults } from '@/lib/exam-user-defaults';
 import { signChallengeToken } from '../../challenge/_lib/auth';
 
 export const runtime = 'nodejs';
@@ -8,27 +9,31 @@ export const dynamic = 'force-dynamic';
 
 export async function POST(req: NextRequest) {
   try {
-    const body = await req.json();
-    const { candidateName, candidateEmail, processCode } = body ?? {};
+    let body: Record<string, unknown> = {};
+    try {
+      body = await req.json();
+    } catch {
+      body = {};
+    }
+    const { processCode } = body ?? {};
 
-    if (!candidateName?.trim()) {
+    const authClient = createClient();
+    const {
+      data: { user },
+      error: userError,
+    } = await authClient.auth.getUser();
+
+    if (userError || !user) {
       return NextResponse.json(
-        { error: 'candidateName is required' },
-        { status: 400 }
+        { error: 'Iniciá sesión para rendir este challenge.' },
+        { status: 401 }
       );
     }
 
-    // Resolver el usuario server-side (no confiar en el body); null si invitado
-    let aiquaaUserId: string | null = null;
-    try {
-      const authClient = createClient();
-      const {
-        data: { user },
-      } = await authClient.auth.getUser();
-      aiquaaUserId = user?.id ?? null;
-    } catch {
-      aiquaaUserId = null;
-    }
+    const defaults = getExamUserDefaults(user);
+    const candidateName =
+      defaults.fullName || defaults.email || `Usuario ${user.id.slice(0, 8)}`;
+    const candidateEmail = defaults.email || null;
 
     const supabase = createAdminClient();
 
@@ -75,9 +80,9 @@ export async function POST(req: NextRequest) {
       .from('qac_attempts')
       .insert({
         catalog_id: assessment.id,
-        candidate_name: candidateName.trim(),
-        candidate_email: candidateEmail?.trim() ?? null,
-        aiquaa_user_id: aiquaaUserId,
+        candidate_name: candidateName,
+        candidate_email: candidateEmail,
+        aiquaa_user_id: user.id,
         process_code: resolvedProcessCode,
         status: 'in_progress',
       })
@@ -102,7 +107,7 @@ export async function POST(req: NextRequest) {
     const challengeToken = await signChallengeToken(sessionId, 'usr_001');
 
     return NextResponse.json(
-      { attemptId: attempt.id, challengeToken, sessionId },
+      { attemptId: attempt.id, challengeToken, sessionId, candidateName },
       { status: 201 }
     );
   } catch {

--- a/apps/frontend/src/app/assessments/api-banking/start/page.tsx
+++ b/apps/frontend/src/app/assessments/api-banking/start/page.tsx
@@ -10,20 +10,12 @@ import { SESSION_KEYS } from '../types';
 export default function StartPage() {
   const router = useRouter();
   const { user, isLoading: authLoading } = useSupabaseAuth();
-  const [name, setName] = useState('');
-  const [email, setEmail] = useState('');
   const [processCode, setProcessCode] = useState('');
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
-
-  // Pre-fill from active AIQUAA session
-  useEffect(() => {
-    if (user) {
-      const defaults = getExamUserDefaults(user);
-      if (defaults.fullName) setName(defaults.fullName);
-      if (defaults.email) setEmail(defaults.email);
-    }
-  }, [user]);
+  const userDefaults = getExamUserDefaults(user);
+  const participantLabel =
+    userDefaults.fullName || userDefaults.email || 'tu cuenta AIQUAA';
 
   // Pre-fill process code from ?code= (links desde invitaciones/procesos)
   useEffect(() => {
@@ -33,8 +25,8 @@ export default function StartPage() {
 
   async function handleStart(ev: React.FormEvent) {
     ev.preventDefault();
-    if (!name.trim()) {
-      setError('El nombre es requerido.');
+    if (!user) {
+      setError('Iniciá sesión para rendir este challenge.');
       return;
     }
 
@@ -46,8 +38,6 @@ export default function StartPage() {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
-          candidateName: name.trim(),
-          candidateEmail: email.trim() || undefined,
           processCode: processCode.trim() || undefined,
         }),
       });
@@ -58,11 +48,14 @@ export default function StartPage() {
         return;
       }
 
-      const { attemptId, challengeToken } = await res.json();
+      const { attemptId, challengeToken, candidateName } = await res.json();
 
       sessionStorage.setItem(SESSION_KEYS.attemptId, String(attemptId));
       sessionStorage.setItem(SESSION_KEYS.challengeToken, challengeToken);
-      sessionStorage.setItem(SESSION_KEYS.candidateName, name.trim());
+      sessionStorage.setItem(
+        SESSION_KEYS.candidateName,
+        candidateName || participantLabel
+      );
       sessionStorage.setItem(SESSION_KEYS.startedAt, new Date().toISOString());
 
       router.push('/assessments/api-banking/workspace');
@@ -99,34 +92,12 @@ export default function StartPage() {
         </div>
 
         <form onSubmit={handleStart} className="space-y-4">
-          <div className="space-y-1">
-            <label className="block text-sm font-medium text-slate-700 dark:text-slate-300">
-              Nombre <span className="text-red-400">*</span>
-            </label>
-            <input
-              type="text"
-              className="w-full rounded-lg border border-slate-300 dark:border-slate-600 px-3 py-2 text-sm bg-white dark:bg-slate-800 focus:outline-none focus:ring-2 focus:ring-blue-500"
-              placeholder="Tu nombre completo"
-              value={name}
-              onChange={(e) => setName(e.target.value)}
-              disabled={loading}
-              autoFocus
-            />
-          </div>
-
-          <div className="space-y-1">
-            <label className="block text-sm font-medium text-slate-700 dark:text-slate-300">
-              Email{' '}
-              <span className="text-slate-400 font-normal">(opcional)</span>
-            </label>
-            <input
-              type="email"
-              className="w-full rounded-lg border border-slate-300 dark:border-slate-600 px-3 py-2 text-sm bg-white dark:bg-slate-800 focus:outline-none focus:ring-2 focus:ring-blue-500"
-              placeholder="tu@email.com"
-              value={email}
-              onChange={(e) => setEmail(e.target.value)}
-              disabled={loading}
-            />
+          <div className="rounded-lg border border-slate-200 bg-white p-3 text-sm text-slate-700 dark:border-slate-700 dark:bg-slate-900/60 dark:text-slate-300">
+            Vas a rendir como{' '}
+            <span className="font-semibold text-slate-900 dark:text-white">
+              {participantLabel}
+            </span>
+            .
           </div>
 
           <ProcessCodeInput
@@ -147,7 +118,7 @@ export default function StartPage() {
 
           <button
             type="submit"
-            disabled={loading || !name.trim()}
+            disabled={loading || !user}
             className="w-full py-3 rounded-lg bg-blue-600 text-white font-semibold hover:bg-blue-700 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
           >
             {loading ? 'Iniciando...' : 'Comenzar challenge →'}

--- a/apps/frontend/src/components/auth/AuthForm.tsx
+++ b/apps/frontend/src/components/auth/AuthForm.tsx
@@ -75,6 +75,10 @@ export default function AuthForm({
   const searchParams = useSearchParams();
   const error = searchParams?.get('error');
   const message = searchParams?.get('message');
+  const redirect = searchParams?.get('redirect');
+  const redirectQuery = redirect
+    ? `?redirect=${encodeURIComponent(redirect)}`
+    : '';
 
   const isLogin = mode === 'login';
   const audience: Audience = (formData.audience as Audience) || 'candidato';
@@ -101,8 +105,8 @@ export default function AuthForm({
   const linkHref = isLogin
     ? isEmpresa
       ? '/empresa/registro'
-      : '/register'
-    : '/login';
+      : `/register${redirectQuery}`
+    : `/login${redirectQuery}`;
 
   const fieldClass = (hasError: boolean) =>
     `w-full px-4 py-2.5 rounded-xl border text-sm outline-none shadow-sm transition-all duration-200 focus-visible:ring-2 focus-visible:ring-indigo-400/70 focus-visible:ring-offset-1 ${
@@ -541,7 +545,7 @@ export default function AuthForm({
                   ¿Olvidaste tu contraseña?
                 </Link>
                 <Link
-                  href="/register"
+                  href={`/register${redirectQuery}`}
                   className="font-semibold text-indigo-500 hover:text-indigo-400 underline-offset-4 hover:underline"
                 >
                   {t('auth.register.link')}

--- a/apps/frontend/src/components/auth/LoginForm.tsx
+++ b/apps/frontend/src/components/auth/LoginForm.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React, { useRef, useState } from 'react';
-import { useRouter } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 import { resendConfirmationAction } from '@/actions/auth';
 import { createClient } from '@/lib/supabase/client';
 import AuthForm from './AuthForm';
@@ -9,6 +9,7 @@ import EmailVerificationModal from './EmailVerificationModal';
 
 export default function LoginForm() {
   const router = useRouter();
+  const searchParams = useSearchParams();
   const [isLoading, setIsLoading] = useState(false);
   const [errors, setErrors] = useState<{ [key: string]: string }>({});
   const [showAlert, setShowAlert] = useState(false);
@@ -21,6 +22,14 @@ export default function LoginForm() {
   const [showVerifyModal, setShowVerifyModal] = useState(false);
 
   const passwordRef = useRef<HTMLInputElement>(null);
+
+  const getSafeRedirect = () => {
+    const redirect = searchParams?.get('redirect');
+    if (!redirect || !redirect.startsWith('/') || redirect.startsWith('//')) {
+      return null;
+    }
+    return redirect;
+  };
 
   const validateForm = (): boolean => {
     const newErrors: { [key: string]: string } = {};
@@ -71,7 +80,10 @@ export default function LoginForm() {
       setShowAlert(true);
     } else {
       const audience = data.user?.user_metadata?.audience;
-      router.push(audience === 'empresa' ? '/empresa' : '/ranking?welcome=1');
+      router.push(
+        getSafeRedirect() ??
+          (audience === 'empresa' ? '/empresa' : '/ranking?welcome=1')
+      );
       router.refresh();
     }
   };
@@ -108,34 +120,34 @@ export default function LoginForm() {
 
   return (
     <>
-    {showVerifyModal && (
-      <EmailVerificationModal
-        email={formData.email}
-        context="login-blocked"
-        onClose={() => setShowVerifyModal(false)}
-        onResend={handleResend}
+      {showVerifyModal && (
+        <EmailVerificationModal
+          email={formData.email}
+          context="login-blocked"
+          onClose={() => setShowVerifyModal(false)}
+          onResend={handleResend}
+        />
+      )}
+      <AuthForm
+        mode="login"
+        onSubmit={handleSubmit}
+        isLoading={isLoading}
+        errors={errors}
+        formData={formData}
+        onFieldChange={handleChange}
+        onPasswordChange={handlePasswordChange}
+        onClearErrors={() => {
+          setErrors({});
+          setShowAlert(false);
+        }}
+        socialLoginError={socialLoginError}
+        onSocialError={() => {}}
+        showAlert={showAlert}
+        alertMessage={alertMessage}
+        alertType={alertType}
+        showResend={false}
+        passwordRef={passwordRef}
       />
-    )}
-    <AuthForm
-      mode="login"
-      onSubmit={handleSubmit}
-      isLoading={isLoading}
-      errors={errors}
-      formData={formData}
-      onFieldChange={handleChange}
-      onPasswordChange={handlePasswordChange}
-      onClearErrors={() => {
-        setErrors({});
-        setShowAlert(false);
-      }}
-      socialLoginError={socialLoginError}
-      onSocialError={() => {}}
-      showAlert={showAlert}
-      alertMessage={alertMessage}
-      alertType={alertType}
-      showResend={false}
-      passwordRef={passwordRef}
-    />
     </>
   );
 }

--- a/apps/frontend/src/components/labs/ExamAuthGate.tsx
+++ b/apps/frontend/src/components/labs/ExamAuthGate.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import Link from 'next/link';
+import { usePathname, useSearchParams } from 'next/navigation';
 import { useSupabaseAuth } from '@/contexts/SupabaseAuthContext';
 import { useTheme } from '@/contexts/ThemeContext';
 
@@ -10,13 +11,24 @@ interface ExamAuthGateProps {
   examEmoji?: string;
 }
 
-export default function ExamAuthGate({ children, examName, examEmoji = '📝' }: ExamAuthGateProps) {
+export default function ExamAuthGate({
+  children,
+  examName,
+  examEmoji = '📝',
+}: ExamAuthGateProps) {
   const { isAuthenticated, isLoading } = useSupabaseAuth();
   const { isDarkMode } = useTheme();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const queryString = searchParams?.toString();
+  const redirectTarget = `${pathname}${queryString ? `?${queryString}` : ''}`;
+  const encodedRedirect = encodeURIComponent(redirectTarget);
 
   if (isLoading) {
     return (
-      <div className={`min-h-screen flex items-center justify-center ${isDarkMode ? 'bg-slate-900' : 'bg-gray-50'}`}>
+      <div
+        className={`min-h-screen flex items-center justify-center ${isDarkMode ? 'bg-slate-900' : 'bg-gray-50'}`}
+      >
         <div className="animate-spin rounded-full h-10 w-10 border-t-2 border-indigo-500" />
       </div>
     );
@@ -24,27 +36,47 @@ export default function ExamAuthGate({ children, examName, examEmoji = '📝' }:
 
   if (!isAuthenticated) {
     return (
-      <div className={`min-h-screen flex items-center justify-center py-12 px-4 ${isDarkMode ? 'bg-slate-900' : 'bg-gray-50'}`}>
-        <div className={`max-w-md w-full rounded-2xl p-8 text-center space-y-6 ${isDarkMode ? 'bg-slate-800 border border-slate-700' : 'bg-white border border-gray-200 shadow-lg'}`}>
-
+      <div
+        className={`min-h-screen flex items-center justify-center py-12 px-4 ${isDarkMode ? 'bg-slate-900' : 'bg-gray-50'}`}
+      >
+        <div
+          className={`max-w-md w-full rounded-2xl p-8 text-center space-y-6 ${isDarkMode ? 'bg-slate-800 border border-slate-700' : 'bg-white border border-gray-200 shadow-lg'}`}
+        >
           <div className="inline-flex items-center justify-center w-20 h-20 rounded-2xl bg-gradient-to-br from-indigo-500 to-violet-600 text-4xl mx-auto">
             🔒
           </div>
 
           <div>
-            <h2 className={`text-2xl font-bold mb-2 ${isDarkMode ? 'text-white' : 'text-gray-900'}`}>
+            <h2
+              className={`text-2xl font-bold mb-2 ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
+            >
               Acceso restringido
             </h2>
-            <p className={`text-sm leading-relaxed ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}>
-              Para tomar el <strong className={isDarkMode ? 'text-slate-200' : 'text-gray-800'}>{examEmoji} {examName}</strong> y guardar tus resultados en tu perfil, necesitás una cuenta en AIQUAA.
+            <p
+              className={`text-sm leading-relaxed ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}
+            >
+              Para tomar el{' '}
+              <strong
+                className={isDarkMode ? 'text-slate-200' : 'text-gray-800'}
+              >
+                {examEmoji} {examName}
+              </strong>{' '}
+              y guardar tus resultados en tu perfil, necesitás una cuenta en
+              AIQUAA.
             </p>
           </div>
 
-          <div className={`rounded-xl p-4 text-left space-y-2 ${isDarkMode ? 'bg-slate-700/50' : 'bg-indigo-50'}`}>
-            <p className={`text-xs font-semibold uppercase tracking-wide ${isDarkMode ? 'text-slate-400' : 'text-indigo-600'}`}>
+          <div
+            className={`rounded-xl p-4 text-left space-y-2 ${isDarkMode ? 'bg-slate-700/50' : 'bg-indigo-50'}`}
+          >
+            <p
+              className={`text-xs font-semibold uppercase tracking-wide ${isDarkMode ? 'text-slate-400' : 'text-indigo-600'}`}
+            >
               Con tu cuenta podés:
             </p>
-            <ul className={`text-sm space-y-1 ${isDarkMode ? 'text-slate-300' : 'text-gray-700'}`}>
+            <ul
+              className={`text-sm space-y-1 ${isDarkMode ? 'text-slate-300' : 'text-gray-700'}`}
+            >
               <li>📊 Ver tu historial de exámenes</li>
               <li>📈 Trackear tu progreso a lo largo del tiempo</li>
               <li>🏆 Guardar tus mejores resultados</li>
@@ -54,13 +86,13 @@ export default function ExamAuthGate({ children, examName, examEmoji = '📝' }:
 
           <div className="flex flex-col gap-3">
             <Link
-              href="/register"
+              href={`/register?redirect=${encodedRedirect}`}
               className="w-full py-3 px-4 bg-indigo-600 hover:bg-indigo-700 text-white text-sm font-semibold rounded-xl transition-colors"
             >
               🎉 Crear cuenta gratis
             </Link>
             <Link
-              href="/login"
+              href={`/login?redirect=${encodedRedirect}`}
               className={`w-full py-3 px-4 text-sm font-semibold rounded-xl border transition-colors ${
                 isDarkMode
                   ? 'border-slate-600 text-slate-300 hover:bg-slate-700'
@@ -70,7 +102,6 @@ export default function ExamAuthGate({ children, examName, examEmoji = '📝' }:
               Ya tengo cuenta → Iniciar sesión
             </Link>
           </div>
-
         </div>
       </div>
     );


### PR DESCRIPTION
## Summary

- Requires authenticated AIQUAA sessions before starting API Banking attempts.
- Removes the manual name/email fields from API Banking start and derives candidate identity from the active session.
- Preserves `?code=...` bootcamp/process codes through assessment auth redirects and post-login navigation.
- Validates process codes server-side for API Banking and shared SQL assessments before attempts are created or resumed.

## Validation

- `pnpm --filter @aiquaa/frontend lint` passed with existing warnings.
- `pnpm --filter @aiquaa/frontend type-check` passed.
- Pre-push hook passed frontend/backend type-check and backend unit tests.
- Docker was unavailable locally, so integration DB setup was skipped by the hook.