### PR TITLE
Prevent edits after grading; add unload guards

### DIFF
--- a/apps/frontend/src/actions/assessments.ts
+++ b/apps/frontend/src/actions/assessments.ts
@@ -345,7 +345,11 @@ export async function saveAssessmentAnswerAction(input: {
   currentSectionSlug?: string;
 }) {
   const { supabase } = await getAuthenticatedUser();
-  await getAttemptRecord(input.attemptId);
+  const attempt = await getAttemptRecord(input.attemptId);
+
+  if (attempt.status === 'graded') {
+    throw new Error('El examen ya fue entregado y no admite cambios.');
+  }
 
   const timestamp = new Date().toISOString();
 
@@ -382,6 +386,10 @@ export async function submitAssessmentSectionAction(input: {
 }) {
   const { supabase } = await getAuthenticatedUser();
   const bundle = await loadSectionBundle(input.attemptId, input.sectionSlug);
+
+  if (bundle.attempt.status === 'graded') {
+    throw new Error('El examen ya fue entregado y no admite cambios.');
+  }
 
   let sectionScore = 0;
   const feedbackMessages: string[] = [];

--- a/apps/frontend/src/app/assessments/_shared/components/AssessmentSectionScreen.tsx
+++ b/apps/frontend/src/app/assessments/_shared/components/AssessmentSectionScreen.tsx
@@ -63,6 +63,10 @@ export default function AssessmentSectionScreen({
         setLoading(true);
         const data = await getAssessmentSectionAction(attemptId, sectionSlug);
         if (cancelled) return;
+        if (data.attempt.status === 'graded') {
+          router.replace(`${basePath}/result?attempt=${attemptId}`);
+          return;
+        }
         setPayload(data);
         const nextAnswers: AnswerMap = {};
         data.answers.forEach((answer) => {
@@ -92,6 +96,18 @@ export default function AssessmentSectionScreen({
       );
     };
   }, [attemptId, basePath, router, sectionSlug]);
+
+  useEffect(() => {
+    if (!payload || payload.attempt.status === 'graded') return;
+
+    const handleBeforeUnload = (event: BeforeUnloadEvent) => {
+      event.preventDefault();
+      event.returnValue = '';
+    };
+
+    window.addEventListener('beforeunload', handleBeforeUnload);
+    return () => window.removeEventListener('beforeunload', handleBeforeUnload);
+  }, [payload]);
 
   function scheduleAutosave(questionId: string, value: unknown) {
     if (!attemptId) return;
@@ -145,7 +161,7 @@ export default function AssessmentSectionScreen({
         }
 
         await finalizeAssessmentAttemptAction(attemptId);
-        router.push(`${basePath}/result?attempt=${attemptId}`);
+        router.replace(`${basePath}/result?attempt=${attemptId}`);
       } catch (submitSectionError) {
         setSubmitError(
           submitSectionError instanceof Error

--- a/apps/frontend/src/app/labs/git/components/ExamSimulator.tsx
+++ b/apps/frontend/src/app/labs/git/components/ExamSimulator.tsx
@@ -32,9 +32,11 @@ export default function ExamSimulator({
   const [questions, setQuestions] = useState<ExamQuestion[]>([]);
   const [currentQuestionIndex, setCurrentQuestionIndex] = useState(0);
   const [answers, setAnswers] = useState<Map<number, string[]>>(new Map());
-  const [markedForReview, setMarkedForReview] = useState<Set<number>>(new Set());
+  const [markedForReview, setMarkedForReview] = useState<Set<number>>(
+    new Set()
+  );
   const [timeRemaining, setTimeRemaining] = useState(
-    mode === 'exam' ? examData.examInfo.timeLimit * 60 : 0,
+    mode === 'exam' ? examData.examInfo.timeLimit * 60 : 0
   );
   const [isRunning, setIsRunning] = useState(mode === 'exam');
   const [showSubmitDialog, setShowSubmitDialog] = useState(false);
@@ -44,18 +46,15 @@ export default function ExamSimulator({
   const questionsInitialized = useRef(false);
   const submitRef = useRef<(autoSubmit?: boolean) => void>(() => {});
 
-  const handleSubmitExam = useCallback(
-    (autoSubmit = false) => {
-      if (!autoSubmit) {
-        setShowSubmitDialog(true);
-        return;
-      }
+  const handleSubmitExam = useCallback((autoSubmit = false) => {
+    if (!autoSubmit) {
+      setShowSubmitDialog(true);
+      return;
+    }
 
-      setIsRunning(false);
-      setHasSubmitted(true);
-    },
-    [],
-  );
+    setIsRunning(false);
+    setHasSubmitted(true);
+  }, []);
 
   useEffect(() => {
     submitRef.current = handleSubmitExam;
@@ -75,7 +74,7 @@ export default function ExamSimulator({
         return newAnswers;
       });
     },
-    [],
+    []
   );
 
   const toggleMarkForReview = useCallback(() => {
@@ -111,7 +110,7 @@ export default function ExamSimulator({
     const preparedQuestions = prepareExamQuestions(
       examData.questions,
       examData.examInfo.totalQuestions,
-      true,
+      true
     );
     setQuestions(preparedQuestions);
   }, [examData]);
@@ -131,6 +130,18 @@ export default function ExamSimulator({
 
     return () => clearInterval(timer);
   }, [isRunning, mode]);
+
+  useEffect(() => {
+    if (mode !== 'exam' || !isRunning || hasSubmitted) return;
+
+    const handleBeforeUnload = (event: BeforeUnloadEvent) => {
+      event.preventDefault();
+      event.returnValue = '';
+    };
+
+    window.addEventListener('beforeunload', handleBeforeUnload);
+    return () => window.removeEventListener('beforeunload', handleBeforeUnload);
+  }, [isRunning, mode, hasSubmitted]);
 
   if (questions.length === 0) {
     return (
@@ -154,7 +165,7 @@ export default function ExamSimulator({
       questions,
       answers,
       timeSpent,
-      examData.examInfo.passingScore,
+      examData.examInfo.passingScore
     );
 
     if (onExamComplete && !savedRef.current) {
@@ -173,12 +184,16 @@ export default function ExamSimulator({
   const isMarked = markedForReview.has(currentQuestion.id);
 
   return (
-    <div className={`min-h-screen py-8 transition-colors ${isDarkMode ? 'bg-slate-900' : 'bg-gray-50'}`}>
+    <div
+      className={`min-h-screen py-8 transition-colors ${isDarkMode ? 'bg-slate-900' : 'bg-gray-50'}`}
+    >
       <div className="container mx-auto px-4 max-w-6xl">
         <div className="mb-6">
           <div className="flex flex-col md:flex-row justify-between items-start md:items-center gap-4 mb-4">
             <div>
-              <h1 className={`text-2xl font-bold ${isDarkMode ? 'text-white' : 'text-gray-900'}`}>
+              <h1
+                className={`text-2xl font-bold ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
+              >
                 AIQUAA | Examen Técnico GIT
               </h1>
               <p className={isDarkMode ? 'text-slate-400' : 'text-gray-600'}>
@@ -187,26 +202,36 @@ export default function ExamSimulator({
             </div>
 
             {mode === 'exam' && (
-              <div className={`p-4 rounded-lg shadow-lg border-2 ${
-                timeRemaining < 300
-                  ? isDarkMode
-                    ? 'bg-red-900/30 border-red-700'
-                    : 'bg-red-50 border-red-300'
-                  : isDarkMode
-                  ? 'bg-slate-800 border-slate-700'
-                  : 'bg-white border-gray-200'
-              }`}>
+              <div
+                className={`p-4 rounded-lg shadow-lg border-2 ${
+                  timeRemaining < 300
+                    ? isDarkMode
+                      ? 'bg-red-900/30 border-red-700'
+                      : 'bg-red-50 border-red-300'
+                    : isDarkMode
+                      ? 'bg-slate-800 border-slate-700'
+                      : 'bg-white border-gray-200'
+                }`}
+              >
                 <div className="flex items-center gap-3">
                   <span className="text-3xl">⏱️</span>
                   <div>
-                    <p className={`text-sm font-medium ${isDarkMode ? 'text-slate-400' : 'text-gray-600'}`}>
+                    <p
+                      className={`text-sm font-medium ${isDarkMode ? 'text-slate-400' : 'text-gray-600'}`}
+                    >
                       Tiempo Restante
                     </p>
-                    <p className={`text-2xl font-bold ${
-                      timeRemaining < 300
-                        ? isDarkMode ? 'text-red-300' : 'text-red-700'
-                        : isDarkMode ? 'text-slate-100' : 'text-gray-900'
-                    }`}>
+                    <p
+                      className={`text-2xl font-bold ${
+                        timeRemaining < 300
+                          ? isDarkMode
+                            ? 'text-red-300'
+                            : 'text-red-700'
+                          : isDarkMode
+                            ? 'text-slate-100'
+                            : 'text-gray-900'
+                      }`}
+                    >
                       {formatTime(timeRemaining)}
                     </p>
                   </div>
@@ -216,20 +241,29 @@ export default function ExamSimulator({
           </div>
 
           <div className="space-y-2">
-            <div className={`flex justify-between text-sm font-medium ${isDarkMode ? 'text-slate-300' : 'text-gray-700'}`}>
+            <div
+              className={`flex justify-between text-sm font-medium ${isDarkMode ? 'text-slate-300' : 'text-gray-700'}`}
+            >
               <span>
                 📝 Pregunta {currentQuestionIndex + 1} de {questions.length}
               </span>
               <span>
-                ✓ Respondidas: <strong>{answeredCount}</strong> | ⏳ Sin Responder: <strong>{unansweredCount}</strong>
+                ✓ Respondidas: <strong>{answeredCount}</strong> | ⏳ Sin
+                Responder: <strong>{unansweredCount}</strong>
               </span>
             </div>
-            <div className={`w-full rounded-full h-3 shadow-inner ${isDarkMode ? 'bg-slate-700' : 'bg-gray-200'}`}>
+            <div
+              className={`w-full rounded-full h-3 shadow-inner ${isDarkMode ? 'bg-slate-700' : 'bg-gray-200'}`}
+            >
               <div
                 className={`h-3 rounded-full transition-all duration-300 ${
                   progress === 100
-                    ? isDarkMode ? 'bg-green-500' : 'bg-green-600'
-                    : isDarkMode ? 'bg-amber-500' : 'bg-amber-600'
+                    ? isDarkMode
+                      ? 'bg-green-500'
+                      : 'bg-green-600'
+                    : isDarkMode
+                      ? 'bg-amber-500'
+                      : 'bg-amber-600'
                 }`}
                 style={{ width: `${progress}%` }}
               />
@@ -256,7 +290,9 @@ export default function ExamSimulator({
           showFeedback={mode === 'training'}
         />
 
-        <div className={`mt-6 rounded-lg shadow-lg border ${isDarkMode ? 'bg-slate-800 border-slate-700' : 'bg-white border-gray-200'}`}>
+        <div
+          className={`mt-6 rounded-lg shadow-lg border ${isDarkMode ? 'bg-slate-800 border-slate-700' : 'bg-white border-gray-200'}`}
+        >
           <div className="p-6">
             <div className="flex flex-col md:flex-row justify-between items-center gap-4">
               <button
@@ -268,8 +304,8 @@ export default function ExamSimulator({
                       ? 'bg-slate-700 text-slate-500 cursor-not-allowed border-2 border-slate-700'
                       : 'bg-gray-200 text-gray-400 cursor-not-allowed border-2 border-gray-200'
                     : isDarkMode
-                    ? 'bg-slate-700 hover:bg-slate-600 text-slate-100 border-2 border-slate-600 hover:border-slate-500'
-                    : 'bg-white hover:bg-gray-50 text-gray-900 border-2 border-gray-300 hover:border-gray-400'
+                      ? 'bg-slate-700 hover:bg-slate-600 text-slate-100 border-2 border-slate-600 hover:border-slate-500'
+                      : 'bg-white hover:bg-gray-50 text-gray-900 border-2 border-gray-300 hover:border-gray-400'
                 }`}
               >
                 ← Anterior
@@ -282,8 +318,8 @@ export default function ExamSimulator({
                     isMarked
                       ? 'bg-gradient-to-r from-amber-600 to-amber-500 hover:from-amber-700 hover:to-amber-600 text-white shadow-lg'
                       : isDarkMode
-                      ? 'bg-slate-700 hover:bg-slate-600 text-slate-100 border-2 border-slate-600'
-                      : 'bg-white hover:bg-gray-50 text-gray-900 border-2 border-gray-300'
+                        ? 'bg-slate-700 hover:bg-slate-600 text-slate-100 border-2 border-slate-600'
+                        : 'bg-white hover:bg-gray-50 text-gray-900 border-2 border-gray-300'
                   }`}
                 >
                   🚩 {isMarked ? 'Desmarcar' : 'Marcar'}
@@ -308,8 +344,8 @@ export default function ExamSimulator({
                       ? 'bg-slate-700 text-slate-500 cursor-not-allowed border-2 border-slate-700'
                       : 'bg-gray-200 text-gray-400 cursor-not-allowed border-2 border-gray-200'
                     : isDarkMode
-                    ? 'bg-slate-700 hover:bg-slate-600 text-slate-100 border-2 border-slate-600 hover:border-slate-500'
-                    : 'bg-white hover:bg-gray-50 text-gray-900 border-2 border-gray-300 hover:border-gray-400'
+                      ? 'bg-slate-700 hover:bg-slate-600 text-slate-100 border-2 border-slate-600 hover:border-slate-500'
+                      : 'bg-white hover:bg-gray-50 text-gray-900 border-2 border-gray-300 hover:border-gray-400'
                 }`}
               >
                 Siguiente →
@@ -331,47 +367,66 @@ export default function ExamSimulator({
 
         {showSubmitDialog && (
           <div className="fixed inset-0 bg-black/70 backdrop-blur-sm flex items-center justify-center z-50 p-4">
-            <div className={`rounded-xl shadow-2xl max-w-md w-full border-2 ${
-              isDarkMode
-                ? 'bg-slate-800 border-slate-700'
-                : 'bg-white border-gray-200'
-            }`}>
+            <div
+              className={`rounded-xl shadow-2xl max-w-md w-full border-2 ${
+                isDarkMode
+                  ? 'bg-slate-800 border-slate-700'
+                  : 'bg-white border-gray-200'
+              }`}
+            >
               <div className="p-6">
                 <div className="flex items-center gap-3 mb-4">
                   <span className="text-3xl">📤</span>
-                  <h2 className={`text-2xl font-bold ${isDarkMode ? 'text-slate-100' : 'text-gray-900'}`}>
+                  <h2
+                    className={`text-2xl font-bold ${isDarkMode ? 'text-slate-100' : 'text-gray-900'}`}
+                  >
                     ¿Enviar Examen?
                   </h2>
                 </div>
-                <p className={`mb-4 text-base ${isDarkMode ? 'text-slate-300' : 'text-gray-600'}`}>
-                  Está a punto de enviar su examen. Una vez enviado, no podrá realizar cambios.
+                <p
+                  className={`mb-4 text-base ${isDarkMode ? 'text-slate-300' : 'text-gray-600'}`}
+                >
+                  Está a punto de enviar su examen. Una vez enviado, no podrá
+                  realizar cambios.
                 </p>
-                <div className={`mb-6 p-4 rounded-lg border ${
-                  isDarkMode
-                    ? 'bg-slate-700/50 border-slate-600'
-                    : 'bg-gray-50 border-gray-200'
-                }`}>
-                  <p className={`font-semibold mb-3 ${isDarkMode ? 'text-slate-200' : 'text-gray-900'}`}>📊 Resumen:</p>
-                  <ul className={`space-y-2 ${isDarkMode ? 'text-slate-300' : 'text-gray-700'}`}>
+                <div
+                  className={`mb-6 p-4 rounded-lg border ${
+                    isDarkMode
+                      ? 'bg-slate-700/50 border-slate-600'
+                      : 'bg-gray-50 border-gray-200'
+                  }`}
+                >
+                  <p
+                    className={`font-semibold mb-3 ${isDarkMode ? 'text-slate-200' : 'text-gray-900'}`}
+                  >
+                    📊 Resumen:
+                  </p>
+                  <ul
+                    className={`space-y-2 ${isDarkMode ? 'text-slate-300' : 'text-gray-700'}`}
+                  >
                     <li className="flex items-center gap-2">
                       <span className="text-green-500">✓</span>
                       Preguntas respondidas: <strong>{answeredCount}</strong>
                     </li>
                     <li className="flex items-center gap-2">
                       <span className="text-gray-500">○</span>
-                      Preguntas sin responder: <strong>{unansweredCount}</strong>
+                      Preguntas sin responder:{' '}
+                      <strong>{unansweredCount}</strong>
                     </li>
                     <li className="flex items-center gap-2">
                       <span className="text-amber-500">🚩</span>
-                      Marcadas para revisar: <strong>{markedForReview.size}</strong>
+                      Marcadas para revisar:{' '}
+                      <strong>{markedForReview.size}</strong>
                     </li>
                   </ul>
                   {unansweredCount > 0 && (
-                    <div className={`mt-4 p-3 rounded-lg border-2 ${
-                      isDarkMode
-                        ? 'bg-red-900/30 border-red-700 text-red-300'
-                        : 'bg-red-50 border-red-300 text-red-800'
-                    }`}>
+                    <div
+                      className={`mt-4 p-3 rounded-lg border-2 ${
+                        isDarkMode
+                          ? 'bg-red-900/30 border-red-700 text-red-300'
+                          : 'bg-red-50 border-red-300 text-red-800'
+                      }`}
+                    >
                       <p className="font-semibold flex items-center gap-2">
                         <span>⚠️</span>
                         Tiene {unansweredCount} pregunta(s) sin responder.

--- a/apps/frontend/src/app/labs/istqb/components/ExamSimulator.tsx
+++ b/apps/frontend/src/app/labs/istqb/components/ExamSimulator.tsx
@@ -214,6 +214,18 @@ export default function ExamSimulator({
   }, [isRunning, mode]);
 
   useEffect(() => {
+    if (mode !== 'exam' || !isRunning || hasSubmitted) return;
+
+    const handleBeforeUnload = (event: BeforeUnloadEvent) => {
+      event.preventDefault();
+      event.returnValue = '';
+    };
+
+    window.addEventListener('beforeunload', handleBeforeUnload);
+    return () => window.removeEventListener('beforeunload', handleBeforeUnload);
+  }, [isRunning, mode, hasSubmitted]);
+
+  useEffect(() => {
     const questionId = questions[currentQuestionIndex]?.id;
     if (!questionId) return;
 

--- a/apps/frontend/src/app/labs/performance/components/ExamSimulator.tsx
+++ b/apps/frontend/src/app/labs/performance/components/ExamSimulator.tsx
@@ -34,9 +34,11 @@ export default function ExamSimulator({
   const [questions, setQuestions] = useState<ExamQuestion[]>([]);
   const [currentQuestionIndex, setCurrentQuestionIndex] = useState(0);
   const [answers, setAnswers] = useState<Map<number, string[]>>(new Map());
-  const [markedForReview, setMarkedForReview] = useState<Set<number>>(new Set());
+  const [markedForReview, setMarkedForReview] = useState<Set<number>>(
+    new Set()
+  );
   const [timeRemaining, setTimeRemaining] = useState(
-    mode === 'exam' ? examData.examInfo.timeLimit * 60 : 0,
+    mode === 'exam' ? examData.examInfo.timeLimit * 60 : 0
   );
   const [isRunning, setIsRunning] = useState(mode === 'exam');
   const [showSubmitDialog, setShowSubmitDialog] = useState(false);
@@ -64,10 +66,12 @@ export default function ExamSimulator({
       submit: '✓ Enviar Examen',
       submitEarly: 'Enviar examen antes de tiempo',
       submitDialogTitle: '¿Enviar Examen?',
-      submitDialogMessage: 'Está a punto de enviar su examen. Una vez enviado, no podrá realizar cambios.',
+      submitDialogMessage:
+        'Está a punto de enviar su examen. Una vez enviado, no podrá realizar cambios.',
       summary: 'Resumen:',
       marked: 'Marcadas para revisar',
-      unansweredWarning: (count: number) => `Tiene ${count} pregunta(s) sin responder.`,
+      unansweredWarning: (count: number) =>
+        `Tiene ${count} pregunta(s) sin responder.`,
       cancel: 'Cancelar',
       confirm: '✓ Confirmar Envío',
     },
@@ -89,10 +93,12 @@ export default function ExamSimulator({
       submit: '✓ Submit Exam',
       submitEarly: 'Submit exam early',
       submitDialogTitle: 'Submit Exam?',
-      submitDialogMessage: 'You are about to submit your exam. Once submitted, you cannot make changes.',
+      submitDialogMessage:
+        'You are about to submit your exam. Once submitted, you cannot make changes.',
       summary: 'Summary:',
       marked: 'Marked for review',
-      unansweredWarning: (count: number) => `You have ${count} unanswered question(s).`,
+      unansweredWarning: (count: number) =>
+        `You have ${count} unanswered question(s).`,
       cancel: 'Cancel',
       confirm: '✓ Confirm Submit',
     },
@@ -100,18 +106,15 @@ export default function ExamSimulator({
 
   const text = t[language as keyof typeof t];
 
-  const handleSubmitExam = useCallback(
-    (autoSubmit = false) => {
-      if (!autoSubmit) {
-        setShowSubmitDialog(true);
-        return;
-      }
+  const handleSubmitExam = useCallback((autoSubmit = false) => {
+    if (!autoSubmit) {
+      setShowSubmitDialog(true);
+      return;
+    }
 
-      setIsRunning(false);
-      setHasSubmitted(true);
-    },
-    [],
-  );
+    setIsRunning(false);
+    setHasSubmitted(true);
+  }, []);
 
   // Keep a stable ref so the timer effect never needs to re-run when the callback identity
   // changes, preventing interval accumulation (Issue #58).
@@ -133,7 +136,7 @@ export default function ExamSimulator({
         return newAnswers;
       });
     },
-    [],
+    []
   );
 
   const toggleMarkForReview = useCallback(() => {
@@ -171,7 +174,7 @@ export default function ExamSimulator({
     const preparedQuestions = prepareExamQuestions(
       examData.questions,
       examData.examInfo.totalQuestions,
-      true,
+      true
     );
     setQuestions(preparedQuestions);
   }, [examData]);
@@ -191,6 +194,18 @@ export default function ExamSimulator({
 
     return () => clearInterval(timer);
   }, [isRunning, mode]);
+
+  useEffect(() => {
+    if (mode !== 'exam' || !isRunning || hasSubmitted) return;
+
+    const handleBeforeUnload = (event: BeforeUnloadEvent) => {
+      event.preventDefault();
+      event.returnValue = '';
+    };
+
+    window.addEventListener('beforeunload', handleBeforeUnload);
+    return () => window.removeEventListener('beforeunload', handleBeforeUnload);
+  }, [isRunning, mode, hasSubmitted]);
 
   if (questions.length === 0) {
     return (
@@ -214,7 +229,7 @@ export default function ExamSimulator({
       questions,
       answers,
       timeSpent,
-      examData.examInfo.passingScore,
+      examData.examInfo.passingScore
     );
 
     onExamComplete?.(result);
@@ -232,19 +247,25 @@ export default function ExamSimulator({
   }
 
   const currentQuestion = questions[currentQuestionIndex];
-  const answeredCount = [...answers.values()].filter((v) => v.length > 0).length;
+  const answeredCount = [...answers.values()].filter(
+    (v) => v.length > 0
+  ).length;
   const progress = (answeredCount / questions.length) * 100;
   const unansweredCount = questions.length - answeredCount;
   const isLastQuestion = currentQuestionIndex === questions.length - 1;
   const isMarked = markedForReview.has(currentQuestion.id);
 
   return (
-    <div className={`min-h-screen py-8 transition-colors ${isDarkMode ? 'bg-slate-900' : 'bg-gray-50'}`}>
+    <div
+      className={`min-h-screen py-8 transition-colors ${isDarkMode ? 'bg-slate-900' : 'bg-gray-50'}`}
+    >
       <div className="container mx-auto px-4 max-w-6xl">
         <div className="mb-6">
           <div className="flex flex-col md:flex-row justify-between items-start md:items-center gap-4 mb-4">
             <div>
-              <h1 className={`text-2xl font-bold ${isDarkMode ? 'text-white' : 'text-gray-900'}`}>
+              <h1
+                className={`text-2xl font-bold ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
+              >
                 {text.title}
               </h1>
               <p className={isDarkMode ? 'text-slate-400' : 'text-gray-600'}>
@@ -253,24 +274,36 @@ export default function ExamSimulator({
             </div>
 
             {mode === 'exam' && (
-              <div className={`p-4 rounded-lg shadow-lg border-2 ${timeRemaining < 300
-                ? isDarkMode
-                  ? 'bg-red-900/30 border-red-700'
-                  : 'bg-red-50 border-red-300'
-                : isDarkMode
-                  ? 'bg-slate-800 border-slate-700'
-                  : 'bg-white border-gray-200'
-                }`}>
+              <div
+                className={`p-4 rounded-lg shadow-lg border-2 ${
+                  timeRemaining < 300
+                    ? isDarkMode
+                      ? 'bg-red-900/30 border-red-700'
+                      : 'bg-red-50 border-red-300'
+                    : isDarkMode
+                      ? 'bg-slate-800 border-slate-700'
+                      : 'bg-white border-gray-200'
+                }`}
+              >
                 <div className="flex items-center gap-3">
                   <span className="text-3xl">⏱️</span>
                   <div>
-                    <p className={`text-sm font-medium ${isDarkMode ? 'text-slate-400' : 'text-gray-600'}`}>
+                    <p
+                      className={`text-sm font-medium ${isDarkMode ? 'text-slate-400' : 'text-gray-600'}`}
+                    >
                       {text.timeRemaining}
                     </p>
-                    <p className={`text-2xl font-bold ${timeRemaining < 300
-                      ? isDarkMode ? 'text-red-300' : 'text-red-700'
-                      : isDarkMode ? 'text-slate-100' : 'text-gray-900'
-                      }`}>
+                    <p
+                      className={`text-2xl font-bold ${
+                        timeRemaining < 300
+                          ? isDarkMode
+                            ? 'text-red-300'
+                            : 'text-red-700'
+                          : isDarkMode
+                            ? 'text-slate-100'
+                            : 'text-gray-900'
+                      }`}
+                    >
                       {formatTime(timeRemaining)}
                     </p>
                   </div>
@@ -280,20 +313,31 @@ export default function ExamSimulator({
           </div>
 
           <div className="space-y-2">
-            <div className={`flex justify-between text-sm font-medium ${isDarkMode ? 'text-slate-300' : 'text-gray-700'}`}>
+            <div
+              className={`flex justify-between text-sm font-medium ${isDarkMode ? 'text-slate-300' : 'text-gray-700'}`}
+            >
               <span>
-                📝 {text.question} {currentQuestionIndex + 1} {text.of} {questions.length}
+                📝 {text.question} {currentQuestionIndex + 1} {text.of}{' '}
+                {questions.length}
               </span>
               <span>
-                ✓ {text.answered}: <strong>{answeredCount}</strong> | ⏳ {text.unanswered}: <strong>{unansweredCount}</strong>
+                ✓ {text.answered}: <strong>{answeredCount}</strong> | ⏳{' '}
+                {text.unanswered}: <strong>{unansweredCount}</strong>
               </span>
             </div>
-            <div className={`w-full rounded-full h-3 shadow-inner ${isDarkMode ? 'bg-slate-700' : 'bg-gray-200'}`}>
+            <div
+              className={`w-full rounded-full h-3 shadow-inner ${isDarkMode ? 'bg-slate-700' : 'bg-gray-200'}`}
+            >
               <div
-                className={`h-3 rounded-full transition-all duration-300 ${progress === 100
-                  ? isDarkMode ? 'bg-green-500' : 'bg-green-600'
-                  : isDarkMode ? 'bg-amber-500' : 'bg-amber-600'
-                  }`}
+                className={`h-3 rounded-full transition-all duration-300 ${
+                  progress === 100
+                    ? isDarkMode
+                      ? 'bg-green-500'
+                      : 'bg-green-600'
+                    : isDarkMode
+                      ? 'bg-amber-500'
+                      : 'bg-amber-600'
+                }`}
                 style={{ width: `${progress}%` }}
               />
             </div>
@@ -320,20 +364,23 @@ export default function ExamSimulator({
           language={language}
         />
 
-        <div className={`mt-6 rounded-lg shadow-lg border ${isDarkMode ? 'bg-slate-800 border-slate-700' : 'bg-white border-gray-200'}`}>
+        <div
+          className={`mt-6 rounded-lg shadow-lg border ${isDarkMode ? 'bg-slate-800 border-slate-700' : 'bg-white border-gray-200'}`}
+        >
           <div className="p-6">
             <div className="flex flex-col md:flex-row justify-between items-center gap-4">
               <button
                 onClick={goToPreviousQuestion}
                 disabled={currentQuestionIndex === 0}
-                className={`px-5 py-3 rounded-lg font-semibold transition-all w-full md:w-auto ${currentQuestionIndex === 0
-                  ? isDarkMode
-                    ? 'bg-slate-700 text-slate-500 cursor-not-allowed border-2 border-slate-700'
-                    : 'bg-gray-200 text-gray-400 cursor-not-allowed border-2 border-gray-200'
-                  : isDarkMode
-                    ? 'bg-slate-700 hover:bg-slate-600 text-slate-100 border-2 border-slate-600 hover:border-slate-500'
-                    : 'bg-white hover:bg-gray-50 text-gray-900 border-2 border-gray-300 hover:border-gray-400'
-                  }`}
+                className={`px-5 py-3 rounded-lg font-semibold transition-all w-full md:w-auto ${
+                  currentQuestionIndex === 0
+                    ? isDarkMode
+                      ? 'bg-slate-700 text-slate-500 cursor-not-allowed border-2 border-slate-700'
+                      : 'bg-gray-200 text-gray-400 cursor-not-allowed border-2 border-gray-200'
+                    : isDarkMode
+                      ? 'bg-slate-700 hover:bg-slate-600 text-slate-100 border-2 border-slate-600 hover:border-slate-500'
+                      : 'bg-white hover:bg-gray-50 text-gray-900 border-2 border-gray-300 hover:border-gray-400'
+                }`}
               >
                 {text.previous}
               </button>
@@ -341,12 +388,13 @@ export default function ExamSimulator({
               <div className="flex gap-3 w-full md:w-auto">
                 <button
                   onClick={toggleMarkForReview}
-                  className={`px-5 py-3 rounded-lg font-semibold transition-all flex-1 md:flex-none ${isMarked
-                    ? 'bg-gradient-to-r from-amber-600 to-amber-500 hover:from-amber-700 hover:to-amber-600 text-white shadow-lg'
-                    : isDarkMode
-                      ? 'bg-slate-700 hover:bg-slate-600 text-slate-100 border-2 border-slate-600'
-                      : 'bg-white hover:bg-gray-50 text-gray-900 border-2 border-gray-300'
-                    }`}
+                  className={`px-5 py-3 rounded-lg font-semibold transition-all flex-1 md:flex-none ${
+                    isMarked
+                      ? 'bg-gradient-to-r from-amber-600 to-amber-500 hover:from-amber-700 hover:to-amber-600 text-white shadow-lg'
+                      : isDarkMode
+                        ? 'bg-slate-700 hover:bg-slate-600 text-slate-100 border-2 border-slate-600'
+                        : 'bg-white hover:bg-gray-50 text-gray-900 border-2 border-gray-300'
+                  }`}
                 >
                   🚩 {isMarked ? text.unmark : text.mark}
                 </button>
@@ -364,14 +412,15 @@ export default function ExamSimulator({
               <button
                 onClick={goToNextQuestion}
                 disabled={isLastQuestion}
-                className={`px-5 py-3 rounded-lg font-semibold transition-all w-full md:w-auto ${isLastQuestion
-                  ? isDarkMode
-                    ? 'bg-slate-700 text-slate-500 cursor-not-allowed border-2 border-slate-700'
-                    : 'bg-gray-200 text-gray-400 cursor-not-allowed border-2 border-gray-200'
-                  : isDarkMode
-                    ? 'bg-slate-700 hover:bg-slate-600 text-slate-100 border-2 border-slate-600 hover:border-slate-500'
-                    : 'bg-white hover:bg-gray-50 text-gray-900 border-2 border-gray-300 hover:border-gray-400'
-                  }`}
+                className={`px-5 py-3 rounded-lg font-semibold transition-all w-full md:w-auto ${
+                  isLastQuestion
+                    ? isDarkMode
+                      ? 'bg-slate-700 text-slate-500 cursor-not-allowed border-2 border-slate-700'
+                      : 'bg-gray-200 text-gray-400 cursor-not-allowed border-2 border-gray-200'
+                    : isDarkMode
+                      ? 'bg-slate-700 hover:bg-slate-600 text-slate-100 border-2 border-slate-600 hover:border-slate-500'
+                      : 'bg-white hover:bg-gray-50 text-gray-900 border-2 border-gray-300 hover:border-gray-400'
+                }`}
               >
                 {text.next}
               </button>
@@ -392,26 +441,42 @@ export default function ExamSimulator({
 
         {showSubmitDialog && (
           <div className="fixed inset-0 bg-black/70 backdrop-blur-sm flex items-center justify-center z-50 p-4">
-            <div className={`rounded-xl shadow-2xl max-w-md w-full border-2 ${isDarkMode
-              ? 'bg-slate-800 border-slate-700'
-              : 'bg-white border-gray-200'
-              }`}>
+            <div
+              className={`rounded-xl shadow-2xl max-w-md w-full border-2 ${
+                isDarkMode
+                  ? 'bg-slate-800 border-slate-700'
+                  : 'bg-white border-gray-200'
+              }`}
+            >
               <div className="p-6">
                 <div className="flex items-center gap-3 mb-4">
                   <span className="text-3xl">📤</span>
-                  <h2 className={`text-2xl font-bold ${isDarkMode ? 'text-slate-100' : 'text-gray-900'}`}>
+                  <h2
+                    className={`text-2xl font-bold ${isDarkMode ? 'text-slate-100' : 'text-gray-900'}`}
+                  >
                     {text.submitDialogTitle}
                   </h2>
                 </div>
-                <p className={`mb-4 text-base ${isDarkMode ? 'text-slate-300' : 'text-gray-600'}`}>
+                <p
+                  className={`mb-4 text-base ${isDarkMode ? 'text-slate-300' : 'text-gray-600'}`}
+                >
                   {text.submitDialogMessage}
                 </p>
-                <div className={`mb-6 p-4 rounded-lg border ${isDarkMode
-                  ? 'bg-slate-700/50 border-slate-600'
-                  : 'bg-gray-50 border-gray-200'
-                  }`}>
-                  <p className={`font-semibold mb-3 ${isDarkMode ? 'text-slate-200' : 'text-gray-900'}`}>{text.summary}</p>
-                  <ul className={`space-y-2 ${isDarkMode ? 'text-slate-300' : 'text-gray-700'}`}>
+                <div
+                  className={`mb-6 p-4 rounded-lg border ${
+                    isDarkMode
+                      ? 'bg-slate-700/50 border-slate-600'
+                      : 'bg-gray-50 border-gray-200'
+                  }`}
+                >
+                  <p
+                    className={`font-semibold mb-3 ${isDarkMode ? 'text-slate-200' : 'text-gray-900'}`}
+                  >
+                    {text.summary}
+                  </p>
+                  <ul
+                    className={`space-y-2 ${isDarkMode ? 'text-slate-300' : 'text-gray-700'}`}
+                  >
                     <li className="flex items-center gap-2">
                       <span className="text-green-500">✓</span>
                       {text.answered}: <strong>{answeredCount}</strong>
@@ -426,10 +491,13 @@ export default function ExamSimulator({
                     </li>
                   </ul>
                   {unansweredCount > 0 && (
-                    <div className={`mt-4 p-3 rounded-lg border-2 ${isDarkMode
-                      ? 'bg-red-900/30 border-red-700 text-red-300'
-                      : 'bg-red-50 border-red-300 text-red-800'
-                      }`}>
+                    <div
+                      className={`mt-4 p-3 rounded-lg border-2 ${
+                        isDarkMode
+                          ? 'bg-red-900/30 border-red-700 text-red-300'
+                          : 'bg-red-50 border-red-300 text-red-800'
+                      }`}
+                    >
                       <p className="font-semibold flex items-center gap-2">
                         <span>⚠️</span>
                         {text.unansweredWarning(unansweredCount)}
@@ -440,10 +508,11 @@ export default function ExamSimulator({
                 <div className="flex gap-3">
                   <button
                     onClick={() => setShowSubmitDialog(false)}
-                    className={`flex-1 px-4 py-3 rounded-lg font-semibold transition-all ${isDarkMode
-                      ? 'bg-slate-700 hover:bg-slate-600 text-slate-200 border-2 border-slate-600'
-                      : 'bg-gray-200 hover:bg-gray-300 text-gray-800 border-2 border-gray-300'
-                      }`}
+                    className={`flex-1 px-4 py-3 rounded-lg font-semibold transition-all ${
+                      isDarkMode
+                        ? 'bg-slate-700 hover:bg-slate-600 text-slate-200 border-2 border-slate-600'
+                        : 'bg-gray-200 hover:bg-gray-300 text-gray-800 border-2 border-gray-300'
+                    }`}
                   >
                     {text.cancel}
                   </button>


### PR DESCRIPTION
Block changes to graded attempts by checking attempt.status in saveAssessmentAnswerAction and submitAssessmentSectionAction and throwing an error when status === 'graded'. Redirect users viewing a graded section to the result page in AssessmentSectionScreen. Add beforeunload handlers to AssessmentSectionScreen and the Git/ISTQB/Performance ExamSimulator components to warn users from accidentally leaving while an exam is running and not yet submitted. Also replace a router.push with router.replace when navigating to the results page to avoid an extra history entry.