### PR TITLE
fix(labs): connect AllPairs XP tracking; show missing profile fields

### DIFF
--- a/apps/frontend/src/app/empresa/perfil/page.tsx
+++ b/apps/frontend/src/app/empresa/perfil/page.tsx
@@ -4,7 +4,11 @@ import { useEffect, useRef, useState, useTransition } from 'react';
 import Link from 'next/link';
 import Image from 'next/image';
 import { useTheme } from '@/contexts/ThemeContext';
-import { getMyEmpresaAction, updateEmpresaAction, type Empresa } from '@/actions/empresa-admin';
+import {
+  getMyEmpresaAction,
+  updateEmpresaAction,
+  type Empresa,
+} from '@/actions/empresa-admin';
 import { createClient } from '@/lib/supabase/client';
 
 const INDUSTRIES = [
@@ -43,17 +47,26 @@ const COUNTRIES = [
   { value: 'otro', label: 'Otro' },
 ];
 
+const PROFILE_FIELDS = [
+  { key: 'logo_url', label: 'Logo de la empresa', anchor: '#logo' },
+  { key: 'razon_social', label: 'Razón social', anchor: '#razon-social' },
+  { key: 'description', label: 'Descripción', anchor: '#descripcion' },
+  { key: 'website_url', label: 'Sitio web', anchor: '#website' },
+  { key: 'industry', label: 'Industria', anchor: '#industria' },
+  { key: 'country', label: 'País', anchor: '#pais' },
+  { key: 'team_size', label: 'Tamaño del equipo', anchor: '#team-size' },
+] as const;
+
 function completionScore(empresa: Empresa): number {
-  const fields = [
-    empresa.logo_url,
-    empresa.description,
-    empresa.website_url,
-    empresa.industry,
-    empresa.country,
-    empresa.team_size,
-    empresa.razon_social,
-  ];
-  return Math.round((fields.filter(Boolean).length / fields.length) * 100);
+  return Math.round(
+    (PROFILE_FIELDS.filter((f) => empresa[f.key as keyof Empresa]).length /
+      PROFILE_FIELDS.length) *
+      100
+  );
+}
+
+function getMissingFields(empresa: Empresa) {
+  return PROFILE_FIELDS.filter((f) => !empresa[f.key as keyof Empresa]);
 }
 
 export default function EmpresaPerfilPage() {
@@ -64,7 +77,10 @@ export default function EmpresaPerfilPage() {
   const [loading, setLoading] = useState(true);
   const [saving, startSaving] = useTransition();
   const [uploading, setUploading] = useState(false);
-  const [alert, setAlert] = useState<{ type: 'success' | 'error'; msg: string } | null>(null);
+  const [alert, setAlert] = useState<{
+    type: 'success' | 'error';
+    msg: string;
+  } | null>(null);
 
   const [form, setForm] = useState({
     razon_social: '',
@@ -120,16 +136,18 @@ export default function EmpresaPerfilPage() {
       return;
     }
 
-    const { data: { publicUrl } } = supabase.storage
-      .from('empresa-logos')
-      .getPublicUrl(path);
+    const {
+      data: { publicUrl },
+    } = supabase.storage.from('empresa-logos').getPublicUrl(path);
 
     const logoUrl = `${publicUrl}?t=${Date.now()}`;
-    const { error: updateErr } = await updateEmpresaAction({ logo_url: logoUrl });
+    const { error: updateErr } = await updateEmpresaAction({
+      logo_url: logoUrl,
+    });
     if (updateErr) {
       setAlert({ type: 'error', msg: updateErr });
     } else {
-      setEmpresa((prev) => prev ? { ...prev, logo_url: logoUrl } : prev);
+      setEmpresa((prev) => (prev ? { ...prev, logo_url: logoUrl } : prev));
       setAlert({ type: 'success', msg: 'Logo actualizado correctamente' });
     }
     setUploading(false);
@@ -139,12 +157,22 @@ export default function EmpresaPerfilPage() {
     setAlert(null);
     // Validate URL
     if (form.website_url && !/^https?:\/\/.+/.test(form.website_url)) {
-      setAlert({ type: 'error', msg: 'El sitio web debe comenzar con http:// o https://' });
+      setAlert({
+        type: 'error',
+        msg: 'El sitio web debe comenzar con http:// o https://',
+      });
       return;
     }
     // Validate RUC format for Paraguay: digits-digit (e.g. 80012345-6)
-    if (form.ruc && form.country === 'PY' && !/^\d{6,8}-\d$/.test(form.ruc.trim())) {
-      setAlert({ type: 'error', msg: 'El RUC debe tener el formato 80012345-6 (dígitos guión dígito verificador)' });
+    if (
+      form.ruc &&
+      form.country === 'PY' &&
+      !/^\d{6,8}-\d$/.test(form.ruc.trim())
+    ) {
+      setAlert({
+        type: 'error',
+        msg: 'El RUC debe tener el formato 80012345-6 (dígitos guión dígito verificador)',
+      });
       return;
     }
     startSaving(async () => {
@@ -152,13 +180,15 @@ export default function EmpresaPerfilPage() {
       if (error) {
         setAlert({ type: 'error', msg: error });
       } else {
-        setEmpresa((prev) => prev ? { ...prev, ...form } : prev);
+        setEmpresa((prev) => (prev ? { ...prev, ...form } : prev));
         setAlert({ type: 'success', msg: 'Perfil guardado correctamente' });
       }
     });
   };
 
-  const card = isDarkMode ? 'bg-dark-secondary border-slate-700' : 'bg-white border-gray-200';
+  const card = isDarkMode
+    ? 'bg-dark-secondary border-slate-700'
+    : 'bg-white border-gray-200';
   const inputClass = `w-full rounded-lg border px-3 py-2 text-sm outline-none transition-colors focus:ring-2 focus:ring-indigo-500 ${
     isDarkMode
       ? 'bg-slate-700 border-slate-600 text-white placeholder-slate-400'
@@ -168,7 +198,9 @@ export default function EmpresaPerfilPage() {
 
   if (loading) {
     return (
-      <div className={`min-h-screen flex items-center justify-center ${isDarkMode ? 'bg-dark-bg' : 'bg-gray-50'}`}>
+      <div
+        className={`min-h-screen flex items-center justify-center ${isDarkMode ? 'bg-dark-bg' : 'bg-gray-50'}`}
+      >
         <div className="animate-spin rounded-full h-10 w-10 border-t-2 border-indigo-500" />
       </div>
     );
@@ -177,16 +209,21 @@ export default function EmpresaPerfilPage() {
   const score = empresa ? completionScore(empresa) : 0;
 
   return (
-    <div className={`min-h-screen transition-colors duration-300 ${isDarkMode ? 'bg-dark-bg' : 'bg-gray-50'}`}>
+    <div
+      className={`min-h-screen transition-colors duration-300 ${isDarkMode ? 'bg-dark-bg' : 'bg-gray-50'}`}
+    >
       <div className="max-w-2xl mx-auto px-4 sm:px-6 lg:px-8 py-12 space-y-6">
-
         {/* Header */}
         <div className="flex items-center justify-between">
           <div>
-            <h1 className={`text-2xl font-bold ${isDarkMode ? 'text-white' : 'text-gray-900'}`}>
+            <h1
+              className={`text-2xl font-bold ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
+            >
               Perfil de empresa
             </h1>
-            <p className={`text-sm mt-1 ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}>
+            <p
+              className={`text-sm mt-1 ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}
+            >
               Esta información es visible para los candidatos QA
             </p>
           </div>
@@ -201,49 +238,93 @@ export default function EmpresaPerfilPage() {
         {/* Completion progress */}
         <div className={`rounded-xl border p-4 ${card}`}>
           <div className="flex items-center justify-between mb-2">
-            <p className={`text-sm font-medium ${isDarkMode ? 'text-slate-300' : 'text-gray-700'}`}>
+            <p
+              className={`text-sm font-medium ${isDarkMode ? 'text-slate-300' : 'text-gray-700'}`}
+            >
               Completitud del perfil
             </p>
-            <span className={`text-sm font-bold ${score >= 80 ? 'text-green-500' : score >= 50 ? 'text-amber-500' : 'text-red-500'}`}>
+            <span
+              className={`text-sm font-bold ${score >= 80 ? 'text-green-500' : score >= 50 ? 'text-amber-500' : 'text-red-500'}`}
+            >
               {score}%
             </span>
           </div>
-          <div className={`w-full h-2 rounded-full ${isDarkMode ? 'bg-slate-700' : 'bg-gray-100'}`}>
+          <div
+            className={`w-full h-2 rounded-full ${isDarkMode ? 'bg-slate-700' : 'bg-gray-100'}`}
+          >
             <div
               className={`h-2 rounded-full transition-all duration-500 ${score >= 80 ? 'bg-green-500' : score >= 50 ? 'bg-amber-400' : 'bg-red-500'}`}
               style={{ width: `${score}%` }}
             />
           </div>
-          {score < 80 && (
-            <p className={`text-xs mt-2 ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}>
-              Un perfil completo atrae más candidatos QA calificados
-            </p>
+          {score < 100 && empresa && getMissingFields(empresa).length > 0 && (
+            <div className="mt-3 space-y-1">
+              <p
+                className={`text-xs font-medium mb-1 ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}
+              >
+                Falta completar:
+              </p>
+              {getMissingFields(empresa).map((f) => (
+                <a
+                  key={f.key}
+                  href={f.anchor}
+                  className={`flex items-center gap-1.5 text-xs hover:underline ${isDarkMode ? 'text-amber-400' : 'text-amber-600'}`}
+                >
+                  <span aria-hidden="true">•</span> {f.label}
+                </a>
+              ))}
+            </div>
           )}
         </div>
 
         {/* Alert */}
         {alert && (
-          <div className={`px-4 py-3 rounded-lg text-sm font-medium flex items-center justify-between ${
-            alert.type === 'success'
-              ? isDarkMode ? 'bg-emerald-900/40 text-emerald-300 border border-emerald-700' : 'bg-emerald-50 text-emerald-700 border border-emerald-200'
-              : isDarkMode ? 'bg-red-900/40 text-red-300 border border-red-700' : 'bg-red-50 text-red-700 border border-red-200'
-          }`}>
-            <span>{alert.type === 'success' ? '✅' : '❌'} {alert.msg}</span>
-            <button onClick={() => setAlert(null)} className="ml-4 opacity-60 hover:opacity-100">✕</button>
+          <div
+            className={`px-4 py-3 rounded-lg text-sm font-medium flex items-center justify-between ${
+              alert.type === 'success'
+                ? isDarkMode
+                  ? 'bg-emerald-900/40 text-emerald-300 border border-emerald-700'
+                  : 'bg-emerald-50 text-emerald-700 border border-emerald-200'
+                : isDarkMode
+                  ? 'bg-red-900/40 text-red-300 border border-red-700'
+                  : 'bg-red-50 text-red-700 border border-red-200'
+            }`}
+          >
+            <span>
+              {alert.type === 'success' ? '✅' : '❌'} {alert.msg}
+            </span>
+            <button
+              onClick={() => setAlert(null)}
+              className="ml-4 opacity-60 hover:opacity-100"
+            >
+              ✕
+            </button>
           </div>
         )}
 
         {/* Logo */}
-        <div className={`rounded-xl border p-6 ${card}`}>
-          <h2 className={`text-base font-semibold mb-4 ${isDarkMode ? 'text-white' : 'text-gray-900'}`}>
+        <div id="logo" className={`rounded-xl border p-6 ${card}`}>
+          <h2
+            className={`text-base font-semibold mb-4 ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
+          >
             Logo de la empresa
           </h2>
           <div className="flex items-center gap-5">
-            <div className={`w-20 h-20 rounded-xl border-2 flex items-center justify-center overflow-hidden shrink-0 relative ${
-              isDarkMode ? 'border-slate-600 bg-slate-700' : 'border-gray-200 bg-gray-50'
-            }`}>
+            <div
+              className={`w-20 h-20 rounded-xl border-2 flex items-center justify-center overflow-hidden shrink-0 relative ${
+                isDarkMode
+                  ? 'border-slate-600 bg-slate-700'
+                  : 'border-gray-200 bg-gray-50'
+              }`}
+            >
               {empresa?.logo_url ? (
-                <Image src={empresa.logo_url} alt="Logo empresa" fill className="object-contain" unoptimized />
+                <Image
+                  src={empresa.logo_url}
+                  alt="Logo empresa"
+                  fill
+                  className="object-contain"
+                  unoptimized
+                />
               ) : (
                 <span className="text-3xl">🏢</span>
               )}
@@ -255,28 +336,44 @@ export default function EmpresaPerfilPage() {
                 disabled={uploading}
                 className="px-4 py-2 rounded-lg text-sm font-medium bg-indigo-600 hover:bg-indigo-700 text-white transition-colors disabled:opacity-50"
               >
-                {uploading ? 'Subiendo...' : empresa?.logo_url ? '🔄 Cambiar logo' : '📷 Subir logo'}
+                {uploading
+                  ? 'Subiendo...'
+                  : empresa?.logo_url
+                    ? '🔄 Cambiar logo'
+                    : '📷 Subir logo'}
               </button>
-              <p className={`text-xs mt-1.5 ${isDarkMode ? 'text-slate-500' : 'text-gray-400'}`}>
+              <p
+                className={`text-xs mt-1.5 ${isDarkMode ? 'text-slate-500' : 'text-gray-400'}`}
+              >
                 PNG, JPG · Máx 2 MB · Recomendado: 400×400px
               </p>
             </div>
-            <input ref={fileRef} type="file" accept="image/png,image/jpeg,image/webp" className="hidden" onChange={handleLogoUpload} />
+            <input
+              ref={fileRef}
+              type="file"
+              accept="image/png,image/jpeg,image/webp"
+              className="hidden"
+              onChange={handleLogoUpload}
+            />
           </div>
         </div>
 
         {/* Datos básicos */}
         <div className={`rounded-xl border p-6 space-y-5 ${card}`}>
-          <h2 className={`text-base font-semibold ${isDarkMode ? 'text-white' : 'text-gray-900'}`}>
+          <h2
+            className={`text-base font-semibold ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
+          >
             Datos de la empresa
           </h2>
 
-          <div>
+          <div id="razon-social">
             <label className={labelClass}>Razón social *</label>
             <input
               type="text"
               value={form.razon_social}
-              onChange={(e) => setForm((f) => ({ ...f, razon_social: e.target.value }))}
+              onChange={(e) =>
+                setForm((f) => ({ ...f, razon_social: e.target.value }))
+              }
               placeholder="Ej: Empresa S.A."
               className={inputClass}
               maxLength={120}
@@ -289,7 +386,9 @@ export default function EmpresaPerfilPage() {
               <input
                 type="text"
                 value={form.nombre_comercial}
-                onChange={(e) => setForm((f) => ({ ...f, nombre_comercial: e.target.value }))}
+                onChange={(e) =>
+                  setForm((f) => ({ ...f, nombre_comercial: e.target.value }))
+                }
                 placeholder="Ej: MiEmpresa"
                 className={inputClass}
                 maxLength={80}
@@ -299,7 +398,9 @@ export default function EmpresaPerfilPage() {
               <label className={labelClass}>
                 RUC{' '}
                 {form.country === 'PY' && (
-                  <span className={`font-normal ${isDarkMode ? 'text-slate-500' : 'text-gray-400'}`}>
+                  <span
+                    className={`font-normal ${isDarkMode ? 'text-slate-500' : 'text-gray-400'}`}
+                  >
                     (formato: 80012345-6)
                   </span>
                 )}
@@ -307,7 +408,9 @@ export default function EmpresaPerfilPage() {
               <input
                 type="text"
                 value={form.ruc}
-                onChange={(e) => setForm((f) => ({ ...f, ruc: e.target.value }))}
+                onChange={(e) =>
+                  setForm((f) => ({ ...f, ruc: e.target.value }))
+                }
                 placeholder="Ej: 80012345-6"
                 className={inputClass}
                 maxLength={20}
@@ -315,27 +418,33 @@ export default function EmpresaPerfilPage() {
             </div>
           </div>
 
-          <div>
+          <div id="descripcion">
             <label className={labelClass}>Descripción</label>
             <textarea
               value={form.description}
-              onChange={(e) => setForm((f) => ({ ...f, description: e.target.value }))}
+              onChange={(e) =>
+                setForm((f) => ({ ...f, description: e.target.value }))
+              }
               rows={4}
               placeholder="¿Qué hace tu empresa? ¿Cuál es su cultura? ¿Qué buscan en un QA?"
               className={`${inputClass} resize-none`}
               maxLength={800}
             />
-            <p className={`text-xs mt-1 text-right ${isDarkMode ? 'text-slate-500' : 'text-gray-400'}`}>
+            <p
+              className={`text-xs mt-1 text-right ${isDarkMode ? 'text-slate-500' : 'text-gray-400'}`}
+            >
               {form.description.length}/800
             </p>
           </div>
 
-          <div>
+          <div id="website">
             <label className={labelClass}>Sitio web</label>
             <input
               type="url"
               value={form.website_url}
-              onChange={(e) => setForm((f) => ({ ...f, website_url: e.target.value }))}
+              onChange={(e) =>
+                setForm((f) => ({ ...f, website_url: e.target.value }))
+              }
               placeholder="https://miempresa.com"
               className={inputClass}
             />
@@ -344,46 +453,58 @@ export default function EmpresaPerfilPage() {
 
         {/* Contexto laboral */}
         <div className={`rounded-xl border p-6 space-y-5 ${card}`}>
-          <h2 className={`text-base font-semibold ${isDarkMode ? 'text-white' : 'text-gray-900'}`}>
+          <h2
+            className={`text-base font-semibold ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
+          >
             Contexto laboral
           </h2>
 
           <div className="grid grid-cols-2 gap-4">
-            <div>
+            <div id="industria">
               <label className={labelClass}>Industria / rubro</label>
               <select
                 value={form.industry}
-                onChange={(e) => setForm((f) => ({ ...f, industry: e.target.value }))}
+                onChange={(e) =>
+                  setForm((f) => ({ ...f, industry: e.target.value }))
+                }
                 className={inputClass}
               >
                 <option value="">Seleccioná...</option>
                 {INDUSTRIES.map((i) => (
-                  <option key={i.value} value={i.value}>{i.label}</option>
+                  <option key={i.value} value={i.value}>
+                    {i.label}
+                  </option>
                 ))}
               </select>
             </div>
-            <div>
+            <div id="pais">
               <label className={labelClass}>País / sede principal</label>
               <select
                 value={form.country}
-                onChange={(e) => setForm((f) => ({ ...f, country: e.target.value }))}
+                onChange={(e) =>
+                  setForm((f) => ({ ...f, country: e.target.value }))
+                }
                 className={inputClass}
               >
                 {COUNTRIES.map((c) => (
-                  <option key={c.value} value={c.value}>{c.label}</option>
+                  <option key={c.value} value={c.value}>
+                    {c.label}
+                  </option>
                 ))}
               </select>
             </div>
           </div>
 
-          <div>
+          <div id="team-size">
             <label className={labelClass}>Tamaño del equipo</label>
             <div className="flex flex-wrap gap-2">
               {TEAM_SIZES.map((ts) => (
                 <button
                   key={ts.value}
                   type="button"
-                  onClick={() => setForm((f) => ({ ...f, team_size: ts.value }))}
+                  onClick={() =>
+                    setForm((f) => ({ ...f, team_size: ts.value }))
+                  }
                   className={`px-3 py-1.5 rounded-lg text-sm font-medium border transition-colors ${
                     form.team_size === ts.value
                       ? 'border-indigo-500 bg-indigo-600 text-white'
@@ -401,12 +522,18 @@ export default function EmpresaPerfilPage() {
 
         {/* Preview link */}
         {empresa && (
-          <div className={`rounded-xl border p-4 flex items-center justify-between ${card}`}>
+          <div
+            className={`rounded-xl border p-4 flex items-center justify-between ${card}`}
+          >
             <div>
-              <p className={`text-sm font-medium ${isDarkMode ? 'text-slate-300' : 'text-gray-700'}`}>
+              <p
+                className={`text-sm font-medium ${isDarkMode ? 'text-slate-300' : 'text-gray-700'}`}
+              >
                 Vista pública de la empresa
               </p>
-              <p className={`text-xs mt-0.5 ${isDarkMode ? 'text-slate-500' : 'text-gray-400'}`}>
+              <p
+                className={`text-xs mt-0.5 ${isDarkMode ? 'text-slate-500' : 'text-gray-400'}`}
+              >
                 Así ve un candidato QA tu empresa
               </p>
             </div>
@@ -414,7 +541,9 @@ export default function EmpresaPerfilPage() {
               href={`/empresas/${empresa.id}`}
               target="_blank"
               className={`text-sm font-medium px-3 py-1.5 rounded-lg transition-colors ${
-                isDarkMode ? 'text-indigo-300 hover:bg-slate-700' : 'text-indigo-600 hover:bg-indigo-50'
+                isDarkMode
+                  ? 'text-indigo-300 hover:bg-slate-700'
+                  : 'text-indigo-600 hover:bg-indigo-50'
               }`}
             >
               Ver perfil →
@@ -432,7 +561,10 @@ export default function EmpresaPerfilPage() {
         </button>
 
         <div className="pb-4">
-          <Link href="/empresa" className={`text-sm ${isDarkMode ? 'text-slate-500 hover:text-slate-300' : 'text-gray-400 hover:text-gray-600'} transition-colors`}>
+          <Link
+            href="/empresa"
+            className={`text-sm ${isDarkMode ? 'text-slate-500 hover:text-slate-300' : 'text-gray-400 hover:text-gray-600'} transition-colors`}
+          >
             ← Volver al panel
           </Link>
         </div>

--- a/apps/frontend/src/app/labs/allpairs/page.tsx
+++ b/apps/frontend/src/app/labs/allpairs/page.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect } from 'react';
 import { PairwiseInput, PairwiseResult, toCsv } from '@aiquaa/allpairs-core';
 import { useToolUsage } from '@/hooks/useToolUsage';
+import labsService from '@/services/labsService';
 import EditorTab from './components/EditorTab';
 import JsonYamlTab from './components/JsonYamlTab';
 import ExamplesTab from './components/ExamplesTab';
@@ -71,6 +72,12 @@ export default function AllPairsPage() {
       }
 
       setResult(data);
+      void labsService
+        .trackAllPairs({
+          sessionId: crypto.randomUUID(),
+          combinationsCount: data.rows.length,
+        })
+        .catch(() => {});
     } catch (err: any) {
       void logError(err, 'generate');
       setError(err.message || 'Failed to generate pairwise combinations');
@@ -114,7 +121,8 @@ export default function AllPairsPage() {
             Generador All Pairs
           </h1>
           <p className="text-gray-600 dark:text-gray-400">
-            Genera combinaciones de pruebas pairwise para reducir casos de prueba manteniendo la cobertura
+            Genera combinaciones de pruebas pairwise para reducir casos de
+            prueba manteniendo la cobertura
           </p>
         </div>
 
@@ -150,9 +158,7 @@ export default function AllPairsPage() {
             {activeTab === 'json-yaml' && (
               <JsonYamlTab input={input} onChange={setInput} />
             )}
-            {activeTab === 'examples' && (
-              <ExamplesTab onSelect={setInput} />
-            )}
+            {activeTab === 'examples' && <ExamplesTab onSelect={setInput} />}
             {activeTab === 'help' && <HelpTab />}
           </div>
         </div>
@@ -172,7 +178,9 @@ export default function AllPairsPage() {
         {error && (
           <div className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg p-4 mb-6">
             <p className="text-red-800 dark:text-red-300 font-medium">Error</p>
-            <p className="text-red-600 dark:text-red-400 text-sm mt-1">{error}</p>
+            <p className="text-red-600 dark:text-red-400 text-sm mt-1">
+              {error}
+            </p>
           </div>
         )}
 


### PR DESCRIPTION
- Call labsService.trackAllPairs() after generation in AllPairs page (fixes #138). Backend endpoint already existed; frontend was only logging to Supabase analytics, never triggering the XP gamification handler.

- Add getMissingFields() to empresa perfil page and replace the generic progress bar hint text with a clickable checklist of unfilled fields (fixes #132). Add anchor ids to each form section so the links scroll correctly.