### PR TITLE
feat(frontend): strengthen legal policies

### DIFF
--- a/apps/frontend/src/app/privacy/page.tsx
+++ b/apps/frontend/src/app/privacy/page.tsx
@@ -1,74 +1,275 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Política de Privacidad | AIQUAA',
+  description:
+    'Política de privacidad de AIQUAA: datos recopilados, finalidad, bases legales, terceros, derechos, retención y seguridad.',
+};
+
+const LAST_UPDATED = 'Junio 2026';
+const CONTACT_EMAIL = 'stevenayal@proton.me';
+
+interface Section {
+  id: string;
+  icon: string;
+  title: string;
+  paragraphs: string[];
+  bullets?: string[];
+}
+
+const SECTIONS: Section[] = [
+  {
+    id: 'responsable',
+    icon: '🛡️',
+    title: '1. Responsable del tratamiento',
+    paragraphs: [
+      'AIQUAA es responsable del tratamiento de los datos personales recolectados a través del sitio, la app, las herramientas de Labs, el foro, el módulo de empresas y los canales de soporte.',
+      'Esta política explica qué información tratamos, por qué la tratamos, con quién puede compartirse y qué derechos podés ejercer.',
+    ],
+  },
+  {
+    id: 'datos',
+    icon: '📝',
+    title: '2. Datos que recopilamos',
+    paragraphs: [
+      'Según el uso que hagas de la plataforma, podemos recopilar datos que nos proporcionás directamente y datos técnicos generados durante el uso del servicio.',
+    ],
+    bullets: [
+      'Datos de cuenta: nombre, email, país, rol o perfil profesional, foto o avatar y preferencias de usuario.',
+      'Datos de autenticación: proveedor de acceso utilizado, identificadores técnicos de sesión, estado de login y metadatos de seguridad.',
+      'Datos de contenido: publicaciones en el foro, comentarios, reportes, respuestas, mensajes y materiales que subas o envíes.',
+      'Datos del módulo de empresas: información de la empresa, procesos de selección, candidatos, resultados de evaluaciones y evidencias asociadas.',
+      'Datos de soporte: consultas que nos envíes por email o formularios de contacto.',
+      'Datos técnicos: IP, tipo de navegador, dispositivo, sistema operativo, idioma, registros de acceso, errores y actividad de seguridad.',
+      'Cookies y almacenamiento local: preferencias, sesión, autenticación y configuraciones necesarias para el funcionamiento de la app.',
+    ],
+  },
+  {
+    id: 'finalidades',
+    icon: '🎯',
+    title: '3. Finalidades del tratamiento',
+    paragraphs: [
+      'Tratamos los datos para operar la plataforma y proteger a la comunidad.',
+    ],
+    bullets: [
+      'Crear y administrar cuentas, sesiones y accesos.',
+      'Habilitar Labs, simuladores, ranking, foro y el módulo de empresas.',
+      'Responder consultas, enviar notificaciones y prestar soporte.',
+      'Prevenir fraude, abuso, spam, scraping, suplantación y uso no autorizado.',
+      'Mejorar la estabilidad, seguridad y calidad del servicio.',
+      'Cumplir obligaciones legales, regulatorias y contractuales.',
+    ],
+  },
+  {
+    id: 'base-legal',
+    icon: '⚖️',
+    title: '4. Base legal',
+    paragraphs: [
+      'Dependiendo del caso, tratamos tus datos sobre una o más de las siguientes bases legales: consentimiento, ejecución del servicio, interés legítimo, obligación legal y, cuando corresponda, el cumplimiento de medidas precontractuales o contractuales.',
+      'Cuando el tratamiento requiera consentimiento, podés retirarlo en cualquier momento, sin afectar la licitud del tratamiento realizado antes de la revocación.',
+    ],
+  },
+  {
+    id: 'terceros',
+    icon: '🔌',
+    title: '5. Proveedores y terceros',
+    paragraphs: [
+      'Podemos utilizar proveedores externos para alojar, autenticar, observar y enviar comunicaciones relacionadas con la plataforma. Estos proveedores pueden procesar datos en nuestro nombre y bajo sus propias políticas.',
+    ],
+    bullets: [
+      'Infraestructura y hosting: Vercel y Railway.',
+      'Autenticación y base de datos: Supabase u otros servicios equivalentes de autenticación/almacenamiento que la plataforma use.',
+      'Correo electrónico y notificaciones: Resend u otro proveedor similar.',
+      'Observabilidad y monitoreo: herramientas de logs, métricas, errores y trazas, como Sentry u OpenTelemetry, si están activas.',
+    ],
+  },
+  {
+    id: 'cookies',
+    icon: '🍪',
+    title: '6. Cookies y almacenamiento local',
+    paragraphs: [
+      'Usamos cookies y almacenamiento local únicamente cuando son necesarios para la autenticación, la sesión, las preferencias, la seguridad y la experiencia de uso.',
+      'Podés configurar tu navegador para bloquear ciertas cookies, pero algunas funciones podrían dejar de funcionar correctamente.',
+    ],
+  },
+  {
+    id: 'labs',
+    icon: '🛠️',
+    title: '7. Herramientas de Labs',
+    paragraphs: [
+      'Muchas herramientas de Labs procesan información directamente en tu navegador y, en esos casos, AIQUAA no almacena el contenido en nuestros servidores salvo que la herramienta indique lo contrario.',
+      'Si una herramienta envía datos a un servidor para responder una solicitud, mostrar resultados o generar contenido, esa operación se informará de forma visible en la propia funcionalidad.',
+    ],
+  },
+  {
+    id: 'retencion',
+    icon: '🗂️',
+    title: '8. Conservación y eliminación',
+    paragraphs: [
+      'Conservamos los datos solo durante el tiempo necesario para cumplir las finalidades descritas, resolver disputas, hacer cumplir nuestros términos y cumplir obligaciones legales.',
+      'Cuando cierres tu cuenta, podremos conservar cierta información de forma limitada por motivos legales, de seguridad, antifraude o auditoría.',
+    ],
+  },
+  {
+    id: 'transferencias',
+    icon: '🌍',
+    title: '9. Transferencias internacionales',
+    paragraphs: [
+      'La plataforma puede procesar datos fuera de Paraguay, incluido en países donde operan nuestros proveedores de infraestructura y comunicaciones.',
+      'Cuando corresponda, aplicamos salvaguardas contractuales y organizativas razonables para proteger esa información.',
+    ],
+  },
+  {
+    id: 'derechos',
+    icon: '🙋',
+    title: '10. Tus derechos',
+    paragraphs: [
+      'Según la legislación aplicable, podés solicitar acceso, rectificación, actualización, eliminación, oposición, limitación y portabilidad de tus datos.',
+      'También podés retirar tu consentimiento cuando ese sea el fundamento del tratamiento, o solicitar la baja de comunicaciones no esenciales.',
+    ],
+    bullets: [
+      'Podés escribirnos para ejercer tus derechos y te responderemos dentro de un plazo razonable.',
+      'Si la ley exige conservar parte de la información, te explicaremos qué datos no pueden eliminarse y por qué.',
+    ],
+  },
+  {
+    id: 'seguridad',
+    icon: '🔐',
+    title: '11. Seguridad',
+    paragraphs: [
+      'Aplicamos medidas técnicas y organizativas razonables para proteger la información contra acceso no autorizado, pérdida, alteración o divulgación indebida.',
+      'Ningún sistema es totalmente invulnerable, por lo que no podemos garantizar seguridad absoluta, pero sí hacemos esfuerzos razonables para reducir los riesgos.',
+    ],
+  },
+  {
+    id: 'menores',
+    icon: '👶',
+    title: '12. Menores de edad',
+    paragraphs: [
+      'La plataforma no está dirigida a menores de edad sin supervisión. Si tenés la edad mínima legal de tu país, o 16 años como mínimo general, podés usar la plataforma solo si la ley lo permite.',
+      'Si detectamos una cuenta creada por un menor sin autorización válida, podremos suspenderla o eliminarla.',
+    ],
+  },
+  {
+    id: 'empresas',
+    icon: '🏢',
+    title: '13. Módulo de empresas',
+    paragraphs: [
+      'Cuando una empresa utiliza la plataforma para reclutar o evaluar candidatos, tratamos los datos necesarios para administrar el proceso y permitir el acceso a resultados.',
+      'La empresa es responsable de usar esos datos solo para fines legítimos de selección, cumplir la normativa aplicable y respetar los derechos de los candidatos.',
+    ],
+  },
+  {
+    id: 'no-venta',
+    icon: '🚫',
+    title: '14. No vendemos tus datos',
+    paragraphs: [
+      'AIQUAA no vende tus datos personales ni los utiliza para publicidad comportamental de terceros.',
+      'Tampoco compartimos información con terceros para fines comerciales ajenos a la prestación, seguridad o mejora del servicio, salvo obligación legal o consentimiento expreso.',
+    ],
+  },
+  {
+    id: 'cambios',
+    icon: '🔄',
+    title: '15. Cambios en esta política',
+    paragraphs: [
+      'Podemos actualizar esta política para reflejar cambios en la plataforma, en nuestros proveedores o en la normativa aplicable.',
+      'Cuando hagamos cambios materiales, publicaremos la nueva versión y, si corresponde, daremos aviso adicional por medios razonables.',
+    ],
+  },
+];
+
 export default function PrivacyPage() {
   return (
     <div className="min-h-screen bg-brand-light py-12 md:py-16">
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+      <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="text-center mb-12">
           <h1 className="text-4xl md:text-5xl font-bold text-brand-text mb-6">
             Política de Privacidad
           </h1>
           <p className="text-xl text-brand-muted max-w-3xl mx-auto">
-            Cómo protegemos tu información en AIQUAA
+            Cómo recopilamos, usamos y protegemos tu información en AIQUAA
           </p>
         </div>
 
         <div className="bg-white rounded-lg shadow-lg p-8 mb-8">
-          <div className="text-center mb-6">
-            <div className="text-4xl mb-4">🔒</div>
-            <h2 className="text-2xl font-bold text-brand-text mb-4">
-              Tu Privacidad es Importante
-            </h2>
-            <p className="text-lg text-brand-text">
-              AIQUAA respeta tu privacidad. Actualmente no recopilamos datos personales sensibles 
-              mediante cookies ni rastreadores.
-            </p>
-          </div>
-        </div>
-
-        <div className="grid md:grid-cols-2 gap-8 mb-8">
-          <div className="bg-white rounded-lg shadow-lg p-6">
-            <div className="text-3xl mb-4">📝</div>
-            <h3 className="text-xl font-bold text-brand-text mb-4">Datos que Recopilamos</h3>
-            <p className="text-brand-text mb-3">
-              Los únicos datos que podés proporcionar son voluntarios a través del formulario de contacto, 
-              y serán utilizados exclusivamente para responder a tu consulta.
-            </p>
-            <p className="text-brand-text">
-              No compartimos tus datos con terceros ni los utilizamos con fines publicitarios.
-            </p>
-          </div>
-
-          <div className="bg-white rounded-lg shadow-lg p-6">
-            <div className="text-3xl mb-4">🛠️</div>
-            <h3 className="text-xl font-bold text-brand-text mb-4">Herramientas de Labs</h3>
-            <p className="text-brand-text mb-3">
-              Las herramientas de Labs no almacenan información en el servidor. Todo el procesamiento 
-              ocurre en tu navegador.
-            </p>
-            <p className="text-brand-text">
-              Esto garantiza que tus datos permanezcan privados y seguros.
-            </p>
-          </div>
-        </div>
-
-        <div className="bg-white rounded-lg shadow-lg p-8 mb-8">
           <div className="text-center">
-            <div className="text-4xl mb-4">📧</div>
-            <h2 className="text-2xl font-bold text-brand-text mb-4">Contacto</h2>
-            <p className="text-lg text-brand-text mb-4">
-              Si tenés dudas sobre nuestra política de privacidad, escribinos a:
+            <div className="text-4xl mb-4" aria-hidden="true">
+              🔒
+            </div>
+            <h2 className="text-2xl font-bold text-brand-text mb-4">
+              Tu privacidad importa
+            </h2>
+            <p className="text-lg text-brand-text leading-relaxed">
+              AIQUAA trata tus datos solo cuando es necesario para brindarte el
+              servicio, proteger la plataforma y cumplir obligaciones legales.
+              No vendemos tus datos ni los usamos para publicidad de terceros.
             </p>
-            <a 
-              href="mailto:stevenayal@proton.me"
+          </div>
+        </div>
+
+        <div className="space-y-6">
+          {SECTIONS.map((section) => (
+            <section
+              key={section.id}
+              id={section.id}
+              className="bg-white rounded-lg shadow-lg p-6 md:p-8"
+            >
+              <div className="flex items-start gap-4">
+                <div className="text-3xl shrink-0" aria-hidden="true">
+                  {section.icon}
+                </div>
+                <div className="flex-1">
+                  <h2 className="text-xl md:text-2xl font-bold text-brand-text mb-4">
+                    {section.title}
+                  </h2>
+                  {section.paragraphs.map((paragraph, index) => (
+                    <p
+                      key={index}
+                      className="text-brand-text mb-3 leading-relaxed"
+                    >
+                      {paragraph}
+                    </p>
+                  ))}
+                  {section.bullets && (
+                    <ul className="list-disc list-inside space-y-2 mt-2 text-brand-text">
+                      {section.bullets.map((bullet, index) => (
+                        <li key={index} className="leading-relaxed">
+                          {bullet}
+                        </li>
+                      ))}
+                    </ul>
+                  )}
+                </div>
+              </div>
+            </section>
+          ))}
+        </div>
+
+        <div className="bg-white rounded-lg shadow-lg p-8 my-8">
+          <div className="text-center">
+            <div className="text-4xl mb-4" aria-hidden="true">
+              📧
+            </div>
+            <h2 className="text-2xl font-bold text-brand-text mb-4">
+              Contacto
+            </h2>
+            <p className="text-lg text-brand-text mb-4">
+              Si tenés consultas sobre privacidad o querés ejercer tus derechos,
+              escribinos a:
+            </p>
+            <a
+              href={`mailto:${CONTACT_EMAIL}`}
               className="text-brand-primary hover:text-brand-primary-dark font-semibold text-lg transition-colors"
             >
-              stevenayal@proton.me
+              {CONTACT_EMAIL}
             </a>
           </div>
         </div>
 
         <div className="bg-brand-primary/10 rounded-lg p-6 text-center">
           <p className="text-brand-text font-medium">
-            Última actualización: 17 de Agosto de 2025
+            Última actualización: {LAST_UPDATED}
           </p>
         </div>
       </div>

--- a/apps/frontend/src/app/terms/page.tsx
+++ b/apps/frontend/src/app/terms/page.tsx
@@ -41,13 +41,15 @@ const SECTIONS: Section[] = [
     icon: '👤',
     title: '3. Registro y cuentas de usuario',
     paragraphs: [
-      'Algunas funciones requieren crear una cuenta. Podés registrarte con email y contraseña o mediante proveedores externos (Google o GitHub). La autenticación se gestiona a través de Supabase.',
-      'Sos responsable de mantener la confidencialidad de tus credenciales y de toda la actividad realizada desde tu cuenta. Debés notificarnos ante cualquier uso no autorizado.',
+      'Algunas funciones requieren crear una cuenta. Podés registrarte con email y contraseña o mediante proveedores externos. La autenticación puede apoyarse en servicios de terceros que la Plataforma habilite en cada momento.',
+      'Sos responsable de mantener la confidencialidad de tus credenciales y de toda la actividad realizada desde tu cuenta. Debés notificarnos ante cualquier uso no autorizado o sospechoso.',
     ],
     bullets: [
       'Debés tener al menos 16 años, o la edad mínima legal de tu país, para crear una cuenta.',
       'La información que proporciones (nombre, país, perfil profesional) debe ser veraz.',
-      'No está permitido crear cuentas múltiples para manipular rankings o evadir restricciones.',
+      'Podemos solicitar verificación adicional de email o identidad para proteger la seguridad de la comunidad y limitar el fraude.',
+      'No está permitido crear cuentas múltiples, automatizadas, fraudulentas o suplantadas para manipular rankings, evadir restricciones o abusar de la Plataforma.',
+      'Podemos limitar, revisar o suspender cuentas nuevas cuando detectemos actividad anómala, riesgo de abuso o incumplimiento de estos términos.',
     ],
   },
   {
@@ -56,12 +58,15 @@ const SECTIONS: Section[] = [
     title: '4. Uso aceptable',
     paragraphs: [
       'Te comprometés a utilizar la Plataforma de manera responsable, ética y conforme a la ley. El uso debe orientarse a fines legítimos de aprendizaje, testing y desarrollo profesional.',
+      'Podemos aplicar límites técnicos, rate limiting, bloqueo temporal o controles adicionales para proteger la estabilidad, la seguridad y la disponibilidad del servicio.',
     ],
     bullets: [
       'No realizar ataques, scraping masivo, pruebas de carga no autorizadas ni intentos de vulnerar la seguridad de la Plataforma o de otros usuarios.',
+      'No usar bots, scripts, automatizaciones, proxies, cuentas falsas o cualquier mecanismo para evadir restricciones, generar tráfico artificial o degradar el servicio.',
       'No publicar contenido ilegal, ofensivo, difamatorio, spam o que infrinja derechos de terceros.',
       'No usar las herramientas para dañar sistemas ajenos ni con fines maliciosos.',
       'No suplantar la identidad de otras personas u organizaciones.',
+      'No intentar descompilar, copiar, extraer, monitorear o reproducir el código, contenido, modelos o lógica interna de la Plataforma sin autorización escrita.',
     ],
   },
   {
@@ -70,7 +75,12 @@ const SECTIONS: Section[] = [
     title: '5. Contenido generado por usuarios',
     paragraphs: [
       'La Plataforma permite publicar contenido: hilos y respuestas en el foro, ideas, reportes de bugs, comentarios y datos de perfil. Conservás la titularidad de lo que publicás, pero nos otorgás una licencia no exclusiva y gratuita para mostrarlo y distribuirlo dentro de la Plataforma.',
-      'Sos el único responsable del contenido que publicás. Nos reservamos el derecho de moderar, editar o eliminar contenido que infrinja estos términos, sin previo aviso.',
+      'Sos el único responsable del contenido que publicás. Nos reservamos el derecho de moderar, ocultar, editar o eliminar contenido que infrinja estos términos, la ley o derechos de terceros, sin previo aviso cuando sea necesario.',
+      'Podemos conservar copias de contenido eliminado cuando resulte necesario para seguridad, auditoría, cumplimiento legal o resolución de disputas.',
+    ],
+    bullets: [
+      'No publiques contenido que sea ilegal, engañoso, invasivo de privacidad, spam, malware o que promueva fraude.',
+      'Si reclamás derechos de autor o marca, podés escribirnos para revisión y retiro del contenido presuntamente infractor.',
     ],
   },
   {
@@ -81,6 +91,7 @@ const SECTIONS: Section[] = [
       'Los simuladores (incluido el de ISTQB® CTFL, Git, Performance y otros) son herramientas de práctica con fines educativos. No constituyen certificaciones oficiales ni reemplazan a los exámenes acreditados por las entidades correspondientes.',
       '"ISTQB" es una marca registrada de International Software Testing Qualifications Board. AIQUAA no está afiliada, patrocinada ni avalada por ISTQB ni por ninguna entidad certificadora; sus contenidos de práctica son material independiente.',
       'El sistema de puntos de experiencia (XP), niveles, logros y rankings tiene fines lúdicos y motivacionales. Nos reservamos el derecho de ajustar las reglas, recalcular puntajes o anular resultados obtenidos de forma fraudulenta.',
+      'Cualquier intento de explotar fallos, automatizar respuestas, alterar resultados o manipular rankings puede generar suspensión inmediata.',
     ],
   },
   {
@@ -90,6 +101,7 @@ const SECTIONS: Section[] = [
     paragraphs: [
       'Las empresas pueden registrarse para crear procesos de selección, invitar candidatos y revisar resultados de evaluaciones. Al usar este módulo, las empresas se comprometen a tratar los datos de los candidatos conforme a la legislación aplicable de protección de datos y a utilizarlos únicamente para fines de reclutamiento legítimos.',
       'Los candidatos que aceptan participar en un proceso consienten que su empresa evaluadora acceda a los resultados asociados a dicho proceso.',
+      'La empresa es responsable de la exactitud de la información que carga, de su legitimidad para tratar esos datos y de no usar la Plataforma para discriminar, perfilar de manera ilegal o infringir normas laborales o de privacidad.',
     ],
   },
   {
@@ -99,6 +111,7 @@ const SECTIONS: Section[] = [
     paragraphs: [
       'Salvo que se indique lo contrario, el contenido educativo original de AIQUAA está licenciado bajo Creative Commons CC BY-NC-SA 4.0, permitiendo su uso no comercial con atribución y bajo la misma licencia.',
       'El código, la marca AIQUAA, el diseño y los logotipos son propiedad de AIQUAA. Las marcas, nombres y logotipos de terceros mencionados en la Plataforma pertenecen a sus respectivos titulares.',
+      'No está permitido extraer, reutilizar o republicar contenido protegido de forma masiva ni insinuar afiliación, patrocinio o respaldo que no exista.',
     ],
   },
   {
@@ -108,6 +121,7 @@ const SECTIONS: Section[] = [
     paragraphs: [
       'La Plataforma se apoya en proveedores externos para funcionar: Supabase (autenticación, base de datos y almacenamiento), Vercel y Railway (alojamiento) y Resend (envío de correos). El uso de la Plataforma implica que cierta información se procese a través de estos servicios conforme a sus propias políticas.',
       'No nos responsabilizamos por interrupciones, fallos o cambios en estos servicios de terceros.',
+      'Podemos incorporar o reemplazar proveedores equivalentes sin necesidad de modificar estos términos de forma inmediata, siempre que ello no cambie de manera sustancial el servicio principal.',
     ],
   },
   {
@@ -117,12 +131,30 @@ const SECTIONS: Section[] = [
     paragraphs: [
       'El tratamiento de tus datos personales se rige por nuestra Política de Privacidad, que forma parte integral de estos términos. Al usar la Plataforma, aceptás dicho tratamiento.',
       'Podés solicitar el acceso, la rectificación o la eliminación de tus datos escribiéndonos al correo de contacto.',
+      'Podemos conservar registros técnicos y de seguridad durante el tiempo necesario para prevenir fraude, investigar abusos y cumplir obligaciones legales.',
+    ],
+  },
+  {
+    id: 'seguridad',
+    icon: '🧯',
+    title: '11. Seguridad, abuso y controles',
+    paragraphs: [
+      'Podemos monitorear actividad, logs y patrones de uso para detectar abuso, fraude, spam, automatización no autorizada o ataques contra la Plataforma.',
+      'Cuando detectemos una amenaza real o probable, podremos limitar funciones, exigir verificación adicional, bloquear IPs, suspender cuentas o adoptar otras medidas razonables sin aviso previo.',
+    ],
+  },
+  {
+    id: 'indemnizacion',
+    icon: '🧾',
+    title: '12. Indemnización',
+    paragraphs: [
+      'En la medida permitida por la ley, aceptás indemnizar y mantener indemne a AIQUAA, sus titulares, colaboradores y proveedores frente a reclamos, daños, pérdidas, sanciones, multas, costos y honorarios razonables derivados de tu uso de la Plataforma, tu contenido o el incumplimiento de estos términos.',
     ],
   },
   {
     id: 'disponibilidad',
     icon: '⚙️',
-    title: '11. Disponibilidad y cambios en el servicio',
+    title: '13. Disponibilidad y cambios en el servicio',
     paragraphs: [
       'La Plataforma se ofrece "tal cual" y "según disponibilidad". Podemos modificar, suspender o discontinuar cualquier funcionalidad, herramienta o contenido en cualquier momento y sin previo aviso.',
       'No garantizamos que el servicio esté libre de errores ni que sea ininterrumpido.',
@@ -131,34 +163,39 @@ const SECTIONS: Section[] = [
   {
     id: 'responsabilidad',
     icon: '⚠️',
-    title: '12. Limitación de responsabilidad',
+    title: '14. Limitación de responsabilidad',
     paragraphs: [
       'AIQUAA no se responsabiliza por daños, pérdidas de datos o decisiones derivadas del uso de la Plataforma o de los resultados obtenidos con sus herramientas. Es tu responsabilidad verificar la precisión y adecuación de dichos resultados antes de aplicarlos en entornos reales.',
-      'En la máxima medida permitida por la ley, nuestra responsabilidad total frente a vos queda limitada, dado que el servicio se presta de forma gratuita.',
+      'En la máxima medida permitida por la ley, nuestra responsabilidad total frente a vos queda limitada. Si la ley aplicable no permite excluir ciertos daños, la exclusión operará hasta el máximo permitido.',
+      'No respondemos por daños indirectos, incidentales, especiales, punitivos, pérdida de ganancias, pérdida de datos o interrupciones causadas por terceros o por fuerza mayor.',
     ],
   },
   {
     id: 'terminacion',
     icon: '🚪',
-    title: '13. Suspensión y terminación de cuentas',
+    title: '15. Suspensión y terminación de cuentas',
     paragraphs: [
-      'Podemos suspender o eliminar tu cuenta si incumplís estos términos, realizás un uso fraudulento o ponés en riesgo a la comunidad o a la Plataforma. Podés solicitar la eliminación de tu cuenta en cualquier momento contactándonos.',
+      'Podemos suspender, restringir o eliminar tu cuenta si incumplís estos términos, realizás un uso fraudulento, comprometés la seguridad, abusás del servicio o ponés en riesgo a la comunidad o a la Plataforma.',
+      'En casos graves podemos actuar de inmediato. Cuando sea razonable, podrás pedir revisión contactándonos.',
+      'Podés solicitar la eliminación de tu cuenta en cualquier momento, sin perjuicio de las retenciones necesarias por ley, seguridad o auditoría.',
     ],
   },
   {
     id: 'modificaciones',
     icon: '🔄',
-    title: '14. Cambios en los términos',
+    title: '16. Cambios en los términos',
     paragraphs: [
       'Podemos actualizar estos Términos y Condiciones para reflejar cambios en la Plataforma o en la normativa aplicable. La fecha de última actualización figura al final de esta página. El uso continuado del servicio tras una modificación implica la aceptación de los nuevos términos.',
+      'Si el cambio es material, podremos notificarlo por medios razonables, incluyendo aviso en la Plataforma o por correo electrónico cuando corresponda.',
     ],
   },
   {
     id: 'ley',
     icon: '⚖️',
-    title: '15. Ley aplicable y jurisdicción',
+    title: '17. Ley aplicable y jurisdicción',
     paragraphs: [
       'Estos términos se rigen por las leyes de la República del Paraguay. Cualquier controversia se someterá a los tribunales competentes de dicha jurisdicción, sin perjuicio de los derechos que la normativa de protección al consumidor reconozca al usuario en su país de residencia.',
+      'Queda prohibido usar la Plataforma en violación de leyes de sanciones, exportación o controles comerciales aplicables a tu jurisdicción.',
     ],
   },
 ];
@@ -235,7 +272,9 @@ export default function TermsPage() {
             <div className="text-4xl mb-4" aria-hidden="true">
               📧
             </div>
-            <h2 className="text-2xl font-bold text-brand-text mb-4">Contacto</h2>
+            <h2 className="text-2xl font-bold text-brand-text mb-4">
+              Contacto
+            </h2>
             <p className="text-lg text-brand-text mb-4">
               Si tenés dudas sobre estos términos, o querés ejercer tus derechos
               sobre tus datos, escribinos a:


### PR DESCRIPTION
## Summary\n- Rewrite privacy policy with stronger global coverage\n- Harden terms against abuse, fake accounts, scraping, and fraud\n- Align legal pages with AIQUAA's current product surface\n\n## Verification\n- pnpm --filter @aiquaa/frontend lint\n- pnpm --filter @aiquaa/frontend type-check\n- git pre-push hooks passed