### PR TITLE
feat(empresa): expired process status + event analytics page

### DIFF
--- a/apps/frontend/src/actions/employer.ts
+++ b/apps/frontend/src/actions/employer.ts
@@ -249,13 +249,17 @@ export async function validateProcessCodeAction(code: string) {
   const supabase = createClient();
   const { data, error } = await supabase
     .from('hiring_processes')
-    .select('code, company_name, position_name, status')
+    .select('code, company_name, position_name, status, expires_at')
     .ilike('code', code.trim())
     .eq('status', 'active')
     .single();
 
-  if (error || !data) return { valid: false, process: null };
-  return { valid: true, process: data };
+  if (error || !data)
+    return { valid: false, process: null, reason: 'not_found' as const };
+  if (data.expires_at && new Date(data.expires_at) < new Date()) {
+    return { valid: false, process: null, reason: 'expired' as const };
+  }
+  return { valid: true, process: data, reason: null };
 }
 
 export async function updateProcessStatusAction(
@@ -430,6 +434,194 @@ export async function getEmpresaDashboardStatsAction(): Promise<{
         month,
         value,
       })),
+    },
+    error: null,
+  };
+}
+
+export interface EventProcessStat {
+  id: string;
+  code: string;
+  position_name: string;
+  status: 'draft' | 'active' | 'closed';
+  expires_at: string | null;
+  candidateCount: number;
+  passedCount: number;
+  passRate: number;
+  topScore: number | null;
+}
+
+export interface EventTopCandidate {
+  name: string;
+  examType: string;
+  processCode: string;
+  percentage: number;
+  passed: boolean;
+}
+
+export interface EventExamTypeStat {
+  examType: string;
+  total: number;
+  passed: number;
+  passRate: number;
+}
+
+export interface EventStats {
+  group: ProcessGroup;
+  processes: EventProcessStat[];
+  topCandidates: EventTopCandidate[];
+  byExamType: EventExamTypeStat[];
+  totals: {
+    candidates: number;
+    passed: number;
+    passRate: number;
+    avgScore: number | null;
+  };
+}
+
+export async function getEventStatsAction(groupId: string): Promise<{
+  data: EventStats | null;
+  error: string | null;
+}> {
+  const supabase = createClient();
+  const {
+    data: { user },
+    error: userError,
+  } = await supabase.auth.getUser();
+  if (userError || !user) return { error: 'No autenticado', data: null };
+
+  const { data: group, error: groupError } = await supabase
+    .from('hiring_process_groups')
+    .select('*')
+    .eq('id', groupId)
+    .single();
+
+  if (groupError || !group)
+    return { error: 'Evento no encontrado', data: null };
+
+  const { data: procs, error: procsError } = await supabase
+    .from('hiring_processes')
+    .select('id, code, position_name, status, expires_at')
+    .eq('group_id', groupId)
+    .order('created_at', { ascending: true });
+
+  if (procsError) return { error: procsError.message, data: null };
+  const processes = procs ?? [];
+
+  const codes = processes.map((p) => p.code);
+  if (codes.length === 0) {
+    return {
+      data: {
+        group,
+        processes: [],
+        topCandidates: [],
+        byExamType: [],
+        totals: { candidates: 0, passed: 0, passRate: 0, avgScore: null },
+      },
+      error: null,
+    };
+  }
+
+  const { data: results, error: resultsError } = await supabase
+    .from('exam_results')
+    .select(
+      'participant_name, participant_email, exam_type, percentage, passed, process_code'
+    )
+    .in('process_code', codes);
+
+  if (resultsError) return { error: resultsError.message, data: null };
+  const allResults = results ?? [];
+
+  // Per-process stats
+  const processStats: EventProcessStat[] = processes.map((p) => {
+    const rows = allResults.filter((r) => r.process_code === p.code);
+    const passed = rows.filter((r) => r.passed).length;
+    const scores = rows.map((r) => r.percentage);
+    return {
+      id: p.id,
+      code: p.code,
+      position_name: p.position_name,
+      status: p.status,
+      expires_at: p.expires_at,
+      candidateCount: rows.length,
+      passedCount: passed,
+      passRate: rows.length > 0 ? Math.round((passed / rows.length) * 100) : 0,
+      topScore: scores.length > 0 ? Math.max(...scores) : null,
+    };
+  });
+
+  // Top 10 candidates: best attempt per (email OR name) across all processes
+  const bestByKey = new Map<
+    string,
+    {
+      name: string;
+      examType: string;
+      processCode: string;
+      percentage: number;
+      passed: boolean;
+    }
+  >();
+  for (const r of allResults) {
+    const key = (r.participant_email || r.participant_name || '').toLowerCase();
+    if (!key) continue;
+    const existing = bestByKey.get(key);
+    if (!existing || r.percentage > existing.percentage) {
+      bestByKey.set(key, {
+        name: r.participant_name || r.participant_email || 'Sin nombre',
+        examType: r.exam_type,
+        processCode: r.process_code ?? '',
+        percentage: r.percentage,
+        passed: r.passed,
+      });
+    }
+  }
+  const topCandidates = Array.from(bestByKey.values())
+    .sort((a, b) => b.percentage - a.percentage)
+    .slice(0, 10);
+
+  // By exam type
+  const examTypeMap = new Map<string, { total: number; passed: number }>();
+  for (const r of allResults) {
+    const et = r.exam_type;
+    const cur = examTypeMap.get(et) ?? { total: 0, passed: 0 };
+    examTypeMap.set(et, {
+      total: cur.total + 1,
+      passed: cur.passed + (r.passed ? 1 : 0),
+    });
+  }
+  const byExamType: EventExamTypeStat[] = Array.from(examTypeMap.entries()).map(
+    ([examType, { total, passed }]) => ({
+      examType,
+      total,
+      passed,
+      passRate: total > 0 ? Math.round((passed / total) * 100) : 0,
+    })
+  );
+
+  const totalCandidates = allResults.length;
+  const totalPassed = allResults.filter((r) => r.passed).length;
+  const avgScore =
+    totalCandidates > 0
+      ? Math.round(
+          allResults.reduce((sum, r) => sum + r.percentage, 0) / totalCandidates
+        )
+      : null;
+
+  return {
+    data: {
+      group,
+      processes: processStats,
+      topCandidates,
+      byExamType,
+      totals: {
+        candidates: totalCandidates,
+        passed: totalPassed,
+        passRate:
+          totalCandidates > 0
+            ? Math.round((totalPassed / totalCandidates) * 100)
+            : 0,
+        avgScore,
+      },
     },
     error: null,
   };

--- a/apps/frontend/src/app/empresa/eventos/[id]/page.tsx
+++ b/apps/frontend/src/app/empresa/eventos/[id]/page.tsx
@@ -1,0 +1,526 @@
+'use client';
+
+import Link from 'next/link';
+import { useEffect, useState } from 'react';
+import { useParams } from 'next/navigation';
+import { useTheme } from '@/contexts/ThemeContext';
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Cell,
+  Legend,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
+import {
+  getEventStatsAction,
+  type EventStats,
+  type EventProcessStat,
+} from '@/actions/employer';
+
+const EXAM_LABELS: Record<string, string> = {
+  istqb: 'ISTQB CTFL',
+  git: 'Git',
+  performance: 'Performance',
+  'api-testing-fundamentals': 'API Fundamentals',
+  'api-banking': 'API Banking',
+  'database-fundamentals': 'BD Fundamentos',
+  'database-practice': 'BD Práctica SQL',
+};
+
+function getEffectiveStatus(
+  p: EventProcessStat
+): 'active' | 'closed' | 'draft' | 'expired' {
+  if (
+    p.status === 'active' &&
+    p.expires_at &&
+    new Date(p.expires_at) < new Date()
+  ) {
+    return 'expired';
+  }
+  return p.status;
+}
+
+const STATUS_BADGE: Record<
+  string,
+  { text: string; light: string; dark: string }
+> = {
+  active: {
+    text: 'Activo',
+    light: 'bg-green-100 text-green-700',
+    dark: 'bg-green-900/40 text-green-300',
+  },
+  closed: {
+    text: 'Cerrado',
+    light: 'bg-red-100 text-red-600',
+    dark: 'bg-red-900/40 text-red-300',
+  },
+  draft: {
+    text: 'Borrador',
+    light: 'bg-gray-100 text-gray-600',
+    dark: 'bg-slate-700 text-slate-400',
+  },
+  expired: {
+    text: 'Vencido',
+    light: 'bg-amber-100 text-amber-700',
+    dark: 'bg-amber-900/40 text-amber-300',
+  },
+};
+
+function StatCard({
+  label,
+  value,
+  sub,
+  isDarkMode,
+}: {
+  label: string;
+  value: string | number;
+  sub?: string;
+  isDarkMode: boolean;
+}) {
+  return (
+    <div
+      className={`rounded-xl border p-4 ${
+        isDarkMode
+          ? 'bg-dark-secondary border-slate-700'
+          : 'bg-white border-gray-200'
+      }`}
+    >
+      <p
+        className={`text-xs font-medium mb-1 ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}
+      >
+        {label}
+      </p>
+      <p
+        className={`text-2xl font-bold ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
+      >
+        {value}
+      </p>
+      {sub && (
+        <p
+          className={`text-xs mt-0.5 ${isDarkMode ? 'text-slate-500' : 'text-gray-400'}`}
+        >
+          {sub}
+        </p>
+      )}
+    </div>
+  );
+}
+
+export default function EventoDetailPage() {
+  const { isDarkMode } = useTheme();
+  const params = useParams();
+  const groupId = params.id as string;
+
+  const [stats, setStats] = useState<EventStats | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    getEventStatsAction(groupId).then(({ data, error: err }) => {
+      if (err) setError(err);
+      else setStats(data);
+      setLoading(false);
+    });
+  }, [groupId]);
+
+  const cardClass = `rounded-xl border ${
+    isDarkMode
+      ? 'bg-dark-secondary border-slate-700'
+      : 'bg-white border-gray-200'
+  }`;
+  const headingClass = `text-sm font-semibold mb-4 ${isDarkMode ? 'text-slate-300' : 'text-gray-700'}`;
+
+  if (loading) {
+    return (
+      <div
+        className={`min-h-screen flex items-center justify-center ${isDarkMode ? 'bg-dark-bg text-slate-400' : 'bg-gray-50 text-gray-400'}`}
+      >
+        Cargando estadísticas...
+      </div>
+    );
+  }
+
+  if (error || !stats) {
+    return (
+      <div
+        className={`min-h-screen flex items-center justify-center ${isDarkMode ? 'bg-dark-bg' : 'bg-gray-50'}`}
+      >
+        <div className="text-center">
+          <p className="text-red-500 mb-4">{error ?? 'Evento no encontrado'}</p>
+          <Link
+            href="/empresa/eventos"
+            className="text-sm text-indigo-600 hover:underline"
+          >
+            ← Volver a eventos
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  const { group, processes, topCandidates, byExamType, totals } = stats;
+
+  const topChartData = topCandidates.map((c) => ({
+    name: c.name.length > 22 ? c.name.slice(0, 22) + '…' : c.name,
+    fullName: c.name,
+    puntaje: c.percentage,
+    examType: EXAM_LABELS[c.examType] ?? c.examType,
+    processCode: c.processCode,
+    passed: c.passed,
+  }));
+
+  const examChartData = byExamType.map((e) => ({
+    name: EXAM_LABELS[e.examType] ?? e.examType,
+    Total: e.total,
+    Aprobados: e.passed,
+    tasa: e.passRate,
+  }));
+
+  const examCount = byExamType.length;
+
+  const tooltipStyle = isDarkMode
+    ? {
+        backgroundColor: '#1e293b',
+        border: '1px solid #334155',
+        color: '#e2e8f0',
+      }
+    : { backgroundColor: '#fff', border: '1px solid #e2e8f0' };
+
+  return (
+    <div
+      className={`min-h-screen transition-colors duration-300 ${isDarkMode ? 'bg-dark-bg' : 'bg-gray-50'}`}
+    >
+      <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-12 space-y-8">
+        {/* Header */}
+        <div>
+          <Link
+            href="/empresa/eventos"
+            className={`text-sm mb-2 inline-block ${isDarkMode ? 'text-slate-500 hover:text-slate-300' : 'text-gray-400 hover:text-gray-600'}`}
+          >
+            ← Eventos y categorías
+          </Link>
+          <div className="flex items-start justify-between gap-4 flex-wrap">
+            <div>
+              <h1
+                className={`text-2xl font-bold ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
+              >
+                {group.name}
+              </h1>
+              {group.description && (
+                <p
+                  className={`text-sm mt-1 ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}
+                >
+                  {group.description}
+                </p>
+              )}
+            </div>
+            <span
+              className={`text-sm ${isDarkMode ? 'text-slate-500' : 'text-gray-400'}`}
+            >
+              {processes.length}{' '}
+              {processes.length === 1 ? 'proceso' : 'procesos'}
+            </span>
+          </div>
+        </div>
+
+        {/* Stats cards */}
+        <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+          <StatCard
+            label="Total candidatos"
+            value={totals.candidates}
+            isDarkMode={isDarkMode}
+          />
+          <StatCard
+            label="Tasa aprobación"
+            value={`${totals.passRate}%`}
+            sub={`${totals.passed} aprobados`}
+            isDarkMode={isDarkMode}
+          />
+          <StatCard
+            label="Puntaje promedio"
+            value={totals.avgScore !== null ? `${totals.avgScore}%` : '—'}
+            isDarkMode={isDarkMode}
+          />
+          <StatCard
+            label="Tipos de examen"
+            value={examCount}
+            isDarkMode={isDarkMode}
+          />
+        </div>
+
+        {totals.candidates === 0 ? (
+          <div
+            className={`text-center py-16 rounded-xl border-2 border-dashed ${
+              isDarkMode
+                ? 'border-slate-700 text-slate-500'
+                : 'border-gray-200 text-gray-400'
+            }`}
+          >
+            <p className="text-4xl mb-3">📭</p>
+            <p className="font-medium mb-1">Sin candidatos todavía</p>
+            <p className="text-sm">
+              Cuando los candidatos rindan exámenes de los procesos de este
+              evento, aparecerán aquí.
+            </p>
+          </div>
+        ) : (
+          <>
+            {/* Charts row */}
+            <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+              {/* Top 10 participants */}
+              <div className={`${cardClass} p-5`}>
+                <p className={headingClass}>Top 10 participantes</p>
+                {topChartData.length === 0 ? (
+                  <p
+                    className={`text-sm ${isDarkMode ? 'text-slate-500' : 'text-gray-400'}`}
+                  >
+                    Sin datos
+                  </p>
+                ) : (
+                  <ResponsiveContainer width="100%" height={280}>
+                    <BarChart
+                      layout="vertical"
+                      data={topChartData}
+                      margin={{ top: 0, right: 16, left: 0, bottom: 0 }}
+                    >
+                      <CartesianGrid
+                        strokeDasharray="3 3"
+                        horizontal={false}
+                        stroke={isDarkMode ? '#334155' : '#f1f5f9'}
+                      />
+                      <XAxis
+                        type="number"
+                        domain={[0, 100]}
+                        tick={{
+                          fontSize: 11,
+                          fill: isDarkMode ? '#94a3b8' : '#6b7280',
+                        }}
+                        tickFormatter={(v) => `${v}%`}
+                      />
+                      <YAxis
+                        type="category"
+                        dataKey="name"
+                        width={100}
+                        tick={{
+                          fontSize: 11,
+                          fill: isDarkMode ? '#94a3b8' : '#6b7280',
+                        }}
+                      />
+                      <Tooltip
+                        contentStyle={tooltipStyle}
+                        formatter={(value: number) => [`${value}%`, 'Puntaje']}
+                        labelFormatter={(_, payload) => {
+                          const d = payload?.[0]?.payload;
+                          if (!d) return '';
+                          return `${d.fullName} — ${d.examType} (${d.processCode})`;
+                        }}
+                      />
+                      <Bar
+                        dataKey="puntaje"
+                        radius={[0, 4, 4, 0]}
+                        maxBarSize={20}
+                      >
+                        {topChartData.map((entry, i) => (
+                          <Cell
+                            key={i}
+                            fill={entry.passed ? '#22c55e' : '#ef4444'}
+                            fillOpacity={0.85}
+                          />
+                        ))}
+                      </Bar>
+                    </BarChart>
+                  </ResponsiveContainer>
+                )}
+                <p
+                  className={`text-xs mt-2 ${isDarkMode ? 'text-slate-600' : 'text-gray-300'}`}
+                >
+                  🟢 Aprobado · 🔴 No aprobado
+                </p>
+              </div>
+
+              {/* By exam type */}
+              <div className={`${cardClass} p-5`}>
+                <p className={headingClass}>Por tipo de examen</p>
+                {examChartData.length === 0 ? (
+                  <p
+                    className={`text-sm ${isDarkMode ? 'text-slate-500' : 'text-gray-400'}`}
+                  >
+                    Sin datos
+                  </p>
+                ) : (
+                  <ResponsiveContainer width="100%" height={280}>
+                    <BarChart
+                      data={examChartData}
+                      margin={{ top: 0, right: 8, left: -16, bottom: 40 }}
+                    >
+                      <CartesianGrid
+                        strokeDasharray="3 3"
+                        stroke={isDarkMode ? '#334155' : '#f1f5f9'}
+                      />
+                      <XAxis
+                        dataKey="name"
+                        tick={{
+                          fontSize: 10,
+                          fill: isDarkMode ? '#94a3b8' : '#6b7280',
+                        }}
+                        angle={-30}
+                        textAnchor="end"
+                        interval={0}
+                      />
+                      <YAxis
+                        tick={{
+                          fontSize: 11,
+                          fill: isDarkMode ? '#94a3b8' : '#6b7280',
+                        }}
+                        allowDecimals={false}
+                      />
+                      <Tooltip
+                        contentStyle={tooltipStyle}
+                        formatter={(value: number, name: string) => [
+                          value,
+                          name,
+                        ]}
+                        labelFormatter={(label, payload) => {
+                          const tasa = payload?.[0]?.payload?.tasa;
+                          return `${label}${tasa !== undefined ? ` — ${tasa}% aprob.` : ''}`;
+                        }}
+                      />
+                      <Legend wrapperStyle={{ fontSize: 12, paddingTop: 8 }} />
+                      <Bar
+                        dataKey="Total"
+                        fill={isDarkMode ? '#6366f1' : '#818cf8'}
+                        radius={[4, 4, 0, 0]}
+                        maxBarSize={32}
+                      />
+                      <Bar
+                        dataKey="Aprobados"
+                        fill={isDarkMode ? '#22c55e' : '#4ade80'}
+                        radius={[4, 4, 0, 0]}
+                        maxBarSize={32}
+                      />
+                    </BarChart>
+                  </ResponsiveContainer>
+                )}
+              </div>
+            </div>
+
+            {/* Processes table */}
+            <div className={`${cardClass} overflow-hidden`}>
+              <div className="px-5 py-4 border-b ${isDarkMode ? 'border-slate-700' : 'border-gray-100'}">
+                <p
+                  className={`text-sm font-semibold ${isDarkMode ? 'text-slate-300' : 'text-gray-700'}`}
+                >
+                  Procesos del evento
+                </p>
+              </div>
+              <div className="overflow-x-auto">
+                <table className="w-full text-sm">
+                  <thead>
+                    <tr
+                      className={`text-xs font-medium uppercase tracking-wider ${
+                        isDarkMode
+                          ? 'bg-slate-800/50 text-slate-400'
+                          : 'bg-gray-50 text-gray-500'
+                      }`}
+                    >
+                      <th className="px-5 py-3 text-left">Proceso</th>
+                      <th className="px-4 py-3 text-left">Código</th>
+                      <th className="px-4 py-3 text-center">Candidatos</th>
+                      <th className="px-4 py-3 text-center">Aprobados</th>
+                      <th className="px-4 py-3 text-center">Tasa</th>
+                      <th className="px-4 py-3 text-center">Top score</th>
+                      <th className="px-4 py-3 text-center">Estado</th>
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-gray-100 dark:divide-slate-700/50">
+                    {processes.map((p) => {
+                      const eff = getEffectiveStatus(p);
+                      const badge = STATUS_BADGE[eff];
+                      return (
+                        <tr
+                          key={p.id}
+                          className={`transition-colors ${
+                            isDarkMode
+                              ? 'hover:bg-slate-800/30'
+                              : 'hover:bg-gray-50'
+                          }`}
+                        >
+                          <td className="px-5 py-3">
+                            <Link
+                              href={`/empresa/procesos/${p.id}`}
+                              className={`font-medium hover:underline ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
+                            >
+                              {p.position_name}
+                            </Link>
+                          </td>
+                          <td className="px-4 py-3">
+                            <span
+                              className={`font-mono text-xs px-2 py-0.5 rounded ${
+                                isDarkMode
+                                  ? 'bg-slate-700 text-slate-300'
+                                  : 'bg-gray-100 text-gray-600'
+                              }`}
+                            >
+                              {p.code}
+                            </span>
+                          </td>
+                          <td
+                            className={`px-4 py-3 text-center ${isDarkMode ? 'text-slate-300' : 'text-gray-700'}`}
+                          >
+                            {p.candidateCount}
+                          </td>
+                          <td
+                            className={`px-4 py-3 text-center ${isDarkMode ? 'text-slate-300' : 'text-gray-700'}`}
+                          >
+                            {p.passedCount}
+                          </td>
+                          <td className="px-4 py-3 text-center">
+                            <span
+                              className={`font-semibold ${
+                                p.passRate >= 60
+                                  ? isDarkMode
+                                    ? 'text-green-400'
+                                    : 'text-green-600'
+                                  : p.candidateCount === 0
+                                    ? isDarkMode
+                                      ? 'text-slate-500'
+                                      : 'text-gray-400'
+                                    : isDarkMode
+                                      ? 'text-red-400'
+                                      : 'text-red-600'
+                              }`}
+                            >
+                              {p.candidateCount === 0 ? '—' : `${p.passRate}%`}
+                            </span>
+                          </td>
+                          <td
+                            className={`px-4 py-3 text-center ${isDarkMode ? 'text-slate-300' : 'text-gray-700'}`}
+                          >
+                            {p.topScore !== null ? `${p.topScore}%` : '—'}
+                          </td>
+                          <td className="px-4 py-3 text-center">
+                            <span
+                              className={`text-xs font-medium px-2 py-0.5 rounded-full ${
+                                isDarkMode ? badge.dark : badge.light
+                              }`}
+                            >
+                              {badge.text}
+                            </span>
+                          </td>
+                        </tr>
+                      );
+                    })}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/src/app/empresa/eventos/page.tsx
+++ b/apps/frontend/src/app/empresa/eventos/page.tsx
@@ -223,18 +223,30 @@ export default function EventosPage() {
                         </p>
                       )}
                     </div>
-                    <button
-                      onClick={() => handleDeleteGroup(group.id)}
-                      disabled={deletingId === group.id}
-                      className={`shrink-0 text-xs px-2 py-1 rounded transition-colors ${
-                        isDarkMode
-                          ? 'text-red-400 hover:bg-red-900/30'
-                          : 'text-red-500 hover:bg-red-50'
-                      }`}
-                      title="Eliminar evento"
-                    >
-                      {deletingId === group.id ? '...' : '🗑️ Eliminar'}
-                    </button>
+                    <div className="flex items-center gap-2 shrink-0">
+                      <Link
+                        href={`/empresa/eventos/${group.id}`}
+                        className={`text-xs px-2 py-1 rounded transition-colors ${
+                          isDarkMode
+                            ? 'text-indigo-400 hover:bg-slate-700'
+                            : 'text-indigo-600 hover:bg-indigo-50'
+                        }`}
+                      >
+                        📊 Estadísticas
+                      </Link>
+                      <button
+                        onClick={() => handleDeleteGroup(group.id)}
+                        disabled={deletingId === group.id}
+                        className={`text-xs px-2 py-1 rounded transition-colors ${
+                          isDarkMode
+                            ? 'text-red-400 hover:bg-red-900/30'
+                            : 'text-red-500 hover:bg-red-50'
+                        }`}
+                        title="Eliminar evento"
+                      >
+                        {deletingId === group.id ? '...' : '🗑️ Eliminar'}
+                      </button>
+                    </div>
                   </div>
 
                   {/* Process chips */}

--- a/apps/frontend/src/app/empresa/procesos/[id]/page.tsx
+++ b/apps/frontend/src/app/empresa/procesos/[id]/page.tsx
@@ -58,7 +58,23 @@ const STATUS_LABELS: Record<
     color: 'bg-red-100 text-red-600',
     darkColor: 'bg-red-900/40 text-red-300',
   },
+  expired: {
+    text: 'Vencido',
+    color: 'bg-amber-100 text-amber-700',
+    darkColor: 'bg-amber-900/40 text-amber-300',
+  },
 };
+
+function getEffectiveStatus(process: HiringProcess): string {
+  if (
+    process.status === 'active' &&
+    process.expires_at &&
+    new Date(process.expires_at) < new Date()
+  ) {
+    return 'expired';
+  }
+  return process.status;
+}
 
 const PROSPECT_STATUS_CONFIG: Record<
   ProspectStatus,
@@ -552,7 +568,9 @@ export default function ProcesoDetailPage() {
     );
   }
 
-  const statusInfo = STATUS_LABELS[process!.status];
+  const effectiveStatus = getEffectiveStatus(process!);
+  const statusInfo = STATUS_LABELS[effectiveStatus] ?? STATUS_LABELS.draft;
+  const isExpired = effectiveStatus === 'expired';
 
   return (
     <div
@@ -625,6 +643,30 @@ export default function ProcesoDetailPage() {
             )}
           </div>
         </div>
+
+        {/* Expired banner */}
+        {isExpired && (
+          <div
+            className={`rounded-xl border px-4 py-3 text-sm flex items-center gap-2 ${
+              isDarkMode
+                ? 'bg-amber-900/20 border-amber-700/50 text-amber-300'
+                : 'bg-amber-50 border-amber-200 text-amber-800'
+            }`}
+          >
+            <span>⚠️</span>
+            <span>
+              Este proceso venció el{' '}
+              <strong>
+                {new Date(process!.expires_at!).toLocaleDateString('es-PY', {
+                  day: 'numeric',
+                  month: 'long',
+                  year: 'numeric',
+                })}
+              </strong>{' '}
+              — los candidatos ya no pueden rendir.
+            </span>
+          </div>
+        )}
 
         {/* Stats */}
         <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">

--- a/apps/frontend/src/app/empresa/procesos/page.tsx
+++ b/apps/frontend/src/app/empresa/procesos/page.tsx
@@ -25,7 +25,19 @@ const statusLabel: Record<string, { text: string; className: string }> = {
   draft: { text: 'Borrador', className: 'bg-gray-100 text-gray-600' },
   active: { text: 'Activo', className: 'bg-green-100 text-green-700' },
   closed: { text: 'Cerrado', className: 'bg-red-100 text-red-600' },
+  expired: { text: 'Vencido', className: 'bg-amber-100 text-amber-700' },
 };
+
+function getEffectiveStatus(p: HiringProcess): string {
+  if (
+    p.status === 'active' &&
+    p.expires_at &&
+    new Date(p.expires_at) < new Date()
+  ) {
+    return 'expired';
+  }
+  return p.status;
+}
 
 function ProcessCard({
   p,
@@ -34,7 +46,9 @@ function ProcessCard({
   p: HiringProcess;
   isDarkMode: boolean;
 }) {
-  const s = statusLabel[p.status] ?? statusLabel.draft;
+  const effectiveStatus = getEffectiveStatus(p);
+  const s = statusLabel[effectiveStatus] ?? statusLabel.draft;
+  const isExpired = effectiveStatus === 'expired';
   return (
     <div
       className={`rounded-xl border p-5 transition-colors ${
@@ -54,11 +68,13 @@ function ProcessCard({
             <span
               className={`text-xs font-medium px-2 py-0.5 rounded-full ${
                 isDarkMode
-                  ? p.status === 'active'
-                    ? 'bg-green-900/40 text-green-300'
-                    : p.status === 'closed'
-                      ? 'bg-red-900/40 text-red-300'
-                      : 'bg-slate-700 text-slate-400'
+                  ? isExpired
+                    ? 'bg-amber-900/40 text-amber-300'
+                    : p.status === 'active'
+                      ? 'bg-green-900/40 text-green-300'
+                      : p.status === 'closed'
+                        ? 'bg-red-900/40 text-red-300'
+                        : 'bg-slate-700 text-slate-400'
                   : s.className
               }`}
             >
@@ -89,9 +105,18 @@ function ProcessCard({
             </span>
             {p.expires_at && (
               <span
-                className={`text-xs ${isDarkMode ? 'text-slate-500' : 'text-gray-400'}`}
+                className={`text-xs ${
+                  isExpired
+                    ? isDarkMode
+                      ? 'text-amber-400'
+                      : 'text-amber-600'
+                    : isDarkMode
+                      ? 'text-slate-500'
+                      : 'text-gray-400'
+                }`}
               >
-                Vence: {new Date(p.expires_at).toLocaleDateString('es-PY')}
+                {isExpired ? 'Venció:' : 'Vence:'}{' '}
+                {new Date(p.expires_at).toLocaleDateString('es-PY')}
               </span>
             )}
           </div>
@@ -241,12 +266,20 @@ export default function ProcesosPage() {
                       >
                         ({groupProcesses.length})
                       </span>
-                      <Link
-                        href="/empresa/eventos"
-                        className={`ml-auto text-xs transition-colors ${isDarkMode ? 'text-slate-500 hover:text-slate-300' : 'text-gray-400 hover:text-gray-600'}`}
-                      >
-                        Gestionar →
-                      </Link>
+                      <div className="ml-auto flex items-center gap-3">
+                        <Link
+                          href={`/empresa/eventos/${group.id}`}
+                          className={`text-xs transition-colors ${isDarkMode ? 'text-indigo-400 hover:text-indigo-300' : 'text-indigo-600 hover:text-indigo-500'}`}
+                        >
+                          📊 Stats
+                        </Link>
+                        <Link
+                          href="/empresa/eventos"
+                          className={`text-xs transition-colors ${isDarkMode ? 'text-slate-500 hover:text-slate-300' : 'text-gray-400 hover:text-gray-600'}`}
+                        >
+                          Gestionar →
+                        </Link>
+                      </div>
                     </div>
                     <div className="space-y-3">
                       {groupProcesses.map((p) => (


### PR DESCRIPTION
## Summary

- **Estado Vencido**: procesos con `expires_at` pasado muestran badge ámbar "Vencido" (distinto de "Cerrado" rojo que es manual). `validateProcessCodeAction` ahora bloquea el acceso de candidatos a procesos vencidos.
- **Banner de aviso**: el detalle de un proceso vencido muestra un banner con la fecha exacta de vencimiento.
- **Vista por Evento**: nueva página `/empresa/eventos/[id]` con estadísticas macro del evento: cards de resumen, gráfico horizontal Top 10 participantes (verde = aprobado, rojo = no aprobado), gráfico por tipo de examen (Total vs Aprobados), y tabla de procesos con sus métricas.
- **Links de navegación**: botones "📊 Estadísticas" en las páginas de eventos y procesos apuntando a la nueva página de detalle.

## Test plan

- [ ] Proceso con `expires_at` en el pasado → badge "Vencido" (ámbar) en lista y en detalle
- [ ] Banner amarillo visible en `/empresa/procesos/[id]` para proceso vencido
- [ ] Candidato que intenta rendir con código de proceso vencido → rechazado
- [ ] Proceso cerrado manualmente (`status = 'closed'`) → badge "Cerrado" (rojo), no "Vencido"
- [ ] Click en "📊 Estadísticas" desde eventos → carga `/empresa/eventos/[id]`
- [ ] Página de evento con candidatos → muestra Top 10 chart + chart por examen + tabla de procesos
- [ ] Página de evento sin candidatos → estado vacío correcto

🤖 Generated with [Claude Code](https://claude.com/claude-code)