### PR TITLE
fix(profiles): use display_name from profiles for exam names

### DIFF
--- a/apps/frontend/src/actions/exams.ts
+++ b/apps/frontend/src/actions/exams.ts
@@ -57,8 +57,15 @@ export async function saveExamResultAction(payload: SaveExamResultPayload) {
   } = await supabase.auth.getUser();
   if (userError || !user) return { error: 'No autenticado' };
 
+  const { data: profile } = await supabase
+    .from('profiles')
+    .select('display_name')
+    .eq('id', user.id)
+    .single();
+
   const resolvedName =
     payload.participant_name?.trim() ||
+    profile?.display_name?.trim() ||
     user.user_metadata?.full_name?.trim() ||
     null;
 

--- a/apps/frontend/src/app/api/assessments/start/route.ts
+++ b/apps/frontend/src/app/api/assessments/start/route.ts
@@ -30,12 +30,21 @@ export async function POST(req: NextRequest) {
       );
     }
 
+    const supabase = createAdminClient();
+
+    const { data: profile } = await supabase
+      .from('profiles')
+      .select('display_name')
+      .eq('id', user.id)
+      .single();
+
     const defaults = getExamUserDefaults(user);
     const candidateName =
-      defaults.fullName || defaults.email || `Usuario ${user.id.slice(0, 8)}`;
+      profile?.display_name?.trim() ||
+      defaults.fullName ||
+      defaults.email ||
+      `Usuario ${user.id.slice(0, 8)}`;
     const candidateEmail = defaults.email || null;
-
-    const supabase = createAdminClient();
 
     // Validar código de proceso si fue provisto
     let resolvedProcessCode: string | null = null;

--- a/apps/frontend/src/app/empresa/candidatos/page.tsx
+++ b/apps/frontend/src/app/empresa/candidatos/page.tsx
@@ -38,7 +38,7 @@ type ExamResult = {
   process_code: string | null;
   section_scores: SectionScore[] | null;
   learning_objectives: unknown | null;
-  profiles?: { display_name: string | null } | null;
+  profiles?: { display_name: string | null }[] | null;
 };
 
 type HiringProcess = {
@@ -106,7 +106,7 @@ export default function CandidatosPage() {
         // Use current profile name when available; fall back to the snapshot stored at exam time
         myResults = ((res ?? []) as ExamResult[]).map((r) => ({
           ...r,
-          participant_name: r.profiles?.display_name ?? r.participant_name,
+          participant_name: r.profiles?.[0]?.display_name ?? r.participant_name,
         }));
       }
 

--- a/apps/frontend/src/app/empresa/candidatos/page.tsx
+++ b/apps/frontend/src/app/empresa/candidatos/page.tsx
@@ -28,6 +28,7 @@ type ExamResult = {
   id: string;
   participant_name: string | null;
   participant_email: string | null;
+  user_id: string | null;
   exam_type: string;
   score: number;
   percentage: number;
@@ -37,6 +38,7 @@ type ExamResult = {
   process_code: string | null;
   section_scores: SectionScore[] | null;
   learning_objectives: unknown | null;
+  profiles?: { display_name: string | null } | null;
 };
 
 type HiringProcess = {
@@ -97,11 +99,15 @@ export default function CandidatosPage() {
         const { data: res } = await supabase
           .from('exam_results')
           .select(
-            'id, participant_name, participant_email, exam_type, score, percentage, passed, time_spent, created_at, process_code, section_scores, learning_objectives'
+            'id, participant_name, participant_email, user_id, exam_type, score, percentage, passed, time_spent, created_at, process_code, section_scores, learning_objectives, profiles(display_name)'
           )
           .in('process_code', processCodes)
           .order('created_at', { ascending: false });
-        myResults = (res ?? []) as ExamResult[];
+        // Use current profile name when available; fall back to the snapshot stored at exam time
+        myResults = ((res ?? []) as ExamResult[]).map((r) => ({
+          ...r,
+          participant_name: r.profiles?.display_name ?? r.participant_name,
+        }));
       }
 
       setProcesses(procs ?? []);

--- a/supabase/migrations/20260618_000001_sync_profile_name_trigger.sql
+++ b/supabase/migrations/20260618_000001_sync_profile_name_trigger.sql
@@ -1,0 +1,23 @@
+-- When a user updates their profile display_name, propagate it to qac_attempts.
+-- exam_results is handled at read time via JOIN with profiles in the candidatos page.
+
+CREATE OR REPLACE FUNCTION public.sync_profile_name_to_qac()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  IF OLD.display_name IS DISTINCT FROM NEW.display_name AND NEW.display_name IS NOT NULL AND NEW.display_name != '' THEN
+    UPDATE public.qac_attempts
+      SET candidate_name = NEW.display_name
+    WHERE aiquaa_user_id = NEW.id::text;
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER trg_sync_qac_candidate_name
+  AFTER UPDATE OF display_name ON public.profiles
+  FOR EACH ROW
+  EXECUTE FUNCTION public.sync_profile_name_to_qac();


### PR DESCRIPTION
## Summary

- **Root cause:** Two sources of truth for user names — `auth.users.raw_user_meta_data.full_name` (stale, set at registration) vs `public.profiles.display_name` (updated when user edits profile). Exam records were reading from the stale metadata, so name changes in the profile had no effect at exam time.
- `saveExamResultAction` now fetches `profiles.display_name` first before falling back to auth metadata
- `api/assessments/start` fetches `profiles.display_name` for `qac_attempts.candidate_name`
- `empresa/candidatos` page JOINs `profiles` at read time — historical exam records show the current profile name without modifying stored exam data
- DB trigger (`trg_sync_qac_candidate_name`) propagates future `display_name` changes to `qac_attempts`

## Test plan

- [ ] Update `display_name` in a test user's profile
- [ ] Take an exam → `exam_results.participant_name` should reflect the updated name
- [ ] Start an API Banking challenge → `qac_attempts.candidate_name` should reflect the updated name
- [ ] Empresa candidatos dashboard shows updated name for that user's historical results
- [ ] Candidates without an AIQUAA profile (external) still show their stored snapshot name

🤖 Generated with [Claude Code](https://claude.com/claude-code)