### PR TITLE
fix(eventos): include assessment_attempts in event stats + all participants table

### DIFF
--- a/apps/frontend/src/actions/employer.ts
+++ b/apps/frontend/src/actions/employer.ts
@@ -451,8 +451,9 @@ export interface EventProcessStat {
   topScore: number | null;
 }
 
-export interface EventTopCandidate {
+export interface EventCandidate {
   name: string;
+  email: string | null;
   examType: string;
   processCode: string;
   percentage: number;
@@ -469,7 +470,8 @@ export interface EventExamTypeStat {
 export interface EventStats {
   group: ProcessGroup;
   processes: EventProcessStat[];
-  topCandidates: EventTopCandidate[];
+  /** All candidates sorted by percentage DESC (use .slice(0,10) for chart) */
+  allCandidates: EventCandidate[];
   byExamType: EventExamTypeStat[];
   totals: {
     candidates: number;
@@ -514,7 +516,7 @@ export async function getEventStatsAction(groupId: string): Promise<{
       data: {
         group,
         processes: [],
-        topCandidates: [],
+        allCandidates: [],
         byExamType: [],
         totals: { candidates: 0, passed: 0, passRate: 0, avgScore: null },
       },
@@ -522,19 +524,80 @@ export async function getEventStatsAction(groupId: string): Promise<{
     };
   }
 
-  const { data: results, error: resultsError } = await supabase
-    .from('exam_results')
-    .select(
-      'participant_name, participant_email, exam_type, percentage, passed, process_code'
-    )
-    .in('process_code', codes);
+  // Fetch from exam_results (istqb, git, performance, api-testing-fundamentals, api-banking)
+  const [examResultsRes, assessmentAttemptsRes] = await Promise.all([
+    supabase
+      .from('exam_results')
+      .select(
+        'participant_name, participant_email, exam_type, percentage, passed, process_code'
+      )
+      .in('process_code', codes),
+    // database-fundamentals and database-practice live in assessment_attempts
+    supabase
+      .from('assessment_attempts')
+      .select(
+        'user_id, total_score, percentage, passed, created_at, assessments!inner(slug), metadata'
+      )
+      .or(codes.map((c) => `metadata->>processCode.eq.${c}`).join(','))
+      .eq('status', 'graded'),
+  ]);
 
-  if (resultsError) return { error: resultsError.message, data: null };
-  const allResults = results ?? [];
+  if (examResultsRes.error)
+    return { error: examResultsRes.error.message, data: null };
 
-  // Per-process stats
+  const examRows = examResultsRes.data ?? [];
+
+  // Resolve user_ids from assessment_attempts to names/emails
+  const attemptRows = assessmentAttemptsRes.data ?? [];
+  const userIds = [
+    ...new Set(attemptRows.map((r: any) => r.user_id).filter(Boolean)),
+  ];
+  const profileMap: Record<
+    string,
+    { display_name: string | null; email: string | null }
+  > = {};
+  if (userIds.length > 0) {
+    const { data: profileRows } = await supabase
+      .from('profiles')
+      .select('id, display_name, email')
+      .in('id', userIds);
+    (profileRows ?? []).forEach((p: any) => {
+      profileMap[p.id] = p;
+    });
+  }
+
+  // Normalise assessment_attempts into the same shape
+  const mappedAttempts: EventCandidate[] = attemptRows.map((r: any) => {
+    const profile = profileMap[r.user_id];
+    const processCode =
+      typeof r.metadata === 'object' && r.metadata !== null
+        ? ((r.metadata as Record<string, string>).processCode ?? '')
+        : '';
+    return {
+      name: profile?.display_name || profile?.email || 'Sin nombre',
+      email: profile?.email ?? null,
+      examType: (r.assessments as any)?.slug ?? 'unknown',
+      processCode,
+      percentage: r.percentage ?? 0,
+      passed: r.passed ?? false,
+    };
+  });
+
+  // Normalise exam_results
+  const mappedExams: EventCandidate[] = examRows.map((r) => ({
+    name: r.participant_name || r.participant_email || 'Sin nombre',
+    email: r.participant_email ?? null,
+    examType: r.exam_type,
+    processCode: r.process_code ?? '',
+    percentage: r.percentage ?? 0,
+    passed: r.passed ?? false,
+  }));
+
+  const allRaw = [...mappedExams, ...mappedAttempts];
+
+  // Per-process stats (across both sources)
   const processStats: EventProcessStat[] = processes.map((p) => {
-    const rows = allResults.filter((r) => r.process_code === p.code);
+    const rows = allRaw.filter((r) => r.processCode === p.code);
     const passed = rows.filter((r) => r.passed).length;
     const scores = rows.map((r) => r.percentage);
     return {
@@ -550,39 +613,24 @@ export async function getEventStatsAction(groupId: string): Promise<{
     };
   });
 
-  // Top 10 candidates: best attempt per (email OR name) across all processes
-  const bestByKey = new Map<
-    string,
-    {
-      name: string;
-      examType: string;
-      processCode: string;
-      percentage: number;
-      passed: boolean;
-    }
-  >();
-  for (const r of allResults) {
-    const key = (r.participant_email || r.participant_name || '').toLowerCase();
+  // Deduplicate by identity key (email ?? name), keeping best score per person
+  const bestByKey = new Map<string, EventCandidate>();
+  for (const r of allRaw) {
+    const key = (r.email || r.name || '').toLowerCase().trim();
     if (!key) continue;
     const existing = bestByKey.get(key);
     if (!existing || r.percentage > existing.percentage) {
-      bestByKey.set(key, {
-        name: r.participant_name || r.participant_email || 'Sin nombre',
-        examType: r.exam_type,
-        processCode: r.process_code ?? '',
-        percentage: r.percentage,
-        passed: r.passed,
-      });
+      bestByKey.set(key, r);
     }
   }
-  const topCandidates = Array.from(bestByKey.values())
-    .sort((a, b) => b.percentage - a.percentage)
-    .slice(0, 10);
+  const allCandidates = Array.from(bestByKey.values()).sort(
+    (a, b) => b.percentage - a.percentage
+  );
 
-  // By exam type
+  // By exam type (across both sources, all rows not deduplicated)
   const examTypeMap = new Map<string, { total: number; passed: number }>();
-  for (const r of allResults) {
-    const et = r.exam_type;
+  for (const r of allRaw) {
+    const et = r.examType;
     const cur = examTypeMap.get(et) ?? { total: 0, passed: 0 };
     examTypeMap.set(et, {
       total: cur.total + 1,
@@ -598,12 +646,13 @@ export async function getEventStatsAction(groupId: string): Promise<{
     })
   );
 
-  const totalCandidates = allResults.length;
-  const totalPassed = allResults.filter((r) => r.passed).length;
+  const totalCandidates = allCandidates.length;
+  const totalPassed = allCandidates.filter((r) => r.passed).length;
   const avgScore =
     totalCandidates > 0
       ? Math.round(
-          allResults.reduce((sum, r) => sum + r.percentage, 0) / totalCandidates
+          allCandidates.reduce((sum, r) => sum + r.percentage, 0) /
+            totalCandidates
         )
       : null;
 
@@ -611,7 +660,7 @@ export async function getEventStatsAction(groupId: string): Promise<{
     data: {
       group,
       processes: processStats,
-      topCandidates,
+      allCandidates,
       byExamType,
       totals: {
         candidates: totalCandidates,

--- a/apps/frontend/src/app/empresa/eventos/[id]/page.tsx
+++ b/apps/frontend/src/app/empresa/eventos/[id]/page.tsx
@@ -118,6 +118,10 @@ export default function EventoDetailPage() {
   const [stats, setStats] = useState<EventStats | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [filterPassed, setFilterPassed] = useState<'all' | 'passed' | 'failed'>(
+    'all'
+  );
+  const [searchCand, setSearchCand] = useState('');
 
   useEffect(() => {
     getEventStatsAction(groupId).then(({ data, error: err }) => {
@@ -162,9 +166,11 @@ export default function EventoDetailPage() {
     );
   }
 
-  const { group, processes, topCandidates, byExamType, totals } = stats;
+  const { group, processes, allCandidates, byExamType, totals } = stats;
 
-  const topChartData = topCandidates.map((c) => ({
+  const top10 = allCandidates.slice(0, 10);
+
+  const topChartData = top10.map((c) => ({
     name: c.name.length > 22 ? c.name.slice(0, 22) + '…' : c.name,
     fullName: c.name,
     puntaje: c.percentage,
@@ -189,6 +195,24 @@ export default function EventoDetailPage() {
         color: '#e2e8f0',
       }
     : { backgroundColor: '#fff', border: '1px solid #e2e8f0' };
+
+  const filteredCandidates = allCandidates.filter((c) => {
+    const matchSearch =
+      !searchCand ||
+      c.name.toLowerCase().includes(searchCand.toLowerCase()) ||
+      (c.email ?? '').toLowerCase().includes(searchCand.toLowerCase());
+    const matchPass =
+      filterPassed === 'all' ||
+      (filterPassed === 'passed' && c.passed) ||
+      (filterPassed === 'failed' && !c.passed);
+    return matchSearch && matchPass;
+  });
+
+  const inputClass = `rounded-lg border px-3 py-1.5 text-sm outline-none transition-colors focus:ring-2 focus:ring-indigo-500 ${
+    isDarkMode
+      ? 'bg-slate-700 border-slate-600 text-white placeholder-slate-400'
+      : 'bg-white border-gray-300 text-gray-900 placeholder-gray-400'
+  }`;
 
   return (
     <div
@@ -336,7 +360,7 @@ export default function EventoDetailPage() {
                   </ResponsiveContainer>
                 )}
                 <p
-                  className={`text-xs mt-2 ${isDarkMode ? 'text-slate-600' : 'text-gray-300'}`}
+                  className={`text-xs mt-2 ${isDarkMode ? 'text-slate-500' : 'text-gray-400'}`}
                 >
                   🟢 Aprobado · 🔴 No aprobado
                 </p>
@@ -408,9 +432,190 @@ export default function EventoDetailPage() {
               </div>
             </div>
 
+            {/* All participants table */}
+            <div className={`${cardClass} overflow-hidden`}>
+              <div
+                className={`px-5 py-4 border-b flex items-center justify-between gap-4 flex-wrap ${isDarkMode ? 'border-slate-700' : 'border-gray-100'}`}
+              >
+                <p
+                  className={`text-sm font-semibold ${isDarkMode ? 'text-slate-300' : 'text-gray-700'}`}
+                >
+                  Todos los participantes{' '}
+                  <span
+                    className={`font-normal text-xs ml-1 ${isDarkMode ? 'text-slate-500' : 'text-gray-400'}`}
+                  >
+                    ({filteredCandidates.length} de {allCandidates.length})
+                  </span>
+                </p>
+                <div className="flex items-center gap-2 flex-wrap">
+                  <input
+                    type="text"
+                    placeholder="Buscar nombre o email..."
+                    value={searchCand}
+                    onChange={(e) => setSearchCand(e.target.value)}
+                    className={`${inputClass} w-48`}
+                  />
+                  <div
+                    className={`flex rounded-lg border overflow-hidden text-xs font-medium ${isDarkMode ? 'border-slate-600' : 'border-gray-200'}`}
+                  >
+                    {(['all', 'passed', 'failed'] as const).map((f) => (
+                      <button
+                        key={f}
+                        onClick={() => setFilterPassed(f)}
+                        className={`px-3 py-1.5 transition-colors ${
+                          filterPassed === f
+                            ? f === 'passed'
+                              ? 'bg-green-600 text-white'
+                              : f === 'failed'
+                                ? 'bg-red-600 text-white'
+                                : isDarkMode
+                                  ? 'bg-slate-600 text-white'
+                                  : 'bg-gray-200 text-gray-800'
+                            : isDarkMode
+                              ? 'text-slate-400 hover:bg-slate-700'
+                              : 'text-gray-500 hover:bg-gray-50'
+                        }`}
+                      >
+                        {f === 'all'
+                          ? 'Todos'
+                          : f === 'passed'
+                            ? 'Aprobados'
+                            : 'No aprobados'}
+                      </button>
+                    ))}
+                  </div>
+                </div>
+              </div>
+              <div className="overflow-x-auto">
+                <table className="w-full text-sm">
+                  <thead>
+                    <tr
+                      className={`text-xs font-medium uppercase tracking-wider ${
+                        isDarkMode
+                          ? 'bg-slate-800/50 text-slate-400'
+                          : 'bg-gray-50 text-gray-500'
+                      }`}
+                    >
+                      <th className="px-4 py-3 text-center w-10">#</th>
+                      <th className="px-5 py-3 text-left">Participante</th>
+                      <th className="px-4 py-3 text-left">Examen</th>
+                      <th className="px-4 py-3 text-left">Proceso</th>
+                      <th className="px-4 py-3 text-center">Puntaje</th>
+                      <th className="px-4 py-3 text-center">Estado</th>
+                    </tr>
+                  </thead>
+                  <tbody
+                    className={`divide-y ${isDarkMode ? 'divide-slate-700/50' : 'divide-gray-100'}`}
+                  >
+                    {filteredCandidates.length === 0 ? (
+                      <tr>
+                        <td
+                          colSpan={6}
+                          className={`px-5 py-8 text-center text-sm ${isDarkMode ? 'text-slate-500' : 'text-gray-400'}`}
+                        >
+                          Sin resultados para este filtro
+                        </td>
+                      </tr>
+                    ) : (
+                      filteredCandidates.map((c, i) => {
+                        const globalRank =
+                          allCandidates.findIndex(
+                            (x) =>
+                              x.name === c.name &&
+                              x.processCode === c.processCode
+                          ) + 1;
+                        return (
+                          <tr
+                            key={i}
+                            className={`transition-colors ${
+                              isDarkMode
+                                ? 'hover:bg-slate-800/30'
+                                : 'hover:bg-gray-50'
+                            }`}
+                          >
+                            <td
+                              className={`px-4 py-3 text-center text-xs font-mono ${isDarkMode ? 'text-slate-500' : 'text-gray-400'}`}
+                            >
+                              {globalRank === 1
+                                ? '🥇'
+                                : globalRank === 2
+                                  ? '🥈'
+                                  : globalRank === 3
+                                    ? '🥉'
+                                    : globalRank}
+                            </td>
+                            <td className="px-5 py-3">
+                              <p
+                                className={`font-medium ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
+                              >
+                                {c.name}
+                              </p>
+                              {c.email && c.email !== c.name && (
+                                <p
+                                  className={`text-xs ${isDarkMode ? 'text-slate-500' : 'text-gray-400'}`}
+                                >
+                                  {c.email}
+                                </p>
+                              )}
+                            </td>
+                            <td
+                              className={`px-4 py-3 text-sm ${isDarkMode ? 'text-slate-300' : 'text-gray-600'}`}
+                            >
+                              {EXAM_LABELS[c.examType] ?? c.examType}
+                            </td>
+                            <td className="px-4 py-3">
+                              <span
+                                className={`font-mono text-xs px-2 py-0.5 rounded ${isDarkMode ? 'bg-slate-700 text-slate-300' : 'bg-gray-100 text-gray-600'}`}
+                              >
+                                {c.processCode}
+                              </span>
+                            </td>
+                            <td className="px-4 py-3 text-center">
+                              <div className="flex items-center justify-center gap-2">
+                                <div
+                                  className={`h-1.5 w-16 rounded-full overflow-hidden ${isDarkMode ? 'bg-slate-700' : 'bg-gray-200'}`}
+                                >
+                                  <div
+                                    className={`h-full rounded-full ${c.passed ? 'bg-green-500' : 'bg-red-500'}`}
+                                    style={{ width: `${c.percentage}%` }}
+                                  />
+                                </div>
+                                <span
+                                  className={`text-xs font-semibold w-10 text-right ${isDarkMode ? 'text-slate-200' : 'text-gray-700'}`}
+                                >
+                                  {c.percentage}%
+                                </span>
+                              </div>
+                            </td>
+                            <td className="px-4 py-3 text-center">
+                              <span
+                                className={`text-xs font-medium px-2 py-0.5 rounded-full ${
+                                  c.passed
+                                    ? isDarkMode
+                                      ? 'bg-green-900/40 text-green-300'
+                                      : 'bg-green-100 text-green-700'
+                                    : isDarkMode
+                                      ? 'bg-red-900/40 text-red-300'
+                                      : 'bg-red-100 text-red-600'
+                                }`}
+                              >
+                                {c.passed ? 'Aprobado' : 'No aprobado'}
+                              </span>
+                            </td>
+                          </tr>
+                        );
+                      })
+                    )}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+
             {/* Processes table */}
             <div className={`${cardClass} overflow-hidden`}>
-              <div className="px-5 py-4 border-b ${isDarkMode ? 'border-slate-700' : 'border-gray-100'}">
+              <div
+                className={`px-5 py-4 border-b ${isDarkMode ? 'border-slate-700' : 'border-gray-100'}`}
+              >
                 <p
                   className={`text-sm font-semibold ${isDarkMode ? 'text-slate-300' : 'text-gray-700'}`}
                 >
@@ -436,7 +641,9 @@ export default function EventoDetailPage() {
                       <th className="px-4 py-3 text-center">Estado</th>
                     </tr>
                   </thead>
-                  <tbody className="divide-y divide-gray-100 dark:divide-slate-700/50">
+                  <tbody
+                    className={`divide-y ${isDarkMode ? 'divide-slate-700/50' : 'divide-gray-100'}`}
+                  >
                     {processes.map((p) => {
                       const eff = getEffectiveStatus(p);
                       const badge = STATUS_BADGE[eff];


### PR DESCRIPTION
## Summary

- `getEventStatsAction` ahora consulta **ambas** tablas: `exam_results` y `assessment_attempts` (via `.or()` sobre `metadata->>processCode`), para que exámenes como BD Fundamentos y BD Práctica SQL aparezcan en el gráfico de tipos de examen y en el ranking.
- Renombrado `topCandidates` → `allCandidates` (lista completa ordenada por puntaje DESC); el Top 10 chart usa `.slice(0,10)`.
- Nueva tabla **"Todos los participantes"** en la página de evento con: posición y medallas 🥇🥈🥉, buscador por nombre/email, filtro Todos/Aprobados/No aprobados, barra de progreso por puntaje, tipo de examen y código de proceso.

## Test plan

- [ ] Evento con procesos que incluyen BD Práctica SQL → aparece en chart "Por tipo de examen"
- [ ] Tabla "Todos los participantes" muestra candidatos de ambas fuentes (exam_results + assessment_attempts)
- [ ] Buscador filtra correctamente por nombre y email
- [ ] Filtro "Aprobados" muestra solo candidatos con `passed = true`
- [ ] Top 10 chart sigue mostrando solo los 10 mejores puntajes

🤖 Generated with [Claude Code](https://claude.com/claude-code)