### PR TITLE
[codex] Fix API challenge attempt creation fallback

### DIFF
--- a/apps/frontend/src/app/api/assessments/[attemptId]/submit/route.ts
+++ b/apps/frontend/src/app/api/assessments/[attemptId]/submit/route.ts
@@ -16,6 +16,7 @@ import {
   ensureXpRules,
   grantGamificationXpEvent,
 } from '@/lib/gamification/grant-xp';
+import { selectAttemptForSubmitWithApiTargetFallback } from '../../_lib/apiTargetPersistence';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -31,13 +32,10 @@ export async function POST(
   const supabase = createAdminClient();
 
   // Fetch attempt
-  const { data: attempt } = await supabase
-    .from('qac_attempts')
-    .select(
-      'id, status, started_at, aiquaa_user_id, candidate_name, candidate_email, process_code, api_target'
-    )
-    .eq('id', attemptId)
-    .single();
+  const { data: attempt } = await selectAttemptForSubmitWithApiTargetFallback(
+    supabase,
+    attemptId
+  );
 
   if (!attempt)
     return NextResponse.json({ error: 'Attempt not found' }, { status: 404 });

--- a/apps/frontend/src/app/api/assessments/__tests__/apiTargetPersistence.test.ts
+++ b/apps/frontend/src/app/api/assessments/__tests__/apiTargetPersistence.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from 'vitest';
+import {
+  insertAttemptWithApiTargetFallback,
+  isMissingApiTargetColumnError,
+  selectAttemptForSubmitWithApiTargetFallback,
+} from '../_lib/apiTargetPersistence';
+
+const missingApiTargetError = {
+  code: 'PGRST204',
+  message:
+    "Could not find the 'api_target' column of 'qac_attempts' in the schema cache",
+};
+
+describe('apiTargetPersistence', () => {
+  it('detects missing api_target column errors from Supabase', () => {
+    expect(isMissingApiTargetColumnError(missingApiTargetError)).toBe(true);
+    expect(
+      isMissingApiTargetColumnError({
+        code: '42703',
+        message: 'column qac_attempts.api_target does not exist',
+      })
+    ).toBe(true);
+    expect(
+      isMissingApiTargetColumnError({
+        code: 'PGRST204',
+        message: "Could not find the 'other_column' column",
+      })
+    ).toBe(false);
+  });
+
+  it('retries attempt creation without api_target when the deployed schema is stale', async () => {
+    const insertedPayloads: Record<string, unknown>[] = [];
+    const responses = [
+      { data: null, error: missingApiTargetError },
+      { data: { id: 123 }, error: null },
+    ];
+    const supabase = {
+      from: () => ({
+        insert: (payload: Record<string, unknown>) => {
+          insertedPayloads.push(payload);
+          return {
+            select: () => ({
+              single: async () => responses.shift(),
+            }),
+          };
+        },
+      }),
+    } as any;
+
+    const result = await insertAttemptWithApiTargetFallback(supabase, {
+      catalog_id: 1,
+      candidate_name: 'Ada QA',
+      api_target: 'nasa',
+      status: 'in_progress',
+    });
+
+    expect(result.data).toEqual({ id: 123 });
+    expect(insertedPayloads).toHaveLength(2);
+    expect(insertedPayloads[0].api_target).toBe('nasa');
+    expect(insertedPayloads[1]).not.toHaveProperty('api_target');
+  });
+
+  it('does not retry attempt creation for unrelated insert errors', async () => {
+    const insertedPayloads: Record<string, unknown>[] = [];
+    const supabase = {
+      from: () => ({
+        insert: (payload: Record<string, unknown>) => {
+          insertedPayloads.push(payload);
+          return {
+            select: () => ({
+              single: async () => ({
+                data: null,
+                error: { code: '23503', message: 'foreign key violation' },
+              }),
+            }),
+          };
+        },
+      }),
+    } as any;
+
+    const result = await insertAttemptWithApiTargetFallback(supabase, {
+      catalog_id: 999,
+      candidate_name: 'Ada QA',
+      api_target: 'rick-and-morty',
+    });
+
+    expect(result.error?.code).toBe('23503');
+    expect(insertedPayloads).toHaveLength(1);
+  });
+
+  it('retries submit attempt lookup without api_target for legacy schemas', async () => {
+    const selectedColumns: string[] = [];
+    const responses = [
+      { data: null, error: missingApiTargetError },
+      {
+        data: {
+          id: 123,
+          status: 'in_progress',
+          process_code: null,
+        },
+        error: null,
+      },
+    ];
+    const supabase = {
+      from: () => ({
+        select: (columns: string) => {
+          selectedColumns.push(columns);
+          return {
+            eq: () => ({
+              single: async () => responses.shift(),
+            }),
+          };
+        },
+      }),
+    } as any;
+
+    const result = await selectAttemptForSubmitWithApiTargetFallback(
+      supabase,
+      123
+    );
+
+    expect(result.data?.id).toBe(123);
+    expect(selectedColumns).toHaveLength(2);
+    expect(selectedColumns[0]).toContain('api_target');
+    expect(selectedColumns[1]).not.toContain('api_target');
+  });
+});

--- a/apps/frontend/src/app/api/assessments/_lib/apiTargetPersistence.ts
+++ b/apps/frontend/src/app/api/assessments/_lib/apiTargetPersistence.ts
@@ -1,0 +1,78 @@
+const API_TARGET_COLUMN = 'api_target';
+
+type SupabaseLike = {
+  from: (table: string) => any;
+};
+
+type SupabaseErrorLike = {
+  code?: string;
+  message?: string;
+  details?: string;
+  hint?: string;
+};
+
+const ATTEMPT_SELECT_WITH_API_TARGET =
+  'id, status, started_at, aiquaa_user_id, candidate_name, candidate_email, process_code, api_target';
+
+const ATTEMPT_SELECT_LEGACY =
+  'id, status, started_at, aiquaa_user_id, candidate_name, candidate_email, process_code';
+
+export function isMissingApiTargetColumnError(
+  error: SupabaseErrorLike | null | undefined
+) {
+  if (!error) return false;
+
+  const text = [error.message, error.details, error.hint]
+    .filter(Boolean)
+    .join(' ')
+    .toLowerCase();
+
+  return (
+    (error.code === '42703' || error.code === 'PGRST204') &&
+    text.includes(API_TARGET_COLUMN)
+  );
+}
+
+export async function insertAttemptWithApiTargetFallback(
+  supabase: SupabaseLike,
+  payload: Record<string, unknown>
+) {
+  const result = await supabase
+    .from('qac_attempts')
+    .insert(payload)
+    .select('id')
+    .single();
+
+  if (!isMissingApiTargetColumnError(result.error)) {
+    return result;
+  }
+
+  const { [API_TARGET_COLUMN]: _apiTarget, ...legacyPayload } = payload;
+
+  return supabase
+    .from('qac_attempts')
+    .insert(legacyPayload)
+    .select('id')
+    .single();
+}
+
+export async function selectAttemptForSubmitWithApiTargetFallback(
+  supabase: SupabaseLike,
+  attemptId: number
+) {
+  const result = await supabase
+    .from('qac_attempts')
+    .select(ATTEMPT_SELECT_WITH_API_TARGET)
+    .eq('id', attemptId)
+    .single();
+
+  if (!isMissingApiTargetColumnError(result.error)) {
+    return result;
+  }
+
+  return supabase
+    .from('qac_attempts')
+    .select(ATTEMPT_SELECT_LEGACY)
+    .eq('id', attemptId)
+    .single();
+}

--- a/apps/frontend/src/app/api/assessments/start/route.ts
+++ b/apps/frontend/src/app/api/assessments/start/route.ts
@@ -7,6 +7,7 @@ import {
   DEFAULT_API_TARGET_ID,
   isApiChallengeTargetId,
 } from '@/app/assessments/api-banking/data/apiChallengeTargets';
+import { insertAttemptWithApiTargetFallback } from '../_lib/apiTargetPersistence';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -105,9 +106,8 @@ export async function POST(req: NextRequest) {
     }
 
     // Create attempt
-    const { data: attempt, error: attemptErr } = await supabase
-      .from('qac_attempts')
-      .insert({
+    const { data: attempt, error: attemptErr } =
+      await insertAttemptWithApiTargetFallback(supabase, {
         catalog_id: assessment.id,
         candidate_name: candidateName,
         candidate_email: candidateEmail,
@@ -115,11 +115,13 @@ export async function POST(req: NextRequest) {
         process_code: resolvedProcessCode,
         api_target: apiTarget,
         status: 'in_progress',
-      })
-      .select('id')
-      .single();
+      });
 
     if (attemptErr || !attempt) {
+      console.warn(
+        '[api-banking] failed to create qac_attempt',
+        attemptErr?.message
+      );
       return NextResponse.json(
         { error: 'Failed to create attempt' },
         { status: 500 }


### PR DESCRIPTION
## Summary
- Adds a Supabase compatibility fallback when creating API challenge attempts with `api_target`.
- Retries start/submit operations without `api_target` if the deployed DB schema or PostgREST schema cache does not expose that column yet.
- Adds unit coverage for stale schema and unrelated-error behavior.

## Root cause
The flexible API challenge writes `qac_attempts.api_target` during start. In environments where the migration has not been applied yet, or Supabase still has a stale schema cache, PostgREST rejects the insert and the candidate sees `Failed to create attempt` for every API option.

## Validation
- `pnpm --filter @aiquaa/frontend test -- apiTargetPersistence api-banking`
- `pnpm --filter @aiquaa/frontend type-check`
- pre-push hook: frontend type-check passed