### PR TITLE
[codex] Fix Vercel build after git-practico metadata merge

### DIFF
--- a/apps/frontend/src/app/dashboard/page.tsx
+++ b/apps/frontend/src/app/dashboard/page.tsx
@@ -31,41 +31,6 @@ interface XpProfile {
   position: number;
 }
 
-const LAB_INFO = {
-  git: { emoji: '🌿', label: 'Examen GIT', href: '/labs/git' },
-  'git-practico': {
-    emoji: '🐙',
-    label: 'Git — Prueba Práctica',
-    href: '/labs/git-practico',
-  },
-  istqb: { emoji: '📋', label: 'ISTQB CTFL v4.0', href: '/labs/istqb' },
-  performance: {
-    emoji: '⚡',
-    label: 'Performance Testing',
-    href: '/labs/performance',
-  },
-  'api-testing-fundamentals': {
-    emoji: '🌐',
-    label: 'API Testing — Fundamentos',
-    href: '/assessments/api-testing-fundamentals',
-  },
-  'api-banking': {
-    emoji: '🏦',
-    label: 'API Banking — Challenge práctico',
-    href: '/assessments/api-banking',
-  },
-  'database-fundamentals': {
-    emoji: '🗄️',
-    label: 'Bases de Datos — Fundamentos',
-    href: '/assessments/database-fundamentals',
-  },
-  'database-practice': {
-    emoji: '🧮',
-    label: 'Bases de Datos — Práctica SQL',
-    href: '/assessments/database-practice',
-  },
-} as const;
-
 export default function DashboardPage() {
   const { isDarkMode } = useTheme();
   const { user } = useSupabaseAuth();

--- a/apps/frontend/src/app/perfil/page.tsx
+++ b/apps/frontend/src/app/perfil/page.tsx
@@ -46,24 +46,6 @@ interface ExamResultRow {
   created_at: string;
 }
 
-const EXAM_DISPLAY: Record<string, { emoji: string; label: string }> = {
-  git: { emoji: '🌿', label: 'GIT' },
-  'git-practico': { emoji: '🐙', label: 'GitHub Práctico' },
-  istqb: { emoji: '📋', label: 'ISTQB CTFL' },
-  performance: { emoji: '⚡', label: 'Performance' },
-  'test-app': { emoji: '🧪', label: 'Test App' },
-  'api-testing-fundamentals': {
-    emoji: '🌐',
-    label: 'API Testing Fundamentals',
-  },
-  'api-banking': { emoji: '🏦', label: 'API Banking Challenge' },
-  'database-fundamentals': {
-    emoji: '🗄️',
-    label: 'Bases de Datos — Fundamentos',
-  },
-  'database-practice': { emoji: '🧮', label: 'Bases de Datos — Práctica SQL' },
-};
-
 const formatTime = (s: number) => {
   const m = Math.floor(s / 60);
   const sec = s % 60;

--- a/apps/frontend/src/lib/exams.ts
+++ b/apps/frontend/src/lib/exams.ts
@@ -4,6 +4,7 @@
 
 export type ExamType =
   | 'git'
+  | 'git-practico'
   | 'istqb'
   | 'performance'
   | 'test-app'
@@ -20,6 +21,11 @@ export interface ExamMeta {
 
 export const EXAM_META: Record<ExamType, ExamMeta> = {
   git: { emoji: '🌿', label: 'Examen GIT', href: '/labs/git' },
+  'git-practico': {
+    emoji: '🐙',
+    label: 'Git — Prueba práctica',
+    href: '/labs/git-practico',
+  },
   istqb: { emoji: '📋', label: 'ISTQB CTFL v4.0', href: '/labs/istqb' },
   performance: {
     emoji: '⚡',


### PR DESCRIPTION
## Summary
- Remove obsolete dashboard `LAB_INFO` metadata that caused the Vercel production build to fail with `noUnusedLocals`.
- Add `git-practico` to the shared `ExamType`/`EXAM_META` catalog used by dashboard and profile.
- Remove the unused profile `EXAM_DISPLAY` map now covered by shared exam metadata.

## Root Cause
PR #182 migrated dashboard/profile display to shared `EXAM_META`, but left stale local metadata and did not add `git-practico` to the shared typed catalog. Vercel failed on the first TypeScript error during `next build`.

## Validation
- `pnpm --filter @aiquaa/frontend type-check`
- `NEXT_PUBLIC_API_URL=https://example.com NEXT_PUBLIC_BACKEND_URL=https://example.com pnpm build:vercel`
- pre-push hook: `pnpm --filter @aiquaa/frontend type-check`