### PR TITLE
feat(frontend): exam history with correct display and filters

### DIFF
--- a/apps/frontend/src/actions/exams.ts
+++ b/apps/frontend/src/actions/exams.ts
@@ -143,25 +143,40 @@ export async function getXpRankingAction(page = 1, limit = 20) {
   };
 }
 
-export async function getExamResultsAction() {
+export async function getExamResultsAction(opts?: {
+  examType?: string;
+  limit?: number;
+  offset?: number;
+}) {
   const supabase = createClient();
   const {
     data: { user },
     error: userError,
   } = await supabase.auth.getUser();
-  if (userError || !user) return { error: 'No autenticado', data: null };
+  if (userError || !user)
+    return { error: 'No autenticado', data: null, total: 0 };
 
-  const { data, error } = await supabase
+  const limit = opts?.limit ?? 20;
+  const offset = opts?.offset ?? 0;
+
+  let query = supabase
     .from('exam_results')
     .select(
-      'id, exam_type, exam_mode, score, total_questions, max_possible_score, passing_score, passed, percentage, time_spent, model, language, created_at'
+      'id, exam_type, exam_mode, score, total_questions, max_possible_score, passing_score, passed, percentage, time_spent, model, language, created_at',
+      { count: 'exact' }
     )
-    .eq('user_id', user.id)
-    .order('created_at', { ascending: false })
-    .limit(20);
+    .eq('user_id', user.id);
 
-  if (error) return { error: error.message, data: null };
-  return { data };
+  if (opts?.examType) {
+    query = query.eq('exam_type', opts.examType);
+  }
+
+  const { data, error, count } = await query
+    .order('created_at', { ascending: false })
+    .range(offset, offset + limit - 1);
+
+  if (error) return { error: error.message, data: null, total: 0 };
+  return { data, total: count ?? 0 };
 }
 
 type LearningObjectiveRow = {

--- a/apps/frontend/src/app/dashboard/page.tsx
+++ b/apps/frontend/src/app/dashboard/page.tsx
@@ -6,6 +6,7 @@ import { useTheme } from '@/contexts/ThemeContext';
 import { useSupabaseAuth } from '@/contexts/SupabaseAuthContext';
 import { getExamResultsAction, getMyXpProfileAction } from '@/actions/exams';
 import { xpForLevel, PY_TIMEZONE } from '@/lib/xp';
+import { EXAM_META, formatExamScore, type ExamType } from '@/lib/exams';
 
 interface ExamResult {
   id: string;
@@ -13,6 +14,7 @@ interface ExamResult {
   exam_mode: string;
   score: number;
   total_questions: number;
+  max_possible_score?: number | null;
   passed: boolean;
   percentage: number;
   time_spent: number | null;
@@ -28,36 +30,6 @@ interface XpProfile {
   achievementCount: number;
   position: number;
 }
-
-const LAB_INFO = {
-  git: { emoji: '🌿', label: 'Examen GIT', href: '/labs/git' },
-  istqb: { emoji: '📋', label: 'ISTQB CTFL v4.0', href: '/labs/istqb' },
-  performance: {
-    emoji: '⚡',
-    label: 'Performance Testing',
-    href: '/labs/performance',
-  },
-  'api-testing-fundamentals': {
-    emoji: '🌐',
-    label: 'API Testing — Fundamentos',
-    href: '/assessments/api-testing-fundamentals',
-  },
-  'api-banking': {
-    emoji: '🏦',
-    label: 'API Banking — Challenge práctico',
-    href: '/assessments/api-banking',
-  },
-  'database-fundamentals': {
-    emoji: '🗄️',
-    label: 'Bases de Datos — Fundamentos',
-    href: '/assessments/database-fundamentals',
-  },
-  'database-practice': {
-    emoji: '🧮',
-    label: 'Bases de Datos — Práctica SQL',
-    href: '/assessments/database-practice',
-  },
-} as const;
 
 export default function DashboardPage() {
   const { isDarkMode } = useTheme();
@@ -99,7 +71,7 @@ export default function DashboardPage() {
       .filter((r) => r.passed && r.exam_mode === 'exam')
       .map((r) => r.exam_type)
   );
-  const allTypes = [
+  const allTypes: ExamType[] = [
     'git',
     'istqb',
     'performance',
@@ -107,7 +79,7 @@ export default function DashboardPage() {
     'api-banking',
     'database-fundamentals',
     'database-practice',
-  ] as const;
+  ];
   const recommended = allTypes.find((t) => !passedTypes.has(t)) ?? null;
   const allPassed = allTypes.every((t) => passedTypes.has(t));
 
@@ -326,7 +298,8 @@ export default function DashboardPage() {
                   <p
                     className={`font-bold text-base ${isDarkMode ? 'text-amber-200' : 'text-amber-900'}`}
                   >
-                    {LAB_INFO[recommended].emoji} {LAB_INFO[recommended].label}
+                    {EXAM_META[recommended].emoji}{' '}
+                    {EXAM_META[recommended].label}
                   </p>
                   <p
                     className={`text-sm mt-0.5 ${isDarkMode ? 'text-amber-400/80' : 'text-amber-700'}`}
@@ -335,7 +308,7 @@ export default function DashboardPage() {
                   </p>
                 </div>
                 <Link
-                  href={LAB_INFO[recommended].href}
+                  href={EXAM_META[recommended].href}
                   className="shrink-0 px-4 py-2 bg-amber-600 hover:bg-amber-700 text-white text-sm font-semibold rounded-lg transition-colors"
                 >
                   Ir al lab →
@@ -423,7 +396,7 @@ export default function DashboardPage() {
               className={`rounded-2xl overflow-hidden ${isDarkMode ? 'bg-slate-800 border border-slate-700' : 'bg-white border border-gray-200 shadow-sm'}`}
             >
               {last3.map((result, i) => {
-                const lab = LAB_INFO[result.exam_type as keyof typeof LAB_INFO];
+                const lab = EXAM_META[result.exam_type as ExamType];
                 const date = new Date(result.created_at).toLocaleDateString(
                   'es-PY',
                   {
@@ -459,7 +432,7 @@ export default function DashboardPage() {
                       <p
                         className={`text-sm font-bold ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
                       >
-                        {result.score}/{result.total_questions}
+                        {formatExamScore(result)}
                       </p>
                       <p
                         className={`text-xs ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}

--- a/apps/frontend/src/app/perfil/page.tsx
+++ b/apps/frontend/src/app/perfil/page.tsx
@@ -12,21 +12,22 @@ import {
 import { getExamResultsAction, getMyXpProfileAction } from '@/actions/exams';
 import Avatar from '@/components/ui/Avatar';
 import { xpForLevel, PY_TIMEZONE } from '@/lib/xp';
+import {
+  EXAM_META,
+  EXAM_TYPES,
+  formatExamScore,
+  type ExamType,
+} from '@/lib/exams';
+
+const EXAM_PAGE_SIZE = 20;
 
 interface ExamResultRow {
   id: string;
-  exam_type:
-    | 'git'
-    | 'istqb'
-    | 'performance'
-    | 'test-app'
-    | 'api-testing-fundamentals'
-    | 'api-banking'
-    | 'database-fundamentals'
-    | 'database-practice';
+  exam_type: ExamType;
   exam_mode: 'exam' | 'training';
   score: number;
   total_questions: number;
+  max_possible_score?: number | null;
   passing_score: number;
   passed: boolean;
   percentage: number;
@@ -35,23 +36,6 @@ interface ExamResultRow {
   language?: string;
   created_at: string;
 }
-
-const EXAM_DISPLAY: Record<string, { emoji: string; label: string }> = {
-  git: { emoji: '🌿', label: 'GIT' },
-  istqb: { emoji: '📋', label: 'ISTQB CTFL' },
-  performance: { emoji: '⚡', label: 'Performance' },
-  'test-app': { emoji: '🧪', label: 'Test App' },
-  'api-testing-fundamentals': {
-    emoji: '🌐',
-    label: 'API Testing Fundamentals',
-  },
-  'api-banking': { emoji: '🏦', label: 'API Banking Challenge' },
-  'database-fundamentals': {
-    emoji: '🗄️',
-    label: 'Bases de Datos — Fundamentos',
-  },
-  'database-practice': { emoji: '🧮', label: 'Bases de Datos — Práctica SQL' },
-};
 
 const formatTime = (s: number) => {
   const m = Math.floor(s / 60);
@@ -93,6 +77,9 @@ export default function PerfilPage() {
   const [previewUrl, setPreviewUrl] = useState<string | null>(null);
   const [examResults, setExamResults] = useState<ExamResultRow[]>([]);
   const [examResultsLoading, setExamResultsLoading] = useState(true);
+  const [examTotal, setExamTotal] = useState(0);
+  const [examFilter, setExamFilter] = useState<ExamType | 'all'>('all');
+  const [examLoadingMore, setExamLoadingMore] = useState(false);
 
   const [formData, setFormData] = useState({
     full_name: '',
@@ -132,13 +119,33 @@ export default function PerfilPage() {
     }
   }, [user, isLoading, initialized, router]);
 
+  // Carga inicial / al cambiar el filtro: reemplaza la lista desde offset 0.
   useEffect(() => {
     if (!user) return;
-    getExamResultsAction().then(({ data }) => {
+    setExamResultsLoading(true);
+    getExamResultsAction({
+      examType: examFilter === 'all' ? undefined : examFilter,
+      limit: EXAM_PAGE_SIZE,
+      offset: 0,
+    }).then(({ data, total }) => {
       setExamResults((data as ExamResultRow[]) || []);
+      setExamTotal(total ?? 0);
       setExamResultsLoading(false);
     });
-  }, [user]);
+  }, [user, examFilter]);
+
+  const loadMoreExams = () => {
+    setExamLoadingMore(true);
+    getExamResultsAction({
+      examType: examFilter === 'all' ? undefined : examFilter,
+      limit: EXAM_PAGE_SIZE,
+      offset: examResults.length,
+    }).then(({ data, total }) => {
+      setExamResults((prev) => [...prev, ...((data as ExamResultRow[]) || [])]);
+      setExamTotal(total ?? 0);
+      setExamLoadingMore(false);
+    });
+  };
 
   useEffect(() => {
     if (!user) return;
@@ -812,6 +819,38 @@ export default function PerfilPage() {
             📊 Historial de exámenes
           </h2>
 
+          {/* Filtro por tipo de examen */}
+          {(examResults.length > 0 || examFilter !== 'all') && (
+            <div className="flex flex-wrap gap-2 mb-4">
+              {(['all', ...EXAM_TYPES] as const).map((t) => {
+                const selected = examFilter === t;
+                const label = t === 'all' ? '🗂️ Todos' : EXAM_META[t].emoji;
+                const text =
+                  t === 'all'
+                    ? 'Todos'
+                    : `${EXAM_META[t].emoji} ${EXAM_META[t].label}`;
+                return (
+                  <button
+                    key={t}
+                    type="button"
+                    onClick={() => setExamFilter(t)}
+                    className={`px-3 py-1.5 rounded-full text-xs font-medium border transition-colors ${
+                      selected
+                        ? 'border-indigo-500 bg-indigo-600 text-white'
+                        : isDarkMode
+                          ? 'border-slate-600 bg-slate-700 text-slate-300 hover:border-indigo-400'
+                          : 'border-gray-300 bg-white text-gray-700 hover:border-indigo-400'
+                    }`}
+                    aria-label={t === 'all' ? 'Todos' : EXAM_META[t].label}
+                    title={t === 'all' ? 'Todos' : EXAM_META[t].label}
+                  >
+                    {t === 'all' ? label : text}
+                  </button>
+                );
+              })}
+            </div>
+          )}
+
           {examResultsLoading ? (
             <div className="flex justify-center py-6">
               <div className="animate-spin rounded-full h-6 w-6 border-t-2 border-indigo-500" />
@@ -824,109 +863,115 @@ export default function PerfilPage() {
               <p
                 className={`text-sm ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}
               >
-                Todavía no rendiste ningún examen.
+                {examFilter === 'all'
+                  ? 'Todavía no rendiste ningún examen.'
+                  : 'No tenés intentos de este tipo de examen todavía.'}
               </p>
-              <div className="flex justify-center gap-3 mt-4 flex-wrap">
-                <a
-                  href="/labs/istqb"
-                  className="text-xs text-indigo-400 hover:underline"
-                >
-                  📋 ISTQB CTFL
-                </a>
-                <span
-                  className={isDarkMode ? 'text-slate-600' : 'text-gray-300'}
-                >
-                  ·
-                </span>
-                <a
-                  href="/labs/git"
-                  className="text-xs text-indigo-400 hover:underline"
-                >
-                  🌿 GIT
-                </a>
-                <span
-                  className={isDarkMode ? 'text-slate-600' : 'text-gray-300'}
-                >
-                  ·
-                </span>
-                <a
-                  href="/labs/performance"
-                  className="text-xs text-indigo-400 hover:underline"
-                >
-                  ⚡ Performance
-                </a>
+              <div className="flex justify-center gap-x-3 gap-y-2 mt-4 flex-wrap">
+                {EXAM_TYPES.map((t) => (
+                  <a
+                    key={t}
+                    href={EXAM_META[t].href}
+                    className="text-xs text-indigo-400 hover:underline"
+                  >
+                    {EXAM_META[t].emoji} {EXAM_META[t].label}
+                  </a>
+                ))}
               </div>
             </div>
           ) : (
-            <div className="space-y-3">
-              {examResults.map((r) => (
-                <div
-                  key={r.id}
-                  className={`flex items-center justify-between px-4 py-3 rounded-lg ${isDarkMode ? 'bg-slate-700/50' : 'bg-gray-50'}`}
-                >
-                  <div className="flex items-center gap-3 min-w-0">
-                    <span className="text-lg shrink-0">
-                      {EXAM_DISPLAY[r.exam_type]?.emoji ?? '📋'}
-                    </span>
-                    <div className="min-w-0">
-                      <p
-                        className={`text-sm font-medium ${isDarkMode ? 'text-slate-200' : 'text-gray-800'}`}
-                      >
-                        {EXAM_DISPLAY[r.exam_type]?.label ?? r.exam_type}
-                        {r.exam_type === 'istqb' && r.model
-                          ? ` · Modelo ${r.model}`
-                          : ''}
-                        {' · '}
-                        <span
-                          className={`text-xs ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}
+            <>
+              <div className="space-y-3">
+                {examResults.map((r) => (
+                  <div
+                    key={r.id}
+                    className={`flex items-center justify-between px-4 py-3 rounded-lg ${isDarkMode ? 'bg-slate-700/50' : 'bg-gray-50'}`}
+                  >
+                    <div className="flex items-center gap-3 min-w-0">
+                      <span className="text-lg shrink-0">
+                        {EXAM_META[r.exam_type]?.emoji ?? '📋'}
+                      </span>
+                      <div className="min-w-0">
+                        <p
+                          className={`text-sm font-medium ${isDarkMode ? 'text-slate-200' : 'text-gray-800'}`}
                         >
-                          {r.exam_mode === 'exam' ? 'Examen' : 'Entrenamiento'}
-                        </span>
-                      </p>
-                      <p
-                        className={`text-xs ${isDarkMode ? 'text-slate-500' : 'text-gray-400'}`}
+                          {EXAM_META[r.exam_type]?.label ?? r.exam_type}
+                          {r.exam_type === 'istqb' && r.model
+                            ? ` · Modelo ${r.model}`
+                            : ''}
+                          {' · '}
+                          <span
+                            className={`text-xs ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}
+                          >
+                            {r.exam_mode === 'exam'
+                              ? 'Examen'
+                              : 'Entrenamiento'}
+                          </span>
+                        </p>
+                        <p
+                          className={`text-xs ${isDarkMode ? 'text-slate-500' : 'text-gray-400'}`}
+                        >
+                          {new Date(r.created_at).toLocaleDateString('es-PY', {
+                            day: '2-digit',
+                            month: 'short',
+                            year: 'numeric',
+                            timeZone: PY_TIMEZONE,
+                          })}
+                          {' · '}
+                          {formatTime(r.time_spent)}
+                        </p>
+                      </div>
+                    </div>
+                    <div className="flex items-center gap-3 shrink-0">
+                      <div className="text-right">
+                        <p
+                          className={`text-sm font-bold ${isDarkMode ? 'text-slate-200' : 'text-gray-800'}`}
+                        >
+                          {formatExamScore(r)}
+                        </p>
+                        <p
+                          className={`text-xs ${isDarkMode ? 'text-slate-500' : 'text-gray-400'}`}
+                        >
+                          {r.percentage.toFixed(0)}%
+                        </p>
+                      </div>
+                      <span
+                        className={`px-2 py-1 rounded-full text-xs font-semibold ${
+                          r.passed
+                            ? isDarkMode
+                              ? 'bg-emerald-900/40 text-emerald-300'
+                              : 'bg-emerald-100 text-emerald-700'
+                            : isDarkMode
+                              ? 'bg-red-900/40 text-red-300'
+                              : 'bg-red-100 text-red-700'
+                        }`}
                       >
-                        {new Date(r.created_at).toLocaleDateString('es-PY', {
-                          day: '2-digit',
-                          month: 'short',
-                          year: 'numeric',
-                          timeZone: PY_TIMEZONE,
-                        })}
-                        {' · '}
-                        {formatTime(r.time_spent)}
-                      </p>
+                        {r.passed ? '✓ Aprobado' : '✗ No aprobado'}
+                      </span>
                     </div>
                   </div>
-                  <div className="flex items-center gap-3 shrink-0">
-                    <div className="text-right">
-                      <p
-                        className={`text-sm font-bold ${isDarkMode ? 'text-slate-200' : 'text-gray-800'}`}
-                      >
-                        {r.score}/{r.total_questions}
-                      </p>
-                      <p
-                        className={`text-xs ${isDarkMode ? 'text-slate-500' : 'text-gray-400'}`}
-                      >
-                        {r.percentage.toFixed(0)}%
-                      </p>
-                    </div>
-                    <span
-                      className={`px-2 py-1 rounded-full text-xs font-semibold ${
-                        r.passed
-                          ? isDarkMode
-                            ? 'bg-emerald-900/40 text-emerald-300'
-                            : 'bg-emerald-100 text-emerald-700'
-                          : isDarkMode
-                            ? 'bg-red-900/40 text-red-300'
-                            : 'bg-red-100 text-red-700'
-                      }`}
-                    >
-                      {r.passed ? '✓ Aprobado' : '✗ No aprobado'}
-                    </span>
-                  </div>
+                ))}
+              </div>
+
+              {examResults.length < examTotal && (
+                <div className="flex justify-center mt-4">
+                  <button
+                    type="button"
+                    onClick={loadMoreExams}
+                    disabled={examLoadingMore}
+                    className={`px-4 py-2 text-xs font-semibold rounded-lg border transition-colors disabled:opacity-50 ${
+                      isDarkMode
+                        ? 'border-slate-600 text-slate-300 hover:bg-slate-700'
+                        : 'border-gray-300 text-gray-700 hover:bg-gray-50'
+                    }`}
+                  >
+                    {examLoadingMore
+                      ? 'Cargando...'
+                      : `Ver más (${examTotal - examResults.length})`}
+                  </button>
                 </div>
-              ))}
-            </div>
+              )}
+            </>
           )}
         </div>
       </div>

--- a/apps/frontend/src/lib/exams.ts
+++ b/apps/frontend/src/lib/exams.ts
@@ -1,0 +1,87 @@
+// Metadata y helpers de display compartidos por el historial de exámenes
+// (perfil y dashboard). Centraliza emojis/labels/href y el formato de puntaje,
+// que difiere entre exámenes por preguntas y assessments por puntos.
+
+export type ExamType =
+  | 'git'
+  | 'istqb'
+  | 'performance'
+  | 'test-app'
+  | 'api-testing-fundamentals'
+  | 'api-banking'
+  | 'database-fundamentals'
+  | 'database-practice';
+
+export interface ExamMeta {
+  emoji: string;
+  label: string;
+  href: string;
+}
+
+export const EXAM_META: Record<ExamType, ExamMeta> = {
+  git: { emoji: '🌿', label: 'Examen GIT', href: '/labs/git' },
+  istqb: { emoji: '📋', label: 'ISTQB CTFL v4.0', href: '/labs/istqb' },
+  performance: {
+    emoji: '⚡',
+    label: 'Performance Testing',
+    href: '/labs/performance',
+  },
+  'test-app': {
+    emoji: '🧪',
+    label: 'Test App',
+    href: '/labs/test-app',
+  },
+  'api-testing-fundamentals': {
+    emoji: '🌐',
+    label: 'API Testing — Fundamentos',
+    href: '/assessments/api-testing-fundamentals',
+  },
+  'api-banking': {
+    emoji: '🏦',
+    label: 'API Banking — Challenge práctico',
+    href: '/assessments/api-banking',
+  },
+  'database-fundamentals': {
+    emoji: '🗄️',
+    label: 'Bases de Datos — Fundamentos',
+    href: '/assessments/database-fundamentals',
+  },
+  'database-practice': {
+    emoji: '🧮',
+    label: 'Bases de Datos — Práctica SQL',
+    href: '/assessments/database-practice',
+  },
+};
+
+export const EXAM_TYPES = Object.keys(EXAM_META) as ExamType[];
+
+// Tipos cuyo `score` representa puntos (no respuestas correctas); el total real
+// vive en `max_possible_score`, no en `total_questions`.
+export const POINTS_BASED_TYPES = new Set<ExamType>([
+  'api-testing-fundamentals',
+  'api-banking',
+  'database-fundamentals',
+  'database-practice',
+]);
+
+export interface ExamScoreFields {
+  exam_type: string;
+  score: number;
+  total_questions: number;
+  max_possible_score?: number | null;
+}
+
+/**
+ * Formatea el puntaje de un examen según su tipo:
+ * - Assessments por puntos: `${score}/${max_possible_score} pts`.
+ * - Exámenes por preguntas (y test-app): `${score}/${total_questions}`.
+ */
+export function formatExamScore(r: ExamScoreFields): string {
+  if (
+    POINTS_BASED_TYPES.has(r.exam_type as ExamType) &&
+    r.max_possible_score != null
+  ) {
+    return `${r.score}/${r.max_possible_score} pts`;
+  }
+  return `${r.score}/${r.total_questions}`;
+}


### PR DESCRIPTION
## Summary

- **Bug root cause:** The `exam_results` table already had data for all 8 exam types, but the score display was designed only for quiz-based exams (git/istqb/performance) where `score = correct answers` and `total_questions = # questions`. Points-based types (api-testing-fundamentals, api-banking, database-fundamentals, database-practice) store `score = points` and `total_questions = # answers/bugs`, with the real total in `max_possible_score` — causing the UI to render nonsense like "85/12".
- **New shared helper** `apps/frontend/src/lib/exams.ts`: `EXAM_META`, `EXAM_TYPES`, `ExamType`, `POINTS_BASED_TYPES`, and `formatExamScore()` that renders `score/max pts` for points-based exams and `correct/total` for quiz-based ones.
- **`getExamResultsAction`** extended with `{examType?, limit?, offset?}` opts and returns `total` count — fully backward-compatible.
- **`/perfil`**: uses `formatExamScore`, adds exam type filter chips, "Ver más" pagination, and expands the empty-state links to all 8 exam types.
- **`/dashboard`**: reuses `EXAM_META` and `formatExamScore` for the last-3 exams display.

## Test plan

- [ ] Log in with an account that has api-banking or database assessment attempts and verify score shows `XX/100 pts` instead of `85/12`
- [ ] Verify git/istqb/performance/test-app still show `correct/total` format
- [ ] Test filter chips in `/perfil` — each chip filters and resets pagination
- [ ] Test "Ver más" button — appends next page and disappears when all loaded
- [ ] Check `/dashboard` last-3 exams render correctly for all types
- [ ] Verify empty state in `/perfil` shows links to all 8 exam types

🤖 Generated with [Claude Code](https://claude.com/claude-code)