### PR TITLE
fix: corregir authService.applyTokens y dashboard allTypes incompleto

### DIFF
--- a/apps/frontend/src/app/dashboard/page.tsx
+++ b/apps/frontend/src/app/dashboard/page.tsx
@@ -104,6 +104,9 @@ export default function DashboardPage() {
     'istqb',
     'performance',
     'api-testing-fundamentals',
+    'api-banking',
+    'database-fundamentals',
+    'database-practice',
   ] as const;
   const recommended = allTypes.find((t) => !passedTypes.has(t)) ?? null;
   const allPassed = allTypes.every((t) => passedTypes.has(t));

--- a/apps/frontend/src/services/authService.ts
+++ b/apps/frontend/src/services/authService.ts
@@ -72,7 +72,7 @@ class AuthService {
     if (typeof window !== 'undefined') {
       localStorage.setItem('accessToken', accessToken);
       if (refreshToken) {
-        localStorage.setItem('refreshToken', accessToken);
+        localStorage.setItem('refreshToken', refreshToken);
       }
     }
   }


### PR DESCRIPTION
$(cat <<'EOF'
## Resumen

Dos bugs detectados en ciclo QA del 15 Jun 2026 y corregidos en esta rama. Ambos habían sido identificados previamente en `claude/nice-galileo-6xh4fo` pero esa rama nunca se mergeó a `main`.

## Bugs corregidos

### 1. `authService.applyTokens()` — sesión corrompida tras renovación OAuth

**Archivo:** `apps/frontend/src/services/authService.ts:75`

```diff
- localStorage.setItem('refreshToken', accessToken);
+ localStorage.setItem('refreshToken', refreshToken);
```

`applyTokens()` guardaba el valor de `accessToken` bajo la clave `'refreshToken'` en localStorage. Al recargar la página, `this.refreshToken` se inicializaba con el access token, haciendo que las llamadas a `/auth/refresh` enviaran el token equivocado y fallaran silenciosamente.

**Impacto:** cualquier usuario que usara la app a través del backend NestJS (flujos OAuth externos) perdía la sesión en el siguiente ciclo de renovación de token.

---

### 2. Dashboard — "¡Aprobaste todos los exámenes!" falso

**Archivo:** `apps/frontend/src/app/dashboard/page.tsx:102`

```diff
  const allTypes = [
    'git',
    'istqb',
    'performance',
    'api-testing-fundamentals',
+   'api-banking',
+   'database-fundamentals',
+   'database-practice',
  ] as const;
```

`allTypes` solo incluía 4 de los 7 exámenes disponibles. Usuarios que aprobaban los 4 originales veían el mensaje de celebración final y dejaban de recibir recomendaciones, sin saber que existían 3 assessments más (api-banking, database-fundamentals, database-practice).

**Impacto:** frena la progresión de usuarios avanzados; oculta contenido nuevo de quienes más lo aprovecharían.

---

## Test plan

- [ ] Registrarse / iniciar sesión con Google → verificar que la sesión persiste tras reload
- [ ] Completar los 4 exámenes originales en modo examen → el dashboard debe recomendar `api-banking` como próximo desafío (no mostrar "¡Aprobaste todos!")
- [ ] Completar los 7 exámenes → recién ahí aparece el mensaje de celebración final

https://claude.ai/code/session_01WqHDiHZgsLeVXJtupPhs2a
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WqHDiHZgsLeVXJtupPhs2a)_