### PR TITLE
feat(empresa): event groups to categorize hiring processes

### DIFF
--- a/apps/frontend/src/actions/employer.ts
+++ b/apps/frontend/src/actions/employer.ts
@@ -13,6 +13,15 @@ export interface HiringProcess {
   status: 'draft' | 'active' | 'closed';
   expires_at?: string;
   created_at: string;
+  group_id?: string | null;
+}
+
+export interface ProcessGroup {
+  id: string;
+  empresa_id: string;
+  name: string;
+  description?: string | null;
+  created_at: string;
 }
 
 export interface ProcessCandidate {
@@ -52,12 +61,107 @@ function generateCode(company: string): string {
   return `${slug}-${year}-${rand}`;
 }
 
+export async function getMyProcessGroupsAction(): Promise<{
+  data: ProcessGroup[] | null;
+  error: string | null;
+}> {
+  const supabase = createClient();
+  const {
+    data: { user },
+    error: userError,
+  } = await supabase.auth.getUser();
+  if (userError || !user) return { error: 'No autenticado', data: null };
+
+  const { data, error } = await supabase
+    .from('hiring_process_groups')
+    .select('*')
+    .order('created_at', { ascending: true });
+
+  if (error) return { error: error.message, data: null };
+  return { data: data ?? [], error: null };
+}
+
+export async function createProcessGroupAction(payload: {
+  name: string;
+  description?: string;
+}): Promise<{ data: ProcessGroup | null; error: string | null }> {
+  const supabase = createClient();
+  const {
+    data: { user },
+    error: userError,
+  } = await supabase.auth.getUser();
+  if (userError || !user) return { error: 'No autenticado', data: null };
+
+  const { data: membership } = await supabase
+    .from('empresa_miembros')
+    .select('empresa_id')
+    .eq('user_id', user.id)
+    .eq('status', 'active')
+    .single();
+
+  if (!membership?.empresa_id)
+    return { error: 'No pertenecés a ninguna empresa', data: null };
+
+  const { data, error } = await supabase
+    .from('hiring_process_groups')
+    .insert({
+      empresa_id: membership.empresa_id,
+      name: payload.name.trim(),
+      description: payload.description?.trim() || null,
+    })
+    .select()
+    .single();
+
+  if (error) return { error: error.message, data: null };
+  return { data, error: null };
+}
+
+export async function deleteProcessGroupAction(
+  groupId: string
+): Promise<{ error: string | null }> {
+  const supabase = createClient();
+  const {
+    data: { user },
+    error: userError,
+  } = await supabase.auth.getUser();
+  if (userError || !user) return { error: 'No autenticado' };
+
+  const { error } = await supabase
+    .from('hiring_process_groups')
+    .delete()
+    .eq('id', groupId);
+
+  if (error) return { error: error.message };
+  return { error: null };
+}
+
+export async function assignProcessToGroupAction(
+  processId: string,
+  groupId: string | null
+): Promise<{ error: string | null }> {
+  const supabase = createClient();
+  const {
+    data: { user },
+    error: userError,
+  } = await supabase.auth.getUser();
+  if (userError || !user) return { error: 'No autenticado' };
+
+  const { error } = await supabase
+    .from('hiring_processes')
+    .update({ group_id: groupId })
+    .eq('id', processId);
+
+  if (error) return { error: error.message };
+  return { error: null };
+}
+
 export async function createHiringProcessAction(payload: {
   company_name: string;
   position_name: string;
   description?: string;
   exam_types: string[];
   expires_at?: string;
+  group_id?: string | null;
 }) {
   const supabase = createClient();
   const {
@@ -75,14 +179,16 @@ export async function createHiringProcessAction(payload: {
     .eq('id', user.id)
     .single();
 
+  const { group_id, ...rest } = payload;
   const { data, error } = await supabase
     .from('hiring_processes')
     .insert({
-      ...payload,
+      ...rest,
       code,
       created_by: user.id,
       status: 'active',
       ...(profile?.empresa_id ? { empresa_id: profile.empresa_id } : {}),
+      ...(group_id ? { group_id } : {}),
     })
     .select()
     .single();

--- a/apps/frontend/src/app/empresa/eventos/page.tsx
+++ b/apps/frontend/src/app/empresa/eventos/page.tsx
@@ -1,0 +1,402 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { useTheme } from '@/contexts/ThemeContext';
+import { createClient } from '@/lib/supabase/client';
+import {
+  getMyProcessGroupsAction,
+  createProcessGroupAction,
+  deleteProcessGroupAction,
+  assignProcessToGroupAction,
+  type ProcessGroup,
+} from '@/actions/employer';
+
+type Process = {
+  id: string;
+  code: string;
+  position_name: string;
+  status: 'draft' | 'active' | 'closed';
+  group_id: string | null;
+};
+
+const statusLabel: Record<string, string> = {
+  active: 'Activo',
+  draft: 'Borrador',
+  closed: 'Cerrado',
+};
+
+export default function EventosPage() {
+  const { isDarkMode } = useTheme();
+  const [groups, setGroups] = useState<ProcessGroup[]>([]);
+  const [processes, setProcesses] = useState<Process[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [newGroupName, setNewGroupName] = useState('');
+  const [newGroupDesc, setNewGroupDesc] = useState('');
+  const [creating, setCreating] = useState(false);
+  const [showForm, setShowForm] = useState(false);
+  const [deletingId, setDeletingId] = useState<string | null>(null);
+  const [addingToGroup, setAddingToGroup] = useState<string | null>(null);
+  const [selectedProcess, setSelectedProcess] = useState<string>('');
+  const [error, setError] = useState<string | null>(null);
+
+  const load = async () => {
+    const supabase = createClient();
+    const [groupsRes, processesRes] = await Promise.all([
+      getMyProcessGroupsAction(),
+      supabase
+        .from('hiring_processes')
+        .select('id, code, position_name, status, group_id')
+        .order('created_at', { ascending: false }),
+    ]);
+    setGroups(groupsRes.data ?? []);
+    setProcesses((processesRes.data ?? []) as Process[]);
+    setLoading(false);
+  };
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  const handleCreateGroup = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!newGroupName.trim()) return;
+    setCreating(true);
+    setError(null);
+    const res = await createProcessGroupAction({
+      name: newGroupName,
+      description: newGroupDesc,
+    });
+    if (res.error) {
+      setError(res.error);
+    } else {
+      setNewGroupName('');
+      setNewGroupDesc('');
+      setShowForm(false);
+      await load();
+    }
+    setCreating(false);
+  };
+
+  const handleDeleteGroup = async (groupId: string) => {
+    if (!confirm('¿Eliminar este evento? Los procesos quedarán sin categoría.'))
+      return;
+    setDeletingId(groupId);
+    await deleteProcessGroupAction(groupId);
+    setDeletingId(null);
+    await load();
+  };
+
+  const handleAssign = async (groupId: string) => {
+    if (!selectedProcess) return;
+    await assignProcessToGroupAction(selectedProcess, groupId);
+    setAddingToGroup(null);
+    setSelectedProcess('');
+    await load();
+  };
+
+  const handleUnassign = async (processId: string) => {
+    await assignProcessToGroupAction(processId, null);
+    await load();
+  };
+
+  const ungrouped = processes.filter((p) => !p.group_id);
+
+  const cardClass = `rounded-xl border ${isDarkMode ? 'bg-dark-secondary border-slate-700' : 'bg-white border-gray-200'}`;
+  const inputClass = `rounded-lg border px-3 py-2 text-sm outline-none transition-colors focus:ring-2 focus:ring-indigo-500 ${
+    isDarkMode
+      ? 'bg-slate-700 border-slate-600 text-white placeholder-slate-400'
+      : 'bg-white border-gray-300 text-gray-900 placeholder-gray-400'
+  }`;
+
+  return (
+    <div
+      className={`min-h-screen transition-colors duration-300 ${isDarkMode ? 'bg-dark-bg' : 'bg-gray-50'}`}
+    >
+      <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+        {/* Header */}
+        <div className="flex items-center justify-between mb-8">
+          <div>
+            <h1
+              className={`text-2xl font-bold ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
+            >
+              Eventos y categorías
+            </h1>
+            <p
+              className={`text-sm mt-1 ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}
+            >
+              Agrupá tus procesos por bootcamp, evento o campaña de selección
+            </p>
+          </div>
+          {!showForm && (
+            <button
+              onClick={() => setShowForm(true)}
+              className="inline-flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-semibold bg-indigo-600 text-white hover:bg-indigo-700 transition-colors"
+            >
+              + Nuevo evento
+            </button>
+          )}
+        </div>
+
+        {/* Create group form */}
+        {showForm && (
+          <form
+            onSubmit={handleCreateGroup}
+            className={`${cardClass} p-5 mb-6 space-y-3`}
+          >
+            <h2
+              className={`text-sm font-semibold ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
+            >
+              Nuevo evento
+            </h2>
+            <input
+              className={`${inputClass} w-full`}
+              placeholder="Nombre del evento (ej. Bootcamp 2026 CLT)"
+              value={newGroupName}
+              onChange={(e) => setNewGroupName(e.target.value)}
+              required
+              maxLength={100}
+              autoFocus
+            />
+            <input
+              className={`${inputClass} w-full`}
+              placeholder="Descripción (opcional)"
+              value={newGroupDesc}
+              onChange={(e) => setNewGroupDesc(e.target.value)}
+              maxLength={300}
+            />
+            {error && <p className="text-sm text-red-500">{error}</p>}
+            <div className="flex gap-2">
+              <button
+                type="submit"
+                disabled={creating || !newGroupName.trim()}
+                className="px-4 py-2 rounded-lg text-sm font-semibold bg-indigo-600 text-white hover:bg-indigo-700 disabled:opacity-50 transition-colors"
+              >
+                {creating ? 'Creando...' : 'Crear evento'}
+              </button>
+              <button
+                type="button"
+                onClick={() => {
+                  setShowForm(false);
+                  setError(null);
+                }}
+                className={`px-4 py-2 rounded-lg text-sm font-medium transition-colors ${isDarkMode ? 'text-slate-300 hover:bg-slate-700' : 'text-gray-700 hover:bg-gray-100'}`}
+              >
+                Cancelar
+              </button>
+            </div>
+          </form>
+        )}
+
+        {loading && (
+          <div
+            className={`text-center py-16 ${isDarkMode ? 'text-slate-400' : 'text-gray-400'}`}
+          >
+            Cargando...
+          </div>
+        )}
+
+        {!loading && (
+          <div className="space-y-4">
+            {/* Groups */}
+            {groups.map((group) => {
+              const groupProcesses = processes.filter(
+                (p) => p.group_id === group.id
+              );
+              const availableToAdd = ungrouped;
+              const isAddingHere = addingToGroup === group.id;
+
+              return (
+                <div key={group.id} className={`${cardClass} p-5`}>
+                  <div className="flex items-start justify-between gap-4 mb-4">
+                    <div>
+                      <h2
+                        className={`font-semibold text-base ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
+                      >
+                        {group.name}
+                      </h2>
+                      {group.description && (
+                        <p
+                          className={`text-xs mt-0.5 ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}
+                        >
+                          {group.description}
+                        </p>
+                      )}
+                    </div>
+                    <button
+                      onClick={() => handleDeleteGroup(group.id)}
+                      disabled={deletingId === group.id}
+                      className={`shrink-0 text-xs px-2 py-1 rounded transition-colors ${
+                        isDarkMode
+                          ? 'text-red-400 hover:bg-red-900/30'
+                          : 'text-red-500 hover:bg-red-50'
+                      }`}
+                      title="Eliminar evento"
+                    >
+                      {deletingId === group.id ? '...' : '🗑️ Eliminar'}
+                    </button>
+                  </div>
+
+                  {/* Process chips */}
+                  <div className="flex flex-wrap gap-2 mb-3">
+                    {groupProcesses.length === 0 && (
+                      <span
+                        className={`text-xs ${isDarkMode ? 'text-slate-500' : 'text-gray-400'}`}
+                      >
+                        Sin procesos asignados
+                      </span>
+                    )}
+                    {groupProcesses.map((p) => (
+                      <div
+                        key={p.id}
+                        className={`inline-flex items-center gap-1.5 pl-3 pr-1.5 py-1 rounded-full text-xs font-mono border ${
+                          isDarkMode
+                            ? 'bg-slate-700 border-slate-600 text-slate-200'
+                            : 'bg-gray-50 border-gray-200 text-gray-700'
+                        }`}
+                      >
+                        <Link
+                          href={`/empresa/procesos/${p.id}`}
+                          className="hover:underline"
+                          title={p.position_name}
+                        >
+                          {p.code}
+                        </Link>
+                        <span
+                          className={`text-xs ${
+                            p.status === 'active'
+                              ? 'text-green-500'
+                              : p.status === 'closed'
+                                ? 'text-red-400'
+                                : 'text-gray-400'
+                          }`}
+                        >
+                          · {statusLabel[p.status]}
+                        </span>
+                        <button
+                          onClick={() => handleUnassign(p.id)}
+                          className={`ml-0.5 w-4 h-4 flex items-center justify-center rounded-full text-xs transition-colors ${
+                            isDarkMode
+                              ? 'hover:bg-slate-600 text-slate-400'
+                              : 'hover:bg-gray-200 text-gray-400'
+                          }`}
+                          title="Quitar del evento"
+                        >
+                          ✕
+                        </button>
+                      </div>
+                    ))}
+                  </div>
+
+                  {/* Add process to group */}
+                  {!isAddingHere ? (
+                    <button
+                      onClick={() => {
+                        setAddingToGroup(group.id);
+                        setSelectedProcess('');
+                      }}
+                      disabled={availableToAdd.length === 0}
+                      className={`text-xs font-medium transition-colors disabled:opacity-40 ${
+                        isDarkMode
+                          ? 'text-indigo-400 hover:text-indigo-300'
+                          : 'text-indigo-600 hover:text-indigo-500'
+                      }`}
+                    >
+                      + Agregar proceso
+                    </button>
+                  ) : (
+                    <div className="flex items-center gap-2 mt-1">
+                      <select
+                        className={`${inputClass} text-xs py-1.5`}
+                        value={selectedProcess}
+                        onChange={(e) => setSelectedProcess(e.target.value)}
+                        autoFocus
+                      >
+                        <option value="">— Seleccioná un proceso —</option>
+                        {availableToAdd.map((p) => (
+                          <option key={p.id} value={p.id}>
+                            {p.code} — {p.position_name}
+                          </option>
+                        ))}
+                      </select>
+                      <button
+                        onClick={() => handleAssign(group.id)}
+                        disabled={!selectedProcess}
+                        className="px-3 py-1.5 rounded-lg text-xs font-semibold bg-indigo-600 text-white hover:bg-indigo-700 disabled:opacity-50 transition-colors"
+                      >
+                        Agregar
+                      </button>
+                      <button
+                        onClick={() => {
+                          setAddingToGroup(null);
+                          setSelectedProcess('');
+                        }}
+                        className={`text-xs ${isDarkMode ? 'text-slate-400 hover:text-slate-200' : 'text-gray-500 hover:text-gray-700'}`}
+                      >
+                        Cancelar
+                      </button>
+                    </div>
+                  )}
+                </div>
+              );
+            })}
+
+            {/* Ungrouped */}
+            {ungrouped.length > 0 && (
+              <div>
+                <p
+                  className={`text-xs font-semibold uppercase tracking-wider mb-2 px-1 ${isDarkMode ? 'text-slate-500' : 'text-gray-400'}`}
+                >
+                  Sin categoría
+                </p>
+                <div className={`${cardClass} p-5`}>
+                  <div className="flex flex-wrap gap-2">
+                    {ungrouped.map((p) => (
+                      <Link
+                        key={p.id}
+                        href={`/empresa/procesos/${p.id}`}
+                        className={`inline-flex items-center gap-1.5 px-3 py-1 rounded-full text-xs font-mono border transition-colors ${
+                          isDarkMode
+                            ? 'bg-slate-700 border-slate-600 text-slate-300 hover:border-slate-500'
+                            : 'bg-gray-50 border-gray-200 text-gray-600 hover:border-gray-300'
+                        }`}
+                        title={p.position_name}
+                      >
+                        {p.code}
+                      </Link>
+                    ))}
+                  </div>
+                </div>
+              </div>
+            )}
+
+            {groups.length === 0 && ungrouped.length === 0 && (
+              <div
+                className={`text-center py-16 rounded-xl border-2 border-dashed ${
+                  isDarkMode
+                    ? 'border-slate-700 text-slate-500'
+                    : 'border-gray-200 text-gray-400'
+                }`}
+              >
+                <p className="text-4xl mb-3">🗂️</p>
+                <p className="font-medium mb-1">No hay eventos todavía</p>
+                <p className="text-sm">
+                  Creá un evento para agrupar tus procesos de selección
+                </p>
+              </div>
+            )}
+          </div>
+        )}
+
+        <div className="mt-8">
+          <Link
+            href="/empresa"
+            className={`text-sm ${isDarkMode ? 'text-slate-500 hover:text-slate-300' : 'text-gray-400 hover:text-gray-600'} transition-colors`}
+          >
+            ← Volver al panel
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/src/app/empresa/page.tsx
+++ b/apps/frontend/src/app/empresa/page.tsx
@@ -46,6 +46,12 @@ const BASE_LINKS = [
     description: 'Invitá candidatos QA directamente a rendir',
   },
   {
+    href: '/empresa/eventos',
+    emoji: '🗂️',
+    title: 'Eventos y categorías',
+    description: 'Agrupá tus procesos por bootcamp, evento o campaña',
+  },
+  {
     href: '/empresa/perfil',
     emoji: '🏢',
     title: 'Perfil de empresa',
@@ -76,14 +82,20 @@ function StatCard({
   href?: string;
 }) {
   const inner = (
-    <div className={`rounded-xl border p-4 relative ${isDarkMode ? 'bg-dark-secondary border-dark-secondary' : 'bg-white border-gray-200'} ${href ? 'hover:border-indigo-400 transition-colors cursor-pointer' : ''}`}>
+    <div
+      className={`rounded-xl border p-4 relative ${isDarkMode ? 'bg-dark-secondary border-dark-secondary' : 'bg-white border-gray-200'} ${href ? 'hover:border-indigo-400 transition-colors cursor-pointer' : ''}`}
+    >
       {badge && (
         <span className="absolute top-3 right-3 text-xs font-bold bg-red-500 text-white rounded-full px-1.5 py-0.5 leading-none">
           {badge}
         </span>
       )}
       <p className={`text-2xl font-bold ${color}`}>{value}</p>
-      <p className={`text-xs mt-1 ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}>{label}</p>
+      <p
+        className={`text-xs mt-1 ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}
+      >
+        {label}
+      </p>
     </div>
   );
   return href ? <Link href={href}>{inner}</Link> : inner;
@@ -91,9 +103,15 @@ function StatCard({
 
 function SkeletonCard({ isDarkMode }: { isDarkMode: boolean }) {
   return (
-    <div className={`rounded-xl border p-4 animate-pulse ${isDarkMode ? 'bg-dark-secondary border-dark-secondary' : 'bg-white border-gray-200'}`}>
-      <div className={`h-7 w-12 rounded mb-2 ${isDarkMode ? 'bg-slate-700' : 'bg-gray-200'}`} />
-      <div className={`h-3 w-20 rounded ${isDarkMode ? 'bg-slate-700' : 'bg-gray-200'}`} />
+    <div
+      className={`rounded-xl border p-4 animate-pulse ${isDarkMode ? 'bg-dark-secondary border-dark-secondary' : 'bg-white border-gray-200'}`}
+    >
+      <div
+        className={`h-7 w-12 rounded mb-2 ${isDarkMode ? 'bg-slate-700' : 'bg-gray-200'}`}
+      />
+      <div
+        className={`h-3 w-20 rounded ${isDarkMode ? 'bg-slate-700' : 'bg-gray-200'}`}
+      />
     </div>
   );
 }
@@ -108,7 +126,9 @@ export default function EmpresaDashboardPage() {
 
   useEffect(() => {
     if (typeof window !== 'undefined') {
-      setBannerDismissed(localStorage.getItem('empresa_banner_dismissed') === '1');
+      setBannerDismissed(
+        localStorage.getItem('empresa_banner_dismissed') === '1'
+      );
     }
   }, []);
 
@@ -137,18 +157,23 @@ export default function EmpresaDashboardPage() {
   const links = isAdmin ? [...BASE_LINKS, ADMIN_LINK] : BASE_LINKS;
 
   return (
-    <div className={`min-h-screen transition-colors duration-300 ${isDarkMode ? 'bg-dark-bg' : 'bg-gray-50'}`}>
+    <div
+      className={`min-h-screen transition-colors duration-300 ${isDarkMode ? 'bg-dark-bg' : 'bg-gray-50'}`}
+    >
       <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
-
         {/* Header */}
         <div className="mb-8">
           <div className="flex items-center gap-3 mb-1">
             <span className="text-3xl">🏢</span>
-            <h1 className={`text-3xl font-bold ${isDarkMode ? 'text-white' : 'text-gray-900'}`}>
+            <h1
+              className={`text-3xl font-bold ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
+            >
               {companyName}
             </h1>
           </div>
-          <p className={`text-sm ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}>
+          <p
+            className={`text-sm ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}
+          >
             Panel de empresa — AIQUAA
           </p>
         </div>
@@ -156,34 +181,82 @@ export default function EmpresaDashboardPage() {
         {/* Stats grid — always visible */}
         <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-8">
           {statsLoading ? (
-            Array.from({ length: 8 }).map((_, i) => <SkeletonCard key={i} isDarkMode={isDarkMode} />)
+            Array.from({ length: 8 }).map((_, i) => (
+              <SkeletonCard key={i} isDarkMode={isDarkMode} />
+            ))
           ) : (
             <>
-              <StatCard label="Procesos activos" value={stats?.activeProcesses ?? 0} color="text-green-500" isDarkMode={isDarkMode} href="/empresa/procesos" />
-              <StatCard label="Candidatos evaluados" value={stats?.totalCandidates ?? 0} color="text-indigo-500" isDarkMode={isDarkMode} href="/empresa/candidatos" />
-              <StatCard label="Tasa de aprobación" value={stats?.totalCandidates ? `${stats.passRate}%` : '—'} color="text-emerald-500" isDarkMode={isDarkMode} />
+              <StatCard
+                label="Procesos activos"
+                value={stats?.activeProcesses ?? 0}
+                color="text-green-500"
+                isDarkMode={isDarkMode}
+                href="/empresa/procesos"
+              />
+              <StatCard
+                label="Candidatos evaluados"
+                value={stats?.totalCandidates ?? 0}
+                color="text-indigo-500"
+                isDarkMode={isDarkMode}
+                href="/empresa/candidatos"
+              />
+              <StatCard
+                label="Tasa de aprobación"
+                value={stats?.totalCandidates ? `${stats.passRate}%` : '—'}
+                color="text-emerald-500"
+                isDarkMode={isDarkMode}
+              />
               <StatCard
                 label="Tiempo promedio"
-                value={stats?.avgTimeSpentMinutes != null ? `${stats.avgTimeSpentMinutes}m` : '—'}
+                value={
+                  stats?.avgTimeSpentMinutes != null
+                    ? `${stats.avgTimeSpentMinutes}m`
+                    : '—'
+                }
                 color="text-amber-500"
                 isDarkMode={isDarkMode}
               />
-              <StatCard label="Total procesos" value={stats?.totalProcesses ?? 0} color="text-slate-500" isDarkMode={isDarkMode} href="/empresa/procesos" />
-              <StatCard label="Procesos cerrados" value={stats?.closedProcesses ?? 0} color="text-slate-400" isDarkMode={isDarkMode} />
+              <StatCard
+                label="Total procesos"
+                value={stats?.totalProcesses ?? 0}
+                color="text-slate-500"
+                isDarkMode={isDarkMode}
+                href="/empresa/procesos"
+              />
+              <StatCard
+                label="Procesos cerrados"
+                value={stats?.closedProcesses ?? 0}
+                color="text-slate-400"
+                isDarkMode={isDarkMode}
+              />
               <StatCard
                 label="Prospectos pendientes"
                 value={stats?.pendingProspects ?? 0}
-                color={stats?.pendingProspects ? 'text-orange-500' : 'text-slate-400'}
+                color={
+                  stats?.pendingProspects ? 'text-orange-500' : 'text-slate-400'
+                }
                 isDarkMode={isDarkMode}
-                badge={stats?.pendingProspects ? String(stats.pendingProspects) : undefined}
+                badge={
+                  stats?.pendingProspects
+                    ? String(stats.pendingProspects)
+                    : undefined
+                }
                 href="/empresa/procesos"
               />
               <StatCard
                 label="Invitaciones activas"
                 value={stats?.pendingInvitaciones ?? 0}
-                color={stats?.pendingInvitaciones ? 'text-blue-500' : 'text-slate-400'}
+                color={
+                  stats?.pendingInvitaciones
+                    ? 'text-blue-500'
+                    : 'text-slate-400'
+                }
                 isDarkMode={isDarkMode}
-                badge={stats?.pendingInvitaciones ? String(stats.pendingInvitaciones) : undefined}
+                badge={
+                  stats?.pendingInvitaciones
+                    ? String(stats.pendingInvitaciones)
+                    : undefined
+                }
                 href="/empresa/invitaciones"
               />
             </>
@@ -192,13 +265,20 @@ export default function EmpresaDashboardPage() {
 
         {/* Empty state CTA when no activity */}
         {!statsLoading && stats?.totalProcesses === 0 && (
-          <div className={`rounded-xl border-2 border-dashed p-8 text-center mb-8 ${isDarkMode ? 'border-slate-700' : 'border-gray-200'}`}>
+          <div
+            className={`rounded-xl border-2 border-dashed p-8 text-center mb-8 ${isDarkMode ? 'border-slate-700' : 'border-gray-200'}`}
+          >
             <p className="text-3xl mb-3">🚀</p>
-            <p className={`font-semibold text-base mb-1 ${isDarkMode ? 'text-white' : 'text-gray-900'}`}>
+            <p
+              className={`font-semibold text-base mb-1 ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
+            >
               ¡Empezá a reclutar talento QA!
             </p>
-            <p className={`text-sm mb-5 ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}>
-              Creá tu primer proceso de selección y compartí el código con los candidatos
+            <p
+              className={`text-sm mb-5 ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}
+            >
+              Creá tu primer proceso de selección y compartí el código con los
+              candidatos
             </p>
             <div className="flex gap-3 justify-center">
               <Link
@@ -219,17 +299,24 @@ export default function EmpresaDashboardPage() {
 
         {/* Welcome banner — collapsible after first visit */}
         {!bannerDismissed && (
-          <div className={`rounded-xl border p-5 mb-8 flex items-start gap-4 ${
-            isDarkMode
-              ? 'bg-indigo-900/30 border-indigo-700/50 text-indigo-200'
-              : 'bg-indigo-50 border-indigo-200 text-indigo-800'
-          }`}>
+          <div
+            className={`rounded-xl border p-5 mb-8 flex items-start gap-4 ${
+              isDarkMode
+                ? 'bg-indigo-900/30 border-indigo-700/50 text-indigo-200'
+                : 'bg-indigo-50 border-indigo-200 text-indigo-800'
+            }`}
+          >
             <span className="text-2xl shrink-0">🎯</span>
             <div className="flex-1">
-              <p className="font-semibold text-base mb-1">¡Bienvenido a tu panel de empresa!</p>
-              <p className={`text-sm ${isDarkMode ? 'text-indigo-300' : 'text-indigo-600'}`}>
-                Creá procesos de selección, compartí el código con tus candidatos
-                y revisá sus resultados de exámenes técnicos en un solo lugar.
+              <p className="font-semibold text-base mb-1">
+                ¡Bienvenido a tu panel de empresa!
+              </p>
+              <p
+                className={`text-sm ${isDarkMode ? 'text-indigo-300' : 'text-indigo-600'}`}
+              >
+                Creá procesos de selección, compartí el código con tus
+                candidatos y revisá sus resultados de exámenes técnicos en un
+                solo lugar.
               </p>
             </div>
             <button
@@ -257,10 +344,14 @@ export default function EmpresaDashboardPage() {
               <div className="flex items-start gap-4">
                 <span className="text-2xl">{item.emoji}</span>
                 <div>
-                  <p className={`font-semibold text-sm mb-0.5 ${isDarkMode ? 'text-white' : 'text-gray-900'}`}>
+                  <p
+                    className={`font-semibold text-sm mb-0.5 ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
+                  >
                     {item.title}
                   </p>
-                  <p className={`text-xs ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}>
+                  <p
+                    className={`text-xs ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}
+                  >
                     {item.description}
                   </p>
                 </div>
@@ -272,8 +363,12 @@ export default function EmpresaDashboardPage() {
         {/* Charts — only when there's data */}
         {stats && (stats.totalProcesses > 0 || stats.totalCandidates > 0) && (
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 mb-8">
-            <div className={`rounded-xl border p-4 ${isDarkMode ? 'bg-dark-secondary border-dark-secondary' : 'bg-white border-gray-200'}`}>
-              <h3 className={`text-sm font-semibold mb-3 ${isDarkMode ? 'text-slate-300' : 'text-gray-700'}`}>
+            <div
+              className={`rounded-xl border p-4 ${isDarkMode ? 'bg-dark-secondary border-dark-secondary' : 'bg-white border-gray-200'}`}
+            >
+              <h3
+                className={`text-sm font-semibold mb-3 ${isDarkMode ? 'text-slate-300' : 'text-gray-700'}`}
+              >
                 Procesos creados (6 meses)
               </h3>
               <div className="h-52">
@@ -283,14 +378,23 @@ export default function EmpresaDashboardPage() {
                     <XAxis dataKey="month" tick={{ fontSize: 11 }} />
                     <YAxis allowDecimals={false} tick={{ fontSize: 11 }} />
                     <Tooltip formatter={(v) => [v, 'Procesos']} />
-                    <Bar dataKey="value" fill="#6366f1" radius={[4, 4, 0, 0]} name="Procesos" />
+                    <Bar
+                      dataKey="value"
+                      fill="#6366f1"
+                      radius={[4, 4, 0, 0]}
+                      name="Procesos"
+                    />
                   </BarChart>
                 </ResponsiveContainer>
               </div>
             </div>
 
-            <div className={`rounded-xl border p-4 ${isDarkMode ? 'bg-dark-secondary border-dark-secondary' : 'bg-white border-gray-200'}`}>
-              <h3 className={`text-sm font-semibold mb-3 ${isDarkMode ? 'text-slate-300' : 'text-gray-700'}`}>
+            <div
+              className={`rounded-xl border p-4 ${isDarkMode ? 'bg-dark-secondary border-dark-secondary' : 'bg-white border-gray-200'}`}
+            >
+              <h3
+                className={`text-sm font-semibold mb-3 ${isDarkMode ? 'text-slate-300' : 'text-gray-700'}`}
+              >
                 Candidatos evaluados (6 meses)
               </h3>
               <div className="h-52">
@@ -300,7 +404,12 @@ export default function EmpresaDashboardPage() {
                     <XAxis dataKey="month" tick={{ fontSize: 11 }} />
                     <YAxis allowDecimals={false} tick={{ fontSize: 11 }} />
                     <Tooltip formatter={(v) => [v, 'Candidatos']} />
-                    <Bar dataKey="value" fill="#f59e0b" radius={[4, 4, 0, 0]} name="Candidatos" />
+                    <Bar
+                      dataKey="value"
+                      fill="#f59e0b"
+                      radius={[4, 4, 0, 0]}
+                      name="Candidatos"
+                    />
                   </BarChart>
                 </ResponsiveContainer>
               </div>
@@ -309,9 +418,14 @@ export default function EmpresaDashboardPage() {
         )}
 
         <div className="text-center">
-          <p className={`text-sm ${isDarkMode ? 'text-slate-500' : 'text-gray-400'}`}>
+          <p
+            className={`text-sm ${isDarkMode ? 'text-slate-500' : 'text-gray-400'}`}
+          >
             ¿Querés explorar la comunidad?{' '}
-            <Link href="/forum" className={`underline transition-colors ${isDarkMode ? 'text-indigo-400 hover:text-indigo-300' : 'text-indigo-600 hover:text-indigo-500'}`}>
+            <Link
+              href="/forum"
+              className={`underline transition-colors ${isDarkMode ? 'text-indigo-400 hover:text-indigo-300' : 'text-indigo-600 hover:text-indigo-500'}`}
+            >
               Ir al foro
             </Link>
           </p>

--- a/apps/frontend/src/app/empresa/procesos/nuevo/page.tsx
+++ b/apps/frontend/src/app/empresa/procesos/nuevo/page.tsx
@@ -1,10 +1,14 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import { useTheme } from '@/contexts/ThemeContext';
 import { createClient } from '@/lib/supabase/client';
 import Link from 'next/link';
+import {
+  getMyProcessGroupsAction,
+  type ProcessGroup,
+} from '@/actions/employer';
 
 const EXAM_OPTIONS = [
   {
@@ -72,11 +76,17 @@ export default function NuevoProcesoPage() {
   const [examTypes, setExamTypes] = useState<string[]>([]);
   const [expiresAt, setExpiresAt] = useState('');
   const [status, setStatus] = useState<'draft' | 'active'>('active');
+  const [groupId, setGroupId] = useState<string>('');
+  const [groups, setGroups] = useState<ProcessGroup[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [createdCode, setCreatedCode] = useState<string | null>(null);
   const [createdId, setCreatedId] = useState<string | null>(null);
   const [codeCopied, setCodeCopied] = useState(false);
+
+  useEffect(() => {
+    getMyProcessGroupsAction().then(({ data }) => setGroups(data ?? []));
+  }, []);
 
   const toggleExam = (id: string) => {
     setExamTypes((prev) =>
@@ -136,6 +146,7 @@ export default function NuevoProcesoPage() {
         exam_types: examTypes,
         status,
         expires_at: expiresAt || null,
+        ...(groupId ? { group_id: groupId } : {}),
       });
 
     if (insertError) {
@@ -295,6 +306,32 @@ export default function NuevoProcesoPage() {
               maxLength={500}
             />
           </div>
+
+          {/* Event group */}
+          {groups.length > 0 && (
+            <div>
+              <label className={labelClass}>
+                Evento{' '}
+                <span
+                  className={isDarkMode ? 'text-slate-500' : 'text-gray-400'}
+                >
+                  (opcional)
+                </span>
+              </label>
+              <select
+                className={inputClass}
+                value={groupId}
+                onChange={(e) => setGroupId(e.target.value)}
+              >
+                <option value="">— Sin categoría —</option>
+                {groups.map((g) => (
+                  <option key={g.id} value={g.id}>
+                    {g.name}
+                  </option>
+                ))}
+              </select>
+            </div>
+          )}
 
           {/* Exam types */}
           <div>

--- a/apps/frontend/src/app/empresa/procesos/page.tsx
+++ b/apps/frontend/src/app/empresa/procesos/page.tsx
@@ -4,6 +4,10 @@ import Link from 'next/link';
 import { useEffect, useState } from 'react';
 import { useTheme } from '@/contexts/ThemeContext';
 import { createClient } from '@/lib/supabase/client';
+import {
+  getMyProcessGroupsAction,
+  type ProcessGroup,
+} from '@/actions/employer';
 
 type HiringProcess = {
   id: string;
@@ -14,58 +18,173 @@ type HiringProcess = {
   exam_types: string[];
   expires_at: string | null;
   created_at: string;
+  group_id: string | null;
 };
 
 const statusLabel: Record<string, { text: string; className: string }> = {
-  draft:  { text: 'Borrador',  className: 'bg-gray-100 text-gray-600' },
-  active: { text: 'Activo',    className: 'bg-green-100 text-green-700' },
-  closed: { text: 'Cerrado',   className: 'bg-red-100 text-red-600' },
+  draft: { text: 'Borrador', className: 'bg-gray-100 text-gray-600' },
+  active: { text: 'Activo', className: 'bg-green-100 text-green-700' },
+  closed: { text: 'Cerrado', className: 'bg-red-100 text-red-600' },
 };
+
+function ProcessCard({
+  p,
+  isDarkMode,
+}: {
+  p: HiringProcess;
+  isDarkMode: boolean;
+}) {
+  const s = statusLabel[p.status] ?? statusLabel.draft;
+  return (
+    <div
+      className={`rounded-xl border p-5 transition-colors ${
+        isDarkMode
+          ? 'bg-dark-secondary border-slate-700'
+          : 'bg-white border-gray-200'
+      }`}
+    >
+      <div className="flex items-start justify-between gap-4">
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2 flex-wrap mb-1">
+            <h2
+              className={`font-semibold text-base ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
+            >
+              {p.position_name}
+            </h2>
+            <span
+              className={`text-xs font-medium px-2 py-0.5 rounded-full ${
+                isDarkMode
+                  ? p.status === 'active'
+                    ? 'bg-green-900/40 text-green-300'
+                    : p.status === 'closed'
+                      ? 'bg-red-900/40 text-red-300'
+                      : 'bg-slate-700 text-slate-400'
+                  : s.className
+              }`}
+            >
+              {s.text}
+            </span>
+          </div>
+          {p.description && (
+            <p
+              className={`text-sm mb-2 line-clamp-2 ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}
+            >
+              {p.description}
+            </p>
+          )}
+          <div className="flex items-center gap-4 flex-wrap">
+            <span
+              className={`text-xs font-mono px-2 py-1 rounded ${
+                isDarkMode
+                  ? 'bg-slate-700 text-slate-300'
+                  : 'bg-gray-100 text-gray-600'
+              }`}
+            >
+              Código: {p.code}
+            </span>
+            <span
+              className={`text-xs ${isDarkMode ? 'text-slate-500' : 'text-gray-400'}`}
+            >
+              {p.exam_types.join(', ')}
+            </span>
+            {p.expires_at && (
+              <span
+                className={`text-xs ${isDarkMode ? 'text-slate-500' : 'text-gray-400'}`}
+              >
+                Vence: {new Date(p.expires_at).toLocaleDateString('es-PY')}
+              </span>
+            )}
+          </div>
+        </div>
+        <Link
+          href={`/empresa/procesos/${p.id}`}
+          className={`shrink-0 text-sm font-medium px-3 py-1.5 rounded-lg transition-colors ${
+            isDarkMode
+              ? 'text-indigo-300 hover:bg-slate-700'
+              : 'text-indigo-600 hover:bg-indigo-50'
+          }`}
+        >
+          Ver →
+        </Link>
+      </div>
+    </div>
+  );
+}
 
 export default function ProcesosPage() {
   const { isDarkMode } = useTheme();
   const [processes, setProcesses] = useState<HiringProcess[]>([]);
+  const [groups, setGroups] = useState<ProcessGroup[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     const load = async () => {
       const supabase = createClient();
-      const { data, error } = await supabase
-        .from('hiring_processes')
-        .select('*')
-        .order('created_at', { ascending: false });
+      const [{ data, error: err }, groupsRes] = await Promise.all([
+        supabase
+          .from('hiring_processes')
+          .select('*')
+          .order('created_at', { ascending: false }),
+        getMyProcessGroupsAction(),
+      ]);
 
-      if (error) setError(error.message);
-      else setProcesses(data ?? []);
+      if (err) setError(err.message);
+      else {
+        setProcesses((data ?? []) as HiringProcess[]);
+        setGroups(groupsRes.data ?? []);
+      }
       setLoading(false);
     };
     load();
   }, []);
 
-  return (
-    <div className={`min-h-screen transition-colors duration-300 ${isDarkMode ? 'bg-dark-bg' : 'bg-gray-50'}`}>
-      <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+  const ungrouped = processes.filter((p) => !p.group_id);
+  const hasGroups = groups.length > 0;
+  const hasAny = processes.length > 0;
 
+  return (
+    <div
+      className={`min-h-screen transition-colors duration-300 ${isDarkMode ? 'bg-dark-bg' : 'bg-gray-50'}`}
+    >
+      <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
         <div className="flex items-center justify-between mb-8">
           <div>
-            <h1 className={`text-2xl font-bold ${isDarkMode ? 'text-white' : 'text-gray-900'}`}>
+            <h1
+              className={`text-2xl font-bold ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
+            >
               Mis procesos de selección
             </h1>
-            <p className={`text-sm mt-1 ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}>
+            <p
+              className={`text-sm mt-1 ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}
+            >
               Todos tus procesos activos, borradores y cerrados
             </p>
           </div>
-          <Link
-            href="/empresa/procesos/nuevo"
-            className="inline-flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-semibold bg-indigo-600 text-white hover:bg-indigo-700 transition-colors"
-          >
-            + Nuevo proceso
-          </Link>
+          <div className="flex items-center gap-2">
+            <Link
+              href="/empresa/eventos"
+              className={`inline-flex items-center gap-1.5 px-3 py-2 rounded-lg text-sm font-medium transition-colors ${
+                isDarkMode
+                  ? 'text-slate-300 hover:bg-slate-700 border border-slate-700'
+                  : 'text-gray-600 hover:bg-gray-100 border border-gray-200'
+              }`}
+            >
+              🗂️ Eventos
+            </Link>
+            <Link
+              href="/empresa/procesos/nuevo"
+              className="inline-flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-semibold bg-indigo-600 text-white hover:bg-indigo-700 transition-colors"
+            >
+              + Nuevo proceso
+            </Link>
+          </div>
         </div>
 
         {loading && (
-          <div className={`text-center py-16 ${isDarkMode ? 'text-slate-400' : 'text-gray-400'}`}>
+          <div
+            className={`text-center py-16 ${isDarkMode ? 'text-slate-400' : 'text-gray-400'}`}
+          >
             Cargando...
           </div>
         )}
@@ -76,13 +195,20 @@ export default function ProcesosPage() {
           </div>
         )}
 
-        {!loading && !error && processes.length === 0 && (
-          <div className={`text-center py-16 rounded-xl border-2 border-dashed ${
-            isDarkMode ? 'border-slate-700 text-slate-500' : 'border-gray-200 text-gray-400'
-          }`}>
+        {!loading && !error && !hasAny && (
+          <div
+            className={`text-center py-16 rounded-xl border-2 border-dashed ${
+              isDarkMode
+                ? 'border-slate-700 text-slate-500'
+                : 'border-gray-200 text-gray-400'
+            }`}
+          >
             <p className="text-4xl mb-3">📂</p>
             <p className="font-medium mb-1">No tenés procesos todavía</p>
-            <p className="text-sm mb-6">Creá tu primer proceso de selección para empezar a recibir candidatos</p>
+            <p className="text-sm mb-6">
+              Creá tu primer proceso de selección para empezar a recibir
+              candidatos
+            </p>
             <Link
               href="/empresa/procesos/nuevo"
               className="inline-flex items-center gap-2 px-5 py-2.5 rounded-lg text-sm font-semibold bg-indigo-600 text-white hover:bg-indigo-700 transition-colors"
@@ -92,71 +218,70 @@ export default function ProcesosPage() {
           </div>
         )}
 
-        {!loading && !error && processes.length > 0 && (
-          <div className="space-y-3">
-            {processes.map((p) => {
-              const s = statusLabel[p.status] ?? statusLabel.draft;
-              return (
-                <div
-                  key={p.id}
-                  className={`rounded-xl border p-5 transition-colors ${
-                    isDarkMode ? 'bg-dark-secondary border-slate-700' : 'bg-white border-gray-200'
-                  }`}
-                >
-                  <div className="flex items-start justify-between gap-4">
-                    <div className="min-w-0 flex-1">
-                      <div className="flex items-center gap-2 flex-wrap mb-1">
-                        <h2 className={`font-semibold text-base ${isDarkMode ? 'text-white' : 'text-gray-900'}`}>
-                          {p.position_name}
-                        </h2>
-                        <span className={`text-xs font-medium px-2 py-0.5 rounded-full ${
-                          isDarkMode
-                            ? (p.status === 'active' ? 'bg-green-900/40 text-green-300' : p.status === 'closed' ? 'bg-red-900/40 text-red-300' : 'bg-slate-700 text-slate-400')
-                            : s.className
-                        }`}>
-                          {s.text}
-                        </span>
-                      </div>
-                      {p.description && (
-                        <p className={`text-sm mb-2 line-clamp-2 ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}>
-                          {p.description}
-                        </p>
-                      )}
-                      <div className="flex items-center gap-4 flex-wrap">
-                        <span className={`text-xs font-mono px-2 py-1 rounded ${
-                          isDarkMode ? 'bg-slate-700 text-slate-300' : 'bg-gray-100 text-gray-600'
-                        }`}>
-                          Código: {p.code}
-                        </span>
-                        <span className={`text-xs ${isDarkMode ? 'text-slate-500' : 'text-gray-400'}`}>
-                          {p.exam_types.join(', ')}
-                        </span>
-                        {p.expires_at && (
-                          <span className={`text-xs ${isDarkMode ? 'text-slate-500' : 'text-gray-400'}`}>
-                            Vence: {new Date(p.expires_at).toLocaleDateString('es-PY')}
-                          </span>
-                        )}
-                      </div>
+        {!loading && !error && hasAny && (
+          <div className="space-y-8">
+            {/* Grouped sections */}
+            {hasGroups &&
+              groups.map((group) => {
+                const groupProcesses = processes.filter(
+                  (p) => p.group_id === group.id
+                );
+                if (groupProcesses.length === 0) return null;
+                return (
+                  <div key={group.id}>
+                    <div className="flex items-center gap-2 mb-3">
+                      <span className="text-base">🗂️</span>
+                      <h2
+                        className={`text-sm font-semibold uppercase tracking-wider ${isDarkMode ? 'text-slate-300' : 'text-gray-600'}`}
+                      >
+                        {group.name}
+                      </h2>
+                      <span
+                        className={`text-xs ${isDarkMode ? 'text-slate-500' : 'text-gray-400'}`}
+                      >
+                        ({groupProcesses.length})
+                      </span>
+                      <Link
+                        href="/empresa/eventos"
+                        className={`ml-auto text-xs transition-colors ${isDarkMode ? 'text-slate-500 hover:text-slate-300' : 'text-gray-400 hover:text-gray-600'}`}
+                      >
+                        Gestionar →
+                      </Link>
                     </div>
-                    <Link
-                      href={`/empresa/procesos/${p.id}`}
-                      className={`shrink-0 text-sm font-medium px-3 py-1.5 rounded-lg transition-colors ${
-                        isDarkMode
-                          ? 'text-indigo-300 hover:bg-slate-700'
-                          : 'text-indigo-600 hover:bg-indigo-50'
-                      }`}
-                    >
-                      Ver →
-                    </Link>
+                    <div className="space-y-3">
+                      {groupProcesses.map((p) => (
+                        <ProcessCard key={p.id} p={p} isDarkMode={isDarkMode} />
+                      ))}
+                    </div>
                   </div>
+                );
+              })}
+
+            {/* Ungrouped */}
+            {ungrouped.length > 0 && (
+              <div>
+                {hasGroups && (
+                  <p
+                    className={`text-sm font-semibold uppercase tracking-wider mb-3 ${isDarkMode ? 'text-slate-500' : 'text-gray-400'}`}
+                  >
+                    Sin categoría
+                  </p>
+                )}
+                <div className="space-y-3">
+                  {ungrouped.map((p) => (
+                    <ProcessCard key={p.id} p={p} isDarkMode={isDarkMode} />
+                  ))}
                 </div>
-              );
-            })}
+              </div>
+            )}
           </div>
         )}
 
         <div className="mt-8">
-          <Link href="/empresa" className={`text-sm ${isDarkMode ? 'text-slate-500 hover:text-slate-300' : 'text-gray-400 hover:text-gray-600'} transition-colors`}>
+          <Link
+            href="/empresa"
+            className={`text-sm ${isDarkMode ? 'text-slate-500 hover:text-slate-300' : 'text-gray-400 hover:text-gray-600'} transition-colors`}
+          >
             ← Volver al panel
           </Link>
         </div>

--- a/supabase/migrations/20260617_000000_hiring_process_groups.sql
+++ b/supabase/migrations/20260617_000000_hiring_process_groups.sql
@@ -1,0 +1,46 @@
+-- Hiring process groups: allows empresa users to categorize processes by event/campaign
+
+CREATE TABLE IF NOT EXISTS hiring_process_groups (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  empresa_id UUID NOT NULL REFERENCES empresas(id) ON DELETE CASCADE,
+  name TEXT NOT NULL,
+  description TEXT,
+  created_at TIMESTAMPTZ DEFAULT now()
+);
+
+ALTER TABLE hiring_processes
+  ADD COLUMN IF NOT EXISTS group_id UUID REFERENCES hiring_process_groups(id) ON DELETE SET NULL;
+
+ALTER TABLE hiring_process_groups ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "empresa_members_select_groups" ON hiring_process_groups
+  FOR SELECT USING (
+    empresa_id IN (
+      SELECT empresa_id FROM empresa_miembros
+      WHERE user_id = auth.uid() AND status = 'active'
+    )
+  );
+
+CREATE POLICY "empresa_members_insert_groups" ON hiring_process_groups
+  FOR INSERT WITH CHECK (
+    empresa_id IN (
+      SELECT empresa_id FROM empresa_miembros
+      WHERE user_id = auth.uid() AND status = 'active'
+    )
+  );
+
+CREATE POLICY "empresa_members_update_groups" ON hiring_process_groups
+  FOR UPDATE USING (
+    empresa_id IN (
+      SELECT empresa_id FROM empresa_miembros
+      WHERE user_id = auth.uid() AND status = 'active'
+    )
+  );
+
+CREATE POLICY "empresa_members_delete_groups" ON hiring_process_groups
+  FOR DELETE USING (
+    empresa_id IN (
+      SELECT empresa_id FROM empresa_miembros
+      WHERE user_id = auth.uid() AND status = 'active'
+    )
+  );


### PR DESCRIPTION
## Summary

- New `hiring_process_groups` table with RLS — empresa members can create/manage groups
- `group_id` FK added to `hiring_processes` (ON DELETE SET NULL, so deleting a group never loses processes)
- New `/empresa/eventos` page: create events, assign/unassign process codes via chip UI
- `/empresa/procesos` list now renders processes grouped under event headers
- Create-process form shows optional "Evento" dropdown when groups exist
- Empresa dashboard has new "Eventos y categorías" quick link

## Initial data to set up

Go to `/empresa/eventos` and create:
1. **Bootcamp 2026 CLT** then add `clase-5-ID3K`, `bootcamp-2026-X1DA`, `CENTRO-2026-HKT`
2. **Selección QA Junio** then add `seleccionqajunio-RCZ2`

## Test plan

- [ ] `/empresa/eventos` loads and shows existing processes in "Sin categoría"
- [ ] Create a group, add processes via dropdown, see chips appear
- [ ] Remove chip (✕) returns process to ungrouped
- [ ] Delete group: confirm dialog; processes stay but group_id becomes null
- [ ] `/empresa/procesos` shows grouped sections with named headers
- [ ] New process form shows event selector when groups exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)
