### PR TITLE
fix(rls): fix infinite recursion in hiring_process_groups policies

### DIFF
--- a/supabase/migrations/20260617_000000_hiring_process_groups.sql
+++ b/supabase/migrations/20260617_000000_hiring_process_groups.sql
@@ -13,34 +13,23 @@ ALTER TABLE hiring_processes
 
 ALTER TABLE hiring_process_groups ENABLE ROW LEVEL SECURITY;
 
+-- Use profiles.empresa_id to avoid infinite recursion on empresa_miembros RLS
 CREATE POLICY "empresa_members_select_groups" ON hiring_process_groups
   FOR SELECT USING (
-    empresa_id IN (
-      SELECT empresa_id FROM empresa_miembros
-      WHERE user_id = auth.uid() AND status = 'active'
-    )
+    empresa_id = (SELECT empresa_id FROM profiles WHERE id = auth.uid())
   );
 
 CREATE POLICY "empresa_members_insert_groups" ON hiring_process_groups
   FOR INSERT WITH CHECK (
-    empresa_id IN (
-      SELECT empresa_id FROM empresa_miembros
-      WHERE user_id = auth.uid() AND status = 'active'
-    )
+    empresa_id = (SELECT empresa_id FROM profiles WHERE id = auth.uid())
   );
 
 CREATE POLICY "empresa_members_update_groups" ON hiring_process_groups
   FOR UPDATE USING (
-    empresa_id IN (
-      SELECT empresa_id FROM empresa_miembros
-      WHERE user_id = auth.uid() AND status = 'active'
-    )
+    empresa_id = (SELECT empresa_id FROM profiles WHERE id = auth.uid())
   );
 
 CREATE POLICY "empresa_members_delete_groups" ON hiring_process_groups
   FOR DELETE USING (
-    empresa_id IN (
-      SELECT empresa_id FROM empresa_miembros
-      WHERE user_id = auth.uid() AND status = 'active'
-    )
+    empresa_id = (SELECT empresa_id FROM profiles WHERE id = auth.uid())
   );


### PR DESCRIPTION
## Fix

**Error:** `infinite recursion detected in policy for relation "empresa_miembros"`

Las 4 RLS policies de `hiring_process_groups` hacían `SELECT FROM empresa_miembros`, disparando la RLS de `empresa_miembros` que tiene una auto-referencia recursiva.

**Fix:** Reemplazar el subquery de `empresa_miembros` por `profiles.empresa_id` — mismo patrón usado en el resto del codebase. No hay join, no hay recursión.

```sql
-- Antes (causa recursión)
empresa_id IN (SELECT empresa_id FROM empresa_miembros WHERE user_id = auth.uid() AND status = 'active')

-- Después (sin recursión)
empresa_id = (SELECT empresa_id FROM profiles WHERE id = auth.uid())
```

El fix ya está aplicado directamente en la DB de producción.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
