### PR TITLE
fix(empresa): show assessment_attempts results in proceso detail

### DIFF
--- a/apps/frontend/src/app/empresa/procesos/[id]/page.tsx
+++ b/apps/frontend/src/app/empresa/procesos/[id]/page.tsx
@@ -390,7 +390,7 @@ export default function ProcesoDetailPage() {
           .select(
             'id, total_score, percentage, passed, started_at, submitted_at, created_at, assessments!inner(slug), profiles(display_name, email)'
           )
-          .eq('metadata->>processCode', proc.code)
+          .filter('metadata->>processCode', 'eq', proc.code)
           .eq('status', 'graded')
           .order('percentage', { ascending: false }),
         getProspectsForProcessAction(proc.id),


### PR DESCRIPTION
## Summary

- Add second query to `assessment_attempts` in the empresa proceso detail page, alongside the existing `exam_results` query
- Filter by `metadata->>'processCode'` using `.filter()` (not `.eq()`) to avoid PostgREST URL-encoding issue with `>>` operator
- Map `assessment_attempts` fields to the existing `ExamResult` shape: name/email from `profiles`, exam type from `assessments.slug`, `time_spent` calculated from `started_at → submitted_at`
- Merge results from both sources into a single postulantes list/ranking

## Root cause

New SQL/DB assessments (`database-fundamentals`, `database-practice`) store results in `assessment_attempts` with `metadata.processCode`. The detail page only queried `exam_results`, so processes using the new assessment system showed 0 postulantes.

A secondary bug: `.eq('metadata->>processCode', value)` URL-encodes `>>` as `%3E%3E`, causing PostgREST to silently return 0 rows. Fixed with `.filter('metadata->>processCode', 'eq', value)`.

## DB changes (already applied to production)

- Added RLS policy `empresa_members_read_process_attempts` on `assessment_attempts` — allows empresa members and process creators to read attempts linked to their processes
- Updated `get_leaderboard()` function to query `assessment_attempts` for `database-fundamentals` and `database-practice` exam types (was only reading `exam_results`)

## Test plan

- [ ] Open `/empresa/procesos/<id>` for a process using `database-fundamentals` or `database-practice` — postulantes should appear
- [ ] Verify tabla and ranking views show candidates with name, score, time
- [ ] Verify legacy `exam_results` processes (git, istqb, etc.) still work
- [ ] Check `/ranking` tabs for Bases de Datos — Fundamentos and Práctica SQL show leaderboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)