### PR TITLE
fix: bugs ciclo QA 20-jun — seguridad, ranking, accesibilidad y UX

### DIFF
--- a/apps/frontend/src/actions/admin.ts
+++ b/apps/frontend/src/actions/admin.ts
@@ -1,6 +1,7 @@
 'use server';
 
 import { createClient } from '@/lib/supabase/server';
+import { createAdminClient } from '@/lib/supabase/admin';
 
 async function requireAdmin() {
   const supabase = createClient();
@@ -31,10 +32,13 @@ export async function getAdminUsersAction() {
 }
 
 export async function changeUserRoleAction(targetUserId: string, newRole: 'comunidad' | 'employer' | 'admin') {
-  const { error, supabase } = await requireAdmin();
-  if (error || !supabase) return { error };
+  // Gate: only admins can reach the service-role call below
+  const { error } = await requireAdmin();
+  if (error) return { error };
 
-  const { error: fnError } = await supabase.rpc('change_user_role', {
+  // Use service-role client so this call cannot be replicated via user JWT
+  const adminClient = createAdminClient();
+  const { error: fnError } = await adminClient.rpc('change_user_role', {
     target_user_id: targetUserId,
     new_role: newRole,
   });

--- a/apps/frontend/src/app/assessments/error.tsx
+++ b/apps/frontend/src/app/assessments/error.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import { useEffect } from 'react';
+import Link from 'next/link';
+
+export default function AssessmentsError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-50 dark:bg-slate-900 px-4">
+      <div className="max-w-md w-full text-center rounded-2xl p-8 bg-white dark:bg-slate-800 border border-gray-200 dark:border-slate-700 shadow-sm">
+        <div className="text-5xl mb-4" aria-hidden="true">
+          ⚠️
+        </div>
+        <h1 className="text-xl font-bold text-gray-900 dark:text-white mb-2">
+          No se pudo cargar la evaluación
+        </h1>
+        <p className="text-sm text-gray-500 dark:text-slate-400 mb-6">
+          Ocurrió un error inesperado. Tu progreso guardado no se perdió —
+          podés intentar reiniciar o volver a Labs.
+        </p>
+        <div className="flex flex-col sm:flex-row gap-3 justify-center">
+          <button
+            onClick={() => reset()}
+            className="rounded-lg bg-indigo-600 px-5 py-2.5 text-sm font-semibold text-white transition hover:bg-indigo-700"
+          >
+            Reintentar
+          </button>
+          <Link
+            href="/labs"
+            className="rounded-lg border border-gray-300 dark:border-slate-600 px-5 py-2.5 text-sm font-medium text-gray-700 dark:text-slate-300 transition hover:bg-gray-50 dark:hover:bg-slate-700"
+          >
+            Volver a Labs
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/src/app/dashboard/page.tsx
+++ b/apps/frontend/src/app/dashboard/page.tsx
@@ -115,14 +115,11 @@ export default function DashboardPage() {
 
   const currentLevelXp = xp ? xpForLevel(xp.level) : 0;
   const nextLevelXp = xp ? xpForLevel(xp.level + 1) : 100;
-  const xpPct = xp
-    ? Math.min(
-        100,
-        Math.round(
-          ((xp.totalXp - currentLevelXp) / (nextLevelXp - currentLevelXp)) * 100
-        )
-      )
-    : 0;
+  const xpRange = nextLevelXp - currentLevelXp;
+  const xpPct =
+    xp && xpRange > 0
+      ? Math.min(100, Math.round(((xp.totalXp - currentLevelXp) / xpRange) * 100))
+      : 0;
 
   if (loading) {
     return (

--- a/apps/frontend/src/app/empresa/page.tsx
+++ b/apps/frontend/src/app/empresa/page.tsx
@@ -4,8 +4,8 @@ import { useEffect, useState } from 'react';
 import Link from 'next/link';
 import { useSupabaseAuth } from '@/contexts/SupabaseAuthContext';
 import { useTheme } from '@/contexts/ThemeContext';
-import { getMyMembershipAction } from '@/actions/empresa-admin';
-import type { EmpresaMemberRole } from '@/actions/empresa-admin';
+import { getMyMembershipAction, getMyEmpresaAction } from '@/actions/empresa-admin';
+import type { EmpresaMemberRole, Empresa } from '@/actions/empresa-admin';
 import {
   getEmpresaDashboardStatsAction,
   type EmpresaDashboardStats,
@@ -120,6 +120,7 @@ export default function EmpresaDashboardPage() {
   const { user } = useSupabaseAuth();
   const { isDarkMode } = useTheme();
   const [myRole, setMyRole] = useState<EmpresaMemberRole | null>(null);
+  const [empresa, setEmpresa] = useState<Empresa | null>(null);
   const [stats, setStats] = useState<EmpresaDashboardStats | null>(null);
   const [statsLoading, setStatsLoading] = useState(true);
   const [bannerDismissed, setBannerDismissed] = useState(false);
@@ -137,6 +138,9 @@ export default function EmpresaDashboardPage() {
     getMyMembershipAction().then(({ data }) => {
       if (data) setMyRole(data.role as EmpresaMemberRole);
     });
+    getMyEmpresaAction().then(({ data }) => {
+      if (data) setEmpresa(data);
+    });
     getEmpresaDashboardStatsAction().then(({ data }) => {
       if (data) setStats(data);
       setStatsLoading(false);
@@ -149,9 +153,7 @@ export default function EmpresaDashboardPage() {
   };
 
   const companyName =
-    user?.user_metadata?.company_name ||
-    user?.user_metadata?.full_name ||
-    'tu empresa';
+    empresa?.nombre_comercial || empresa?.razon_social || 'tu empresa';
 
   const isAdmin = myRole === 'owner' || myRole === 'admin';
   const links = isAdmin ? [...BASE_LINKS, ADMIN_LINK] : BASE_LINKS;

--- a/apps/frontend/src/app/error.tsx
+++ b/apps/frontend/src/app/error.tsx
@@ -1,0 +1,46 @@
+'use client';
+
+import { useEffect } from 'react';
+
+export default function GlobalError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-50 px-4">
+      <div className="max-w-md w-full text-center rounded-2xl p-8 bg-white border border-gray-200 shadow-sm">
+        <div className="text-5xl mb-4" aria-hidden="true">
+          ⚠️
+        </div>
+        <h1 className="text-xl font-bold text-gray-900 mb-2">
+          Algo salió mal
+        </h1>
+        <p className="text-sm text-gray-500 mb-6">
+          Ocurrió un error inesperado. Podés intentar recargar la página o
+          volver al inicio.
+        </p>
+        <div className="flex flex-col sm:flex-row gap-3 justify-center">
+          <button
+            onClick={() => reset()}
+            className="rounded-lg bg-indigo-600 px-5 py-2.5 text-sm font-semibold text-white transition hover:bg-indigo-700"
+          >
+            Reintentar
+          </button>
+          <a
+            href="/"
+            className="rounded-lg border border-gray-300 px-5 py-2.5 text-sm font-medium text-gray-700 transition hover:bg-gray-50"
+          >
+            Volver al inicio
+          </a>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/src/app/labs/allpairs/page.tsx
+++ b/apps/frontend/src/app/labs/allpairs/page.tsx
@@ -129,16 +129,29 @@ export default function AllPairsPage() {
         {/* Tabs */}
         <div className="bg-white dark:bg-gray-800 rounded-lg shadow-lg mb-6">
           <div className="border-b border-gray-200 dark:border-gray-700">
-            <nav className="flex -mb-px">
-              {[
-                { id: 'editor' as Tab, label: 'Editor' },
-                { id: 'json-yaml' as Tab, label: 'JSON/YAML' },
-                { id: 'examples' as Tab, label: 'Ejemplos' },
-                { id: 'help' as Tab, label: 'Ayuda' },
-              ].map((tab) => (
+            <nav role="tablist" aria-label="Secciones del generador" className="flex -mb-px">
+              {(
+                [
+                  { id: 'editor' as Tab, label: 'Editor' },
+                  { id: 'json-yaml' as Tab, label: 'JSON/YAML' },
+                  { id: 'examples' as Tab, label: 'Ejemplos' },
+                  { id: 'help' as Tab, label: 'Ayuda' },
+                ] as const
+              ).map((tab, i, tabs) => (
                 <button
                   key={tab.id}
+                  id={`allpairs-tab-${tab.id}`}
+                  role="tab"
+                  aria-selected={activeTab === tab.id}
+                  aria-controls="allpairs-tabpanel"
                   onClick={() => setActiveTab(tab.id)}
+                  onKeyDown={(e) => {
+                    if (e.key === 'ArrowRight') {
+                      setActiveTab(tabs[(i + 1) % tabs.length].id);
+                    } else if (e.key === 'ArrowLeft') {
+                      setActiveTab(tabs[(i - 1 + tabs.length) % tabs.length].id);
+                    }
+                  }}
                   className={`px-6 py-3 text-sm font-medium border-b-2 transition-colors ${
                     activeTab === tab.id
                       ? 'border-blue-500 text-blue-600 dark:text-blue-400'
@@ -151,7 +164,7 @@ export default function AllPairsPage() {
             </nav>
           </div>
 
-          <div className="p-6">
+          <div id="allpairs-tabpanel" role="tabpanel" aria-labelledby={`allpairs-tab-${activeTab}`} className="p-6">
             {activeTab === 'editor' && (
               <EditorTab input={input} onChange={setInput} />
             )}

--- a/apps/frontend/src/app/labs/error.tsx
+++ b/apps/frontend/src/app/labs/error.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import { useEffect } from 'react';
+import Link from 'next/link';
+
+export default function LabsError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-50 dark:bg-slate-900 px-4">
+      <div className="max-w-md w-full text-center rounded-2xl p-8 bg-white dark:bg-slate-800 border border-gray-200 dark:border-slate-700 shadow-sm">
+        <div className="text-5xl mb-4" aria-hidden="true">
+          🧪
+        </div>
+        <h1 className="text-xl font-bold text-gray-900 dark:text-white mb-2">
+          Este lab no pudo cargar
+        </h1>
+        <p className="text-sm text-gray-500 dark:text-slate-400 mb-6">
+          Ocurrió un error inesperado. Podés intentar reiniciar el lab o
+          volver al catálogo de herramientas.
+        </p>
+        <div className="flex flex-col sm:flex-row gap-3 justify-center">
+          <button
+            onClick={() => reset()}
+            className="rounded-lg bg-indigo-600 px-5 py-2.5 text-sm font-semibold text-white transition hover:bg-indigo-700"
+          >
+            Reintentar
+          </button>
+          <Link
+            href="/labs"
+            className="rounded-lg border border-gray-300 dark:border-slate-600 px-5 py-2.5 text-sm font-medium text-gray-700 dark:text-slate-300 transition hover:bg-gray-50 dark:hover:bg-slate-700"
+          >
+            Volver a Labs
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/src/app/not-found.tsx
+++ b/apps/frontend/src/app/not-found.tsx
@@ -1,0 +1,25 @@
+import Link from 'next/link';
+
+export default function NotFound() {
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-50 px-4">
+      <div className="max-w-md w-full text-center rounded-2xl p-8 bg-white border border-gray-200 shadow-sm">
+        <div className="text-6xl mb-4" aria-hidden="true">
+          🔍
+        </div>
+        <h1 className="text-2xl font-bold text-gray-900 mb-2">
+          Página no encontrada
+        </h1>
+        <p className="text-sm text-gray-500 mb-6">
+          Esta página no existe o fue movida. Verificá la URL o volvé al inicio.
+        </p>
+        <Link
+          href="/"
+          className="inline-block rounded-lg bg-indigo-600 px-6 py-2.5 text-sm font-semibold text-white transition hover:bg-indigo-700"
+        >
+          Volver al inicio
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/src/app/ranking/page.tsx
+++ b/apps/frontend/src/app/ranking/page.tsx
@@ -918,12 +918,27 @@ export default function RankingPage() {
 
         {/* Tabs */}
         <div
+          role="tablist"
+          aria-label="Tipos de ranking"
           className={`flex rounded-xl p-1 gap-1 flex-wrap ${isDarkMode ? 'bg-slate-800' : 'bg-gray-200'}`}
         >
           {EXAM_TABS.map((t) => (
             <button
               key={t.key}
+              id={`ranking-tab-${t.key}`}
+              role="tab"
+              aria-selected={activeTab === t.key}
+              aria-controls="ranking-tabpanel"
               onClick={() => setActiveTab(t.key)}
+              onKeyDown={(e) => {
+                const keys = EXAM_TABS.map((tab) => tab.key);
+                const idx = keys.indexOf(t.key);
+                if (e.key === 'ArrowRight') {
+                  setActiveTab(keys[(idx + 1) % keys.length]);
+                } else if (e.key === 'ArrowLeft') {
+                  setActiveTab(keys[(idx - 1 + keys.length) % keys.length]);
+                }
+              }}
               className={`flex-1 flex items-center justify-center gap-2 py-2.5 px-3 rounded-lg text-sm font-semibold transition-all min-w-[100px] ${
                 activeTab === t.key
                   ? `bg-gradient-to-r ${t.color} text-white shadow-md`
@@ -938,6 +953,7 @@ export default function RankingPage() {
         </div>
 
         {/* Contenido */}
+        <div id="ranking-tabpanel" role="tabpanel" aria-labelledby={`ranking-tab-${activeTab}`}>
         {isReportes ? (
           <ReportadoresTab isDarkMode={isDarkMode} />
         ) : isXp ? (
@@ -1123,6 +1139,7 @@ export default function RankingPage() {
             </p>
           </>
         )}
+        </div>
       </div>
     </div>
   );

--- a/apps/frontend/src/app/ranking/page.tsx
+++ b/apps/frontend/src/app/ranking/page.tsx
@@ -120,9 +120,11 @@ const EXAM_TAB_URLS: Record<string, string> = {
 const MEDAL = ['🥇', '🥈', '🥉'];
 
 function getInitials(name: string) {
-  const parts = name.trim().split(' ');
+  const trimmed = name.trim();
+  if (!trimmed) return '?';
+  const parts = trimmed.split(' ');
   if (parts.length >= 2) return (parts[0][0] + parts[1][0]).toUpperCase();
-  return name.slice(0, 2).toUpperCase();
+  return trimmed.slice(0, 2).toUpperCase();
 }
 
 const COLORS = [

--- a/supabase/migrations/20260620_000000_sec001_revoke_change_user_role_from_authenticated.sql
+++ b/supabase/migrations/20260620_000000_sec001_revoke_change_user_role_from_authenticated.sql
@@ -1,0 +1,13 @@
+-- SEC-001: Revocar EXECUTE de change_user_role() para el rol authenticated.
+--
+-- Contexto: La función es SECURITY DEFINER y ya tiene un guard interno que valida
+-- que el caller sea admin. Sin embargo, cualquier usuario autenticado podía llamarla
+-- directamente via POST /rest/v1/rpc/change_user_role con su JWT, bypassando el
+-- server action de Next.js.
+--
+-- Fix: El server action changeUserRoleAction() ahora usa createAdminClient()
+-- (service role key). La autorización se valida en capa de aplicación con requireAdmin()
+-- antes de hacer la llamada. La función DB ya no necesita ser callable por authenticated.
+--
+-- Permisos resultantes: postgres (superuser) + service_role únicamente.
+REVOKE EXECUTE ON FUNCTION public.change_user_role(uuid, text) FROM authenticated;

--- a/supabase/migrations/20260620_000001_fix_get_leaderboard_dedup_by_display_name.sql
+++ b/supabase/migrations/20260620_000001_fix_get_leaderboard_dedup_by_display_name.sql
@@ -1,0 +1,155 @@
+-- Issue #139: get_leaderboard() deduplicaba por display_name con DISTINCT ON (dname).
+-- Efecto: dos usuarios con el mismo nombre → uno desaparecía silenciosamente del ranking.
+-- Nombres comunes en LATAM (Ana, María) y el fallback 'Anónimo' hacen esto probable a escala.
+--
+-- Fix: eliminar el CTE `deduped` en ambas ramas.
+-- El DISTINCT ON (user_id) en best_attempt ya garantiza exactamente una fila por persona.
+
+CREATE OR REPLACE FUNCTION public.get_leaderboard(p_exam_type text, p_limit integer DEFAULT 20)
+RETURNS TABLE(
+  rank               bigint,
+  display_name       text,
+  avatar_url         text,
+  best_score         integer,
+  total_questions    integer,
+  max_possible_score integer,
+  best_percentage    numeric,
+  passed             boolean,
+  attempts           bigint,
+  achieved_at        timestamp with time zone
+)
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $function$
+  -- ── New assessment system ──────────────────────────────────────────────────
+  SELECT *
+  FROM (
+    WITH asmnt AS (
+      SELECT id FROM public.assessments WHERE slug = p_exam_type
+    ),
+    best_attempt AS (
+      SELECT DISTINCT ON (aa.user_id)
+        aa.user_id,
+        aa.total_score::integer AS best_score,
+        aa.max_score::integer   AS max_score,
+        aa.percentage           AS best_percentage,
+        aa.passed,
+        aa.submitted_at         AS achieved_at
+      FROM public.assessment_attempts aa
+      JOIN asmnt ON aa.assessment_id = asmnt.id
+      WHERE aa.status   = 'graded'
+        AND aa.user_id  IS NOT NULL
+        AND aa.percentage <= 100
+      ORDER BY aa.user_id, aa.percentage DESC, aa.total_score DESC
+    ),
+    attempt_counts AS (
+      SELECT aa.user_id, COUNT(*) AS attempts
+      FROM public.assessment_attempts aa
+      JOIN asmnt ON aa.assessment_id = asmnt.id
+      WHERE aa.status   = 'graded'
+        AND aa.user_id  IS NOT NULL
+      GROUP BY aa.user_id
+    ),
+    with_display AS (
+      SELECT
+        ba.best_score,
+        ba.max_score,
+        ba.best_percentage,
+        ba.passed,
+        ba.achieved_at,
+        ac.attempts,
+        COALESCE(
+          NULLIF(TRIM(u.raw_user_meta_data->>'full_name'),  ''),
+          NULLIF(TRIM(u.raw_user_meta_data->>'username'),   ''),
+          'Anónimo'
+        ) AS dname,
+        u.raw_user_meta_data->>'avatar_url' AS avatar_url
+      FROM best_attempt ba
+      JOIN auth.users u ON u.id = ba.user_id
+      JOIN attempt_counts ac ON ac.user_id = ba.user_id
+    )
+    SELECT
+      ROW_NUMBER() OVER (ORDER BY best_percentage DESC, best_score DESC) AS rank,
+      dname           AS display_name,
+      avatar_url,
+      best_score,
+      max_score       AS total_questions,
+      max_score       AS max_possible_score,
+      best_percentage,
+      passed,
+      attempts,
+      achieved_at
+    FROM with_display
+    ORDER BY best_percentage DESC, best_score DESC
+    LIMIT p_limit
+  ) t
+  WHERE p_exam_type IN ('database-fundamentals', 'database-practice')
+
+  UNION ALL
+
+  -- ── Legacy system ──────────────────────────────────────────────────────────
+  SELECT *
+  FROM (
+    WITH best_attempt AS (
+      SELECT DISTINCT ON (er.user_id)
+        er.user_id,
+        er.score           AS best_score,
+        er.total_questions,
+        er.max_possible_score,
+        er.percentage      AS best_percentage,
+        er.passed,
+        er.created_at      AS achieved_at
+      FROM public.exam_results er
+      WHERE er.exam_type        = p_exam_type
+        AND er.exam_mode        = 'exam'
+        AND er.user_id          IS NOT NULL
+        AND er.percentage       <= 100
+        AND er.total_questions  >= 10
+        AND er.score            <= COALESCE(er.max_possible_score, er.total_questions)
+      ORDER BY er.user_id, er.percentage DESC, er.score DESC
+    ),
+    attempt_counts AS (
+      SELECT user_id, COUNT(*) AS attempts
+      FROM public.exam_results
+      WHERE exam_type = p_exam_type
+        AND exam_mode = 'exam'
+        AND user_id   IS NOT NULL
+      GROUP BY user_id
+    ),
+    with_display AS (
+      SELECT
+        ba.best_score,
+        ba.total_questions,
+        ba.max_possible_score,
+        ba.best_percentage,
+        ba.passed,
+        ba.achieved_at,
+        ac.attempts,
+        COALESCE(
+          NULLIF(TRIM(u.raw_user_meta_data->>'full_name'),  ''),
+          NULLIF(TRIM(u.raw_user_meta_data->>'username'),   ''),
+          'Anónimo'
+        ) AS dname,
+        u.raw_user_meta_data->>'avatar_url' AS avatar_url
+      FROM best_attempt ba
+      JOIN auth.users u ON u.id = ba.user_id
+      JOIN attempt_counts ac ON ac.user_id = ba.user_id
+    )
+    SELECT
+      ROW_NUMBER() OVER (ORDER BY best_percentage DESC, best_score DESC) AS rank,
+      dname           AS display_name,
+      avatar_url,
+      best_score,
+      total_questions,
+      max_possible_score,
+      best_percentage,
+      passed,
+      attempts,
+      achieved_at
+    FROM with_display
+    ORDER BY best_percentage DESC, best_score DESC
+    LIMIT p_limit
+  ) t
+  WHERE p_exam_type NOT IN ('database-fundamentals', 'database-practice');
+$function$;

--- a/supabase/migrations/20260620_000002_sec002_explicit_block_policies_challenge_qac.sql
+++ b/supabase/migrations/20260620_000002_sec002_explicit_block_policies_challenge_qac.sql
@@ -1,0 +1,36 @@
+-- Issue #151 (parcial): Tablas challenge_* y qac_* con RLS habilitado sin políticas.
+-- Estas tablas son accedidas ÚNICAMENTE via createAdminClient() (service role key)
+-- en las API routes de Next.js. El service role bypasea RLS, así que el
+-- comportamiento de la app no cambia.
+-- Se agregan políticas RESTRICTIVE USING (false) para documentar explícitamente
+-- que ningún usuario autenticado o anónimo puede leer/escribir directamente.
+
+CREATE POLICY "Acceso solo via service role" ON public.challenge_accounts
+  AS RESTRICTIVE FOR ALL TO authenticated, anon USING (false);
+
+CREATE POLICY "Acceso solo via service role" ON public.challenge_movements
+  AS RESTRICTIVE FOR ALL TO authenticated, anon USING (false);
+
+CREATE POLICY "Acceso solo via service role" ON public.challenge_sessions
+  AS RESTRICTIVE FOR ALL TO authenticated, anon USING (false);
+
+CREATE POLICY "Acceso solo via service role" ON public.challenge_transfers
+  AS RESTRICTIVE FOR ALL TO authenticated, anon USING (false);
+
+CREATE POLICY "Acceso solo via service role" ON public.challenge_users
+  AS RESTRICTIVE FOR ALL TO authenticated, anon USING (false);
+
+CREATE POLICY "Acceso solo via service role" ON public.qac_attempts
+  AS RESTRICTIVE FOR ALL TO authenticated, anon USING (false);
+
+CREATE POLICY "Acceso solo via service role" ON public.qac_bug_reports
+  AS RESTRICTIVE FOR ALL TO authenticated, anon USING (false);
+
+CREATE POLICY "Acceso solo via service role" ON public.qac_catalog
+  AS RESTRICTIVE FOR ALL TO authenticated, anon USING (false);
+
+CREATE POLICY "Acceso solo via service role" ON public.qac_scores
+  AS RESTRICTIVE FOR ALL TO authenticated, anon USING (false);
+
+CREATE POLICY "Acceso solo via service role" ON public.qac_test_cases
+  AS RESTRICTIVE FOR ALL TO authenticated, anon USING (false);


### PR DESCRIPTION
## Resumen

Fixes de bugs identificados en el ciclo QA rutinario del 20 de junio. **Solo bugs — sin mejoras ni nuevas funcionalidades.**

---

## 🔐 Seguridad

### SEC-001 — Escalación de privilegios `change_user_role()` (Closes #150)
**Problema:** Cualquier usuario autenticado podía llamar `POST /rest/v1/rpc/change_user_role` con su JWT y darse rol `admin`.

**Fix (dos capas):**
- `REVOKE EXECUTE ON FUNCTION public.change_user_role(uuid, text) FROM authenticated` — ningún JWT de usuario puede ejecutar la función directamente
- `changeUserRoleAction()` en `admin.ts` ahora usa `createAdminClient()` (service role key) en vez de la sesión del usuario

**Impacto en funcionalidad:** Ninguno. El panel de admin sigue funcionando; la diferencia es que la llamada a DB usa service role en vez del JWT del admin.

---

## 🏆 Ranking

### Fix `get_leaderboard()` — usuarios ocultos por nombre duplicado (Closes #139)
**Problema:** La función tenía `DISTINCT ON (dname)` que eliminaba silenciosamente a usuarios reales con el mismo nombre visible (ej: dos "Ana Duarte" → una desaparecía).

**Fix:** Eliminar el CTE `deduped` en ambas ramas (new assessment system y legacy). El `DISTINCT ON (user_id)` en `best_attempt` ya garantiza una fila por persona.

**Verificado:** `get_leaderboard('istqb', 5)` devuelve datos correctos post-migración.

---

## 🐛 Frontend — bugs UI

### `getInitials()` retorna string vacío para nombre vacío (Closes #154)
- `ranking/page.tsx` — añadir guard `if (!trimmed) return '?'` para evitar avatar sin texto

### XP progress bar muestra `NaN%` (Closes #155)
- `dashboard/page.tsx` — dividir solo si `xpRange > 0`, retornar `0` si el rango es cero

### Sin error boundaries en rutas clave (Closes #157)
- Crear `app/error.tsx` global con botón "Reintentar" y link a home
- Crear `app/not-found.tsx` global (404 con navegación)
- Crear `app/labs/error.tsx` con contexto de labs ("Volver a Labs")
- Crear `app/assessments/error.tsx` con aviso de que el progreso guardado no se perdió

---

## ♿ Accesibilidad

### Tabs sin roles ARIA en `/ranking` y `/labs/allpairs` (Closes #156)
**Violación:** WCAG 2.1 Level A, criterio 4.1.2 — usuarios de lectores de pantalla no identificaban el componente de tabs ni el tab activo.

**Fix en ambas páginas:**
- `role="tablist"` + `aria-label` en el contenedor de tabs
- `role="tab"` + `aria-selected` + `id` en cada botón
- `role="tabpanel"` + `aria-labelledby` en el panel de contenido
- Navegación por teclado con `ArrowLeft` / `ArrowRight`

---

## 🏢 Dashboard empresa

### Nombre de empresa incorrecto (Closes #161)
**Problema:** `companyName` usaba `user_metadata.company_name || user_metadata.full_name` — usuarios registrados con OAuth (Google/GitHub) veían su nombre personal en vez del nombre de la empresa.

**Fix:** Cargar `empresa` desde `getMyEmpresaAction()` y usar `empresa.nombre_comercial || empresa.razon_social`.

---

## 🗄️ Base de datos

### Políticas RLS explícitas para tablas challenge/qac (parcial #151)
Las 10 tablas (`challenge_*`, `qac_*`) tenían RLS habilitado sin políticas. Son accedidas **solo** via `createAdminClient()` (service role), que bypasea RLS. Se agregan políticas `RESTRICTIVE USING (false)` para documentar explícitamente que el acceso directo por JWT no está permitido.

---

## Migraciones aplicadas en producción

| Archivo | Contenido |
|---------|-----------|
| `20260620_000000_sec001_revoke_change_user_role_from_authenticated.sql` | REVOKE EXECUTE de change_user_role |
| `20260620_000001_fix_get_leaderboard_dedup_by_display_name.sql` | Fix DISTINCT ON (dname) |
| `20260620_000002_sec002_explicit_block_policies_challenge_qac.sql` | Políticas de bloqueo explícito |

## Test plan

- [ ] Panel admin `/admin` — cambio de rol sigue funcionando (usa service role ahora)
- [ ] `/ranking` — todos los tabs navegan con teclado (←/→), lectores de pantalla anuncian tab activo
- [ ] `/ranking` — usuarios con mismo nombre visible aparecen ambos en el leaderboard
- [ ] `/labs/allpairs` — tabs navegan con teclado
- [ ] `/dashboard` — barra de XP no muestra NaN% en ningún nivel
- [ ] `/empresa` — header muestra `nombre_comercial` / `razon_social`, no nombre de OAuth
- [ ] Forzar error en `/labs/istqb` — aparece pantalla de error con "Reintentar" y "Volver a Labs"
- [ ] Navegar a ruta inexistente — aparece 404 con link a home

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HUsJZyueJNCWvQuNKenRKP

---
_Generated by [Claude Code](https://claude.ai/code/session_01HUsJZyueJNCWvQuNKenRKP)_