### PR TITLE
[codex] Add ranking achievement notifications

### DIFF
--- a/apps/frontend/src/actions/exams.ts
+++ b/apps/frontend/src/actions/exams.ts
@@ -2,6 +2,10 @@
 
 import { createClient } from '@/lib/supabase/server';
 import { createAdminClient } from '@/lib/supabase/admin';
+import {
+  getRankingAchievementsForUser,
+  syncRankingAchievementsForUser,
+} from '@/lib/ranking-achievements';
 
 interface SaveExamResultPayload {
   exam_type:
@@ -80,6 +84,14 @@ export async function saveExamResultAction(payload: SaveExamResultPayload) {
   });
 
   if (error) return { error: error.message };
+  try {
+    await syncRankingAchievementsForUser(user.id);
+  } catch (achievementError) {
+    console.warn(
+      '[ranking-achievements] sync after exam failed',
+      achievementError
+    );
+  }
   return { success: true };
 }
 
@@ -337,4 +349,23 @@ export async function getMyXpProfileAction() {
       position: (count ?? 0) + 1,
     },
   };
+}
+
+export async function getMyRankingAchievementsAction() {
+  const supabase = createClient();
+  const {
+    data: { user },
+    error: userError,
+  } = await supabase.auth.getUser();
+  if (userError || !user) return { data: [], error: 'No autenticado' };
+
+  try {
+    await syncRankingAchievementsForUser(user.id);
+    const achievements = await getRankingAchievementsForUser(user.id);
+    return { data: achievements };
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : 'No se pudieron cargar logros';
+    return { data: [], error: message };
+  }
 }

--- a/apps/frontend/src/app/api/achievements/login/route.ts
+++ b/apps/frontend/src/app/api/achievements/login/route.ts
@@ -1,0 +1,45 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createAdminClient } from '@/lib/supabase/admin';
+import { createClient } from '@/lib/supabase/server';
+import { consumeLoginRankingAchievementNotifications } from '@/lib/ranking-achievements';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+async function getAuthenticatedUserId(req: NextRequest) {
+  const bearer = req.headers.get('authorization');
+
+  if (bearer?.startsWith('Bearer ')) {
+    const token = bearer.slice('Bearer '.length);
+    const admin = createAdminClient();
+    const {
+      data: { user },
+    } = await admin.auth.getUser(token);
+    return user?.id ?? null;
+  }
+
+  const supabase = createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  return user?.id ?? null;
+}
+
+export async function POST(req: NextRequest) {
+  const userId = await getAuthenticatedUserId(req);
+
+  if (!userId) {
+    return NextResponse.json({ error: 'No autenticado' }, { status: 401 });
+  }
+
+  try {
+    const achievements =
+      await consumeLoginRankingAchievementNotifications(userId);
+
+    return NextResponse.json({ achievements });
+  } catch (error) {
+    console.warn('[ranking-achievements] login notification failed', error);
+    return NextResponse.json({ achievements: [] });
+  }
+}

--- a/apps/frontend/src/app/perfil/page.tsx
+++ b/apps/frontend/src/app/perfil/page.tsx
@@ -9,7 +9,11 @@ import {
   uploadAvatarAction,
   changePasswordAction,
 } from '@/actions/profile';
-import { getExamResultsAction, getMyXpProfileAction } from '@/actions/exams';
+import {
+  getExamResultsAction,
+  getMyRankingAchievementsAction,
+  getMyXpProfileAction,
+} from '@/actions/exams';
 import Avatar from '@/components/ui/Avatar';
 import { xpForLevel, PY_TIMEZONE } from '@/lib/xp';
 import {
@@ -44,6 +48,18 @@ interface ExamResultRow {
   model?: string;
   language?: string;
   created_at: string;
+}
+
+interface RankingAchievementRow {
+  id: string;
+  rankingType: 'xp_global' | 'exam';
+  rankingSlug: string;
+  rankingLabel: string;
+  position: number;
+  score: number | null;
+  scoreLabel: string | null;
+  achievedAt: string;
+  notifiedAt: string | null;
 }
 
 const formatTime = (s: number) => {
@@ -89,6 +105,11 @@ export default function PerfilPage() {
   const [examTotal, setExamTotal] = useState(0);
   const [examFilter, setExamFilter] = useState<ExamType | 'all'>('all');
   const [examLoadingMore, setExamLoadingMore] = useState(false);
+  const [rankingAchievements, setRankingAchievements] = useState<
+    RankingAchievementRow[]
+  >([]);
+  const [rankingAchievementsLoading, setRankingAchievementsLoading] =
+    useState(true);
 
   const [formData, setFormData] = useState({
     full_name: '',
@@ -161,6 +182,16 @@ export default function PerfilPage() {
     getMyXpProfileAction().then(({ data }) => {
       if (data) setXpProfile(data);
     });
+  }, [user]);
+
+  useEffect(() => {
+    if (!user) return;
+    setRankingAchievementsLoading(true);
+    getMyRankingAchievementsAction()
+      .then(({ data }) => {
+        setRankingAchievements((data as RankingAchievementRow[]) || []);
+      })
+      .finally(() => setRankingAchievementsLoading(false));
   }, [user]);
 
   const handleFileSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -819,6 +850,101 @@ export default function PerfilPage() {
             </div>
           )}
         </div>
+
+        {/* Ranking Achievements */}
+        {!isEmpresa && (
+          <div id="logros-ranking" className={`${card} rounded-xl p-6`}>
+            <div className="flex items-start justify-between gap-4 mb-4">
+              <div>
+                <h2
+                  className={`text-base font-semibold ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
+                >
+                  Logros de ranking
+                </h2>
+                <p
+                  className={`text-xs mt-1 ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}
+                >
+                  Reconocimientos por llegar al Top 3 de AIQUAA.
+                </p>
+              </div>
+              <span
+                className={`rounded-full px-2.5 py-1 text-xs font-bold ${
+                  isDarkMode
+                    ? 'bg-amber-900/40 text-amber-300'
+                    : 'bg-amber-100 text-amber-700'
+                }`}
+              >
+                {rankingAchievements.length}
+              </span>
+            </div>
+
+            {rankingAchievementsLoading ? (
+              <div className="flex justify-center py-6">
+                <div className="animate-spin rounded-full h-6 w-6 border-t-2 border-amber-500" />
+              </div>
+            ) : rankingAchievements.length === 0 ? (
+              <div
+                className={`rounded-lg px-4 py-5 text-center ${isDarkMode ? 'bg-slate-700/40' : 'bg-gray-50'}`}
+              >
+                <p
+                  className={`text-sm font-medium ${isDarkMode ? 'text-slate-200' : 'text-gray-700'}`}
+                >
+                  Todavia no tenes logros de ranking.
+                </p>
+                <p
+                  className={`text-xs mt-1 ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}
+                >
+                  Cuando llegues al Top 3 global de XP o de un ranking de
+                  examen, se va a guardar aca con la fecha.
+                </p>
+              </div>
+            ) : (
+              <div className="space-y-3">
+                {rankingAchievements.map((achievement) => (
+                  <div
+                    key={achievement.id}
+                    className={`rounded-lg p-4 flex items-start justify-between gap-4 ${
+                      isDarkMode ? 'bg-slate-700/50' : 'bg-gray-50'
+                    }`}
+                  >
+                    <div className="min-w-0">
+                      <p
+                        className={`text-sm font-semibold ${isDarkMode ? 'text-slate-100' : 'text-gray-800'}`}
+                      >
+                        #{achievement.position} {achievement.rankingLabel}
+                      </p>
+                      <p
+                        className={`text-xs mt-1 ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}
+                      >
+                        Logro obtenido el{' '}
+                        {new Date(achievement.achievedAt).toLocaleDateString(
+                          'es-PY',
+                          {
+                            day: '2-digit',
+                            month: 'short',
+                            year: 'numeric',
+                            timeZone: PY_TIMEZONE,
+                          }
+                        )}
+                      </p>
+                    </div>
+                    {achievement.scoreLabel && (
+                      <span
+                        className={`shrink-0 rounded-full px-2.5 py-1 text-xs font-bold ${
+                          isDarkMode
+                            ? 'bg-slate-800 text-slate-200'
+                            : 'bg-white text-gray-700 border border-gray-200'
+                        }`}
+                      >
+                        {achievement.scoreLabel}
+                      </span>
+                    )}
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        )}
 
         {/* Exam History */}
         <div className={`${card} rounded-xl p-6`}>

--- a/apps/frontend/src/components/AchievementLoginNotifier.tsx
+++ b/apps/frontend/src/components/AchievementLoginNotifier.tsx
@@ -1,0 +1,125 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import Link from 'next/link';
+import { useSupabaseAuth } from '@/contexts/SupabaseAuthContext';
+import { useTheme } from '@/contexts/ThemeContext';
+
+type LoginAchievement = {
+  id: string;
+  rankingLabel: string;
+  position: number;
+  scoreLabel: string | null;
+  achievedAt: string;
+};
+
+export default function AchievementLoginNotifier() {
+  const { user, session } = useSupabaseAuth();
+  const { isDarkMode } = useTheme();
+  const [achievements, setAchievements] = useState<LoginAchievement[]>([]);
+  const [dismissed, setDismissed] = useState(false);
+
+  const checkKey = useMemo(() => {
+    if (!user?.id || !session?.access_token) return null;
+    return `aiquaa-ranking-achievements:${user.id}:${session.access_token.slice(-12)}`;
+  }, [session?.access_token, user?.id]);
+
+  useEffect(() => {
+    if (!checkKey || !session?.access_token) return;
+    if (sessionStorage.getItem(checkKey) === '1') return;
+
+    sessionStorage.setItem(checkKey, '1');
+
+    fetch('/api/achievements/login', {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${session.access_token}`,
+      },
+    })
+      .then((res) => (res.ok ? res.json() : { achievements: [] }))
+      .then((payload) => {
+        const next = Array.isArray(payload.achievements)
+          ? payload.achievements
+          : [];
+        if (next.length > 0) {
+          setAchievements(next);
+          setDismissed(false);
+        }
+      })
+      .catch(() => {
+        /* Login notification should never block navigation. */
+      });
+  }, [checkKey, session?.access_token]);
+
+  if (dismissed || achievements.length === 0) return null;
+
+  const first = achievements[0];
+  const extraCount = Math.max(0, achievements.length - 1);
+
+  return (
+    <div className="fixed bottom-4 right-4 z-[80] w-[calc(100vw-2rem)] max-w-sm">
+      <div
+        className={`rounded-2xl border p-4 shadow-2xl ${
+          isDarkMode
+            ? 'bg-slate-900 border-amber-700/60 text-slate-100'
+            : 'bg-white border-amber-200 text-gray-900'
+        }`}
+        role="status"
+        aria-live="polite"
+      >
+        <div className="flex items-start gap-3">
+          <div
+            className={`flex h-10 w-10 shrink-0 items-center justify-center rounded-full text-lg ${
+              isDarkMode
+                ? 'bg-amber-900/50 text-amber-300'
+                : 'bg-amber-100 text-amber-700'
+            }`}
+          >
+            #
+          </div>
+          <div className="min-w-0 flex-1">
+            <p className="text-sm font-bold">Nuevo logro de ranking</p>
+            <p
+              className={`mt-1 text-sm ${isDarkMode ? 'text-slate-300' : 'text-gray-600'}`}
+            >
+              Llegaste al puesto #{first.position} en {first.rankingLabel}
+              {first.scoreLabel ? ` con ${first.scoreLabel}` : ''}.
+            </p>
+            {extraCount > 0 && (
+              <p
+                className={`mt-1 text-xs ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}
+              >
+                Tambien tenes {extraCount} logro{extraCount > 1 ? 's' : ''}{' '}
+                nuevo{extraCount > 1 ? 's' : ''}.
+              </p>
+            )}
+            <div className="mt-3 flex items-center gap-3">
+              <Link
+                href="/perfil"
+                onClick={() => setDismissed(true)}
+                className="text-xs font-bold text-amber-600 hover:text-amber-700 dark:text-amber-300 dark:hover:text-amber-200"
+              >
+                Ver logros
+              </Link>
+              <button
+                type="button"
+                onClick={() => setDismissed(true)}
+                className={`text-xs font-medium ${isDarkMode ? 'text-slate-400 hover:text-slate-200' : 'text-gray-500 hover:text-gray-700'}`}
+              >
+                Cerrar
+              </button>
+            </div>
+          </div>
+          <button
+            type="button"
+            onClick={() => setDismissed(true)}
+            className={`shrink-0 rounded-full px-2 text-lg leading-none ${isDarkMode ? 'text-slate-500 hover:text-slate-200' : 'text-gray-400 hover:text-gray-700'}`}
+            aria-label="Cerrar notificacion de logro"
+          >
+            x
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/src/components/Header.tsx
+++ b/apps/frontend/src/components/Header.tsx
@@ -166,6 +166,19 @@ const Header = () => {
                     >
                       👤 Mi perfil
                     </Link>
+                    {!isEmpresa && (
+                      <Link
+                        href="/perfil#logros-ranking"
+                        onClick={() => setIsUserMenuOpen(false)}
+                        className={`flex items-center gap-2 px-4 py-2.5 text-sm transition-colors ${
+                          isDarkMode
+                            ? 'text-slate-200 hover:bg-slate-700'
+                            : 'text-gray-700 hover:bg-gray-50'
+                        }`}
+                      >
+                        # Logros
+                      </Link>
+                    )}
                     <div
                       className={`border-t ${isDarkMode ? 'border-slate-700' : 'border-gray-100'}`}
                     />
@@ -396,6 +409,19 @@ const Header = () => {
                 >
                   👤 Mi perfil
                 </Link>
+                {!isEmpresa && (
+                  <Link
+                    href="/perfil#logros-ranking"
+                    onClick={closeMobileMenu}
+                    className={`flex items-center gap-2 px-3 py-2 rounded-md text-base font-medium transition-colors duration-200 ${
+                      isDarkMode
+                        ? 'text-dark-text hover:bg-dark-secondary'
+                        : 'text-white/80 hover:bg-white/10'
+                    }`}
+                  >
+                    # Logros
+                  </Link>
+                )}
                 <button
                   onClick={handleLogout}
                   disabled={isLoading}

--- a/apps/frontend/src/components/Layout.tsx
+++ b/apps/frontend/src/components/Layout.tsx
@@ -2,6 +2,7 @@
 
 import type { ReactNode } from 'react';
 import { useTheme } from '@/contexts/ThemeContext';
+import AchievementLoginNotifier from './AchievementLoginNotifier';
 import Header from './Header';
 import Footer from './Footer';
 
@@ -11,14 +12,17 @@ interface LayoutProps {
 
 const Layout = ({ children }: LayoutProps) => {
   const { isDarkMode } = useTheme();
-  
+
   return (
-    <div className={`min-h-screen flex flex-col overflow-x-hidden transition-colors duration-300 ${
-      isDarkMode 
-        ? 'bg-dark-background text-dark-text' 
-        : 'bg-brand-background text-brand-text'
-    }`}>
+    <div
+      className={`min-h-screen flex flex-col overflow-x-hidden transition-colors duration-300 ${
+        isDarkMode
+          ? 'bg-dark-background text-dark-text'
+          : 'bg-brand-background text-brand-text'
+      }`}
+    >
       <Header />
+      <AchievementLoginNotifier />
       <main className="flex-1 w-full" role="main">
         {children}
       </main>

--- a/apps/frontend/src/lib/gamification/grant-xp.ts
+++ b/apps/frontend/src/lib/gamification/grant-xp.ts
@@ -1,5 +1,6 @@
 import { createAdminClient } from '@/lib/supabase/admin';
 import { calculateXpLevel } from '@/app/assessments/api-testing-fundamentals/lib/gamification';
+import { syncRankingAchievementsForUser } from '@/lib/ranking-achievements';
 
 export type XpRuleDefinition = {
   eventType: string;
@@ -135,4 +136,13 @@ export async function grantGamificationXpEvent(input: {
   );
 
   if (userXpError) throw new Error(userXpError.message);
+
+  try {
+    await syncRankingAchievementsForUser(input.userId);
+  } catch (achievementError) {
+    console.warn(
+      '[ranking-achievements] sync after xp failed',
+      achievementError
+    );
+  }
 }

--- a/apps/frontend/src/lib/ranking-achievements.ts
+++ b/apps/frontend/src/lib/ranking-achievements.ts
@@ -1,0 +1,367 @@
+import 'server-only';
+
+import { createAdminClient } from '@/lib/supabase/admin';
+import { EXAM_META, type ExamType } from '@/lib/exams';
+
+export type RankingAchievement = {
+  id: string;
+  rankingType: 'xp_global' | 'exam';
+  rankingSlug: string;
+  rankingLabel: string;
+  position: number;
+  score: number | null;
+  scoreLabel: string | null;
+  achievedAt: string;
+  notifiedAt: string | null;
+};
+
+type AchievementCandidate = {
+  rankingType: 'xp_global' | 'exam';
+  rankingSlug: string;
+  rankingLabel: string;
+  position: number;
+  score: number | null;
+  scoreLabel: string | null;
+  achievedAt: string;
+  metadata: Record<string, unknown>;
+};
+
+type ExistingAchievementRow = {
+  id: string;
+  user_id: string;
+  ranking_type: 'xp_global' | 'exam';
+  ranking_slug: string;
+  position: number;
+  notified_at: string | null;
+};
+
+const TOP_LIMIT = 3;
+
+const RANKED_EXAM_TYPES: ExamType[] = [
+  'git',
+  'git-practico',
+  'istqb',
+  'performance',
+  'api-testing-fundamentals',
+  'api-banking',
+  'database-fundamentals',
+  'database-practice',
+];
+
+const ASSESSMENT_RANKING_TYPES = new Set<ExamType>([
+  'database-fundamentals',
+  'database-practice',
+]);
+
+function isMissingAchievementsTableError(error: { code?: string } | null) {
+  return error?.code === '42P01';
+}
+
+function toAchievement(row: any): RankingAchievement {
+  return {
+    id: row.id,
+    rankingType: row.ranking_type,
+    rankingSlug: row.ranking_slug,
+    rankingLabel: row.ranking_label,
+    position: row.position,
+    score:
+      row.score === null || row.score === undefined ? null : Number(row.score),
+    scoreLabel: row.score_label ?? null,
+    achievedAt: row.achieved_at,
+    notifiedAt: row.notified_at ?? null,
+  };
+}
+
+function bestByUser<
+  T extends { user_id: string; percentage: number; score: number },
+>(rows: T[]) {
+  const best = new Map<string, T>();
+
+  for (const row of rows) {
+    const current = best.get(row.user_id);
+    if (
+      !current ||
+      row.percentage > current.percentage ||
+      (row.percentage === current.percentage && row.score > current.score)
+    ) {
+      best.set(row.user_id, row);
+    }
+  }
+
+  return Array.from(best.values()).sort((a, b) => {
+    if (b.percentage !== a.percentage) return b.percentage - a.percentage;
+    return b.score - a.score;
+  });
+}
+
+async function getXpGlobalCandidate(
+  admin: ReturnType<typeof createAdminClient>,
+  userId: string
+): Promise<AchievementCandidate | null> {
+  const { data, error } = await admin
+    .from('ranking_candidatos')
+    .select('user_id, total_xp, level, last_activity_at')
+    .order('total_xp', { ascending: false })
+    .range(0, TOP_LIMIT - 1);
+
+  if (error) return null;
+
+  const index = (data ?? []).findIndex((row: any) => row.user_id === userId);
+  if (index < 0) return null;
+
+  const row = data![index] as any;
+  const totalXp = Number(row.total_xp ?? 0);
+
+  return {
+    rankingType: 'xp_global',
+    rankingSlug: 'xp',
+    rankingLabel: 'Top XP Global AIQUAA',
+    position: index + 1,
+    score: totalXp,
+    scoreLabel: `${totalXp.toLocaleString('es-PY')} XP`,
+    achievedAt: row.last_activity_at ?? new Date().toISOString(),
+    metadata: {
+      level: row.level ?? null,
+      totalXp,
+    },
+  };
+}
+
+async function getLegacyExamCandidate(
+  admin: ReturnType<typeof createAdminClient>,
+  userId: string,
+  examType: ExamType
+): Promise<AchievementCandidate | null> {
+  const { data, error } = await admin
+    .from('exam_results')
+    .select(
+      'user_id, score, total_questions, max_possible_score, percentage, passed, created_at'
+    )
+    .eq('exam_type', examType)
+    .eq('exam_mode', 'exam')
+    .not('user_id', 'is', null)
+    .lte('percentage', 100)
+    .gte('total_questions', 10)
+    .order('percentage', { ascending: false })
+    .order('score', { ascending: false })
+    .limit(1000);
+
+  if (error) return null;
+
+  const validRows = (data ?? [])
+    .filter((row: any) => {
+      const maxScore = row.max_possible_score ?? row.total_questions;
+      return Number(row.score ?? 0) <= Number(maxScore ?? 0);
+    })
+    .map((row: any) => ({
+      user_id: row.user_id as string,
+      score: Number(row.score ?? 0),
+      total: Number(row.max_possible_score ?? row.total_questions ?? 0),
+      percentage: Number(row.percentage ?? 0),
+      passed: Boolean(row.passed),
+      achievedAt: row.created_at as string,
+    }));
+
+  const top = bestByUser(validRows).slice(0, TOP_LIMIT);
+  const index = top.findIndex((row) => row.user_id === userId);
+  if (index < 0) return null;
+
+  const row = top[index];
+  const meta = EXAM_META[examType];
+
+  return {
+    rankingType: 'exam',
+    rankingSlug: examType,
+    rankingLabel: `Top ${meta.label}`,
+    position: index + 1,
+    score: row.score,
+    scoreLabel: `${row.score}/${row.total}`,
+    achievedAt: row.achievedAt,
+    metadata: {
+      percentage: row.percentage,
+      passed: row.passed,
+      examType,
+    },
+  };
+}
+
+async function getAssessmentExamCandidate(
+  admin: ReturnType<typeof createAdminClient>,
+  userId: string,
+  examType: ExamType
+): Promise<AchievementCandidate | null> {
+  const { data: assessment } = await admin
+    .from('assessments')
+    .select('id')
+    .eq('slug', examType)
+    .maybeSingle();
+
+  if (!assessment?.id) return null;
+
+  const { data, error } = await admin
+    .from('assessment_attempts')
+    .select('user_id, total_score, max_score, percentage, passed, submitted_at')
+    .eq('assessment_id', assessment.id)
+    .eq('status', 'graded')
+    .not('user_id', 'is', null)
+    .lte('percentage', 100)
+    .order('percentage', { ascending: false })
+    .order('total_score', { ascending: false })
+    .limit(1000);
+
+  if (error) return null;
+
+  const rows = (data ?? []).map((row: any) => ({
+    user_id: row.user_id as string,
+    score: Number(row.total_score ?? 0),
+    total: Number(row.max_score ?? 0),
+    percentage: Number(row.percentage ?? 0),
+    passed: Boolean(row.passed),
+    achievedAt: row.submitted_at as string,
+  }));
+
+  const top = bestByUser(rows).slice(0, TOP_LIMIT);
+  const index = top.findIndex((row) => row.user_id === userId);
+  if (index < 0) return null;
+
+  const row = top[index];
+  const meta = EXAM_META[examType];
+
+  return {
+    rankingType: 'exam',
+    rankingSlug: examType,
+    rankingLabel: `Top ${meta.label}`,
+    position: index + 1,
+    score: row.score,
+    scoreLabel: `${row.score}/${row.total} pts`,
+    achievedAt: row.achievedAt ?? new Date().toISOString(),
+    metadata: {
+      percentage: row.percentage,
+      passed: row.passed,
+      examType,
+    },
+  };
+}
+
+async function collectAchievementCandidates(userId: string) {
+  const admin = createAdminClient();
+  const candidates: AchievementCandidate[] = [];
+  const xpCandidate = await getXpGlobalCandidate(admin, userId);
+  if (xpCandidate) candidates.push(xpCandidate);
+
+  for (const examType of RANKED_EXAM_TYPES) {
+    const candidate = ASSESSMENT_RANKING_TYPES.has(examType)
+      ? await getAssessmentExamCandidate(admin, userId, examType)
+      : await getLegacyExamCandidate(admin, userId, examType);
+
+    if (candidate) candidates.push(candidate);
+  }
+
+  return candidates;
+}
+
+export async function syncRankingAchievementsForUser(userId: string) {
+  const admin = createAdminClient();
+  const candidates = await collectAchievementCandidates(userId);
+  const changed: RankingAchievement[] = [];
+
+  for (const candidate of candidates) {
+    const { data: existing, error: existingError } = await admin
+      .from('ranking_achievements')
+      .select('id, user_id, ranking_type, ranking_slug, position, notified_at')
+      .eq('user_id', userId)
+      .eq('ranking_type', candidate.rankingType)
+      .eq('ranking_slug', candidate.rankingSlug)
+      .maybeSingle<ExistingAchievementRow>();
+
+    if (isMissingAchievementsTableError(existingError)) return changed;
+    if (existingError) continue;
+
+    if (!existing) {
+      const { data, error } = await admin
+        .from('ranking_achievements')
+        .insert({
+          user_id: userId,
+          ranking_type: candidate.rankingType,
+          ranking_slug: candidate.rankingSlug,
+          ranking_label: candidate.rankingLabel,
+          position: candidate.position,
+          score: candidate.score,
+          score_label: candidate.scoreLabel,
+          achieved_at: candidate.achievedAt,
+          metadata: candidate.metadata,
+        })
+        .select('*')
+        .single();
+
+      if (!error && data) changed.push(toAchievement(data));
+      continue;
+    }
+
+    if (candidate.position < existing.position) {
+      const { data, error } = await admin
+        .from('ranking_achievements')
+        .update({
+          ranking_label: candidate.rankingLabel,
+          position: candidate.position,
+          score: candidate.score,
+          score_label: candidate.scoreLabel,
+          achieved_at: candidate.achievedAt,
+          notified_at: null,
+          metadata: candidate.metadata,
+          updated_at: new Date().toISOString(),
+        })
+        .eq('id', existing.id)
+        .select('*')
+        .single();
+
+      if (!error && data) changed.push(toAchievement(data));
+    }
+  }
+
+  return changed;
+}
+
+export async function getRankingAchievementsForUser(userId: string) {
+  const admin = createAdminClient();
+  const { data, error } = await admin
+    .from('ranking_achievements')
+    .select('*')
+    .eq('user_id', userId)
+    .order('achieved_at', { ascending: false });
+
+  if (isMissingAchievementsTableError(error)) return [];
+  if (error) throw new Error(error.message);
+
+  return (data ?? []).map(toAchievement);
+}
+
+export async function consumeLoginRankingAchievementNotifications(
+  userId: string
+) {
+  const admin = createAdminClient();
+  await syncRankingAchievementsForUser(userId);
+
+  const { data, error } = await admin
+    .from('ranking_achievements')
+    .select('*')
+    .eq('user_id', userId)
+    .is('notified_at', null)
+    .order('achieved_at', { ascending: false });
+
+  if (isMissingAchievementsTableError(error)) return [];
+  if (error) throw new Error(error.message);
+
+  const achievements = (data ?? []).map(toAchievement);
+  if (achievements.length === 0) return achievements;
+
+  await admin
+    .from('ranking_achievements')
+    .update({ notified_at: new Date().toISOString() })
+    .in(
+      'id',
+      achievements.map((achievement) => achievement.id)
+    );
+
+  return achievements;
+}

--- a/supabase/migrations/20260625_010000_ranking_achievements.sql
+++ b/supabase/migrations/20260625_010000_ranking_achievements.sql
@@ -1,0 +1,37 @@
+-- Ranking achievements for users that reach a Top 3 position in AIQUAA rankings.
+
+CREATE TABLE IF NOT EXISTS public.ranking_achievements (
+  id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id         UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  ranking_type    TEXT NOT NULL CHECK (ranking_type IN ('xp_global', 'exam')),
+  ranking_slug    TEXT NOT NULL,
+  ranking_label   TEXT NOT NULL,
+  position        INT NOT NULL CHECK (position BETWEEN 1 AND 3),
+  score           NUMERIC,
+  score_label     TEXT,
+  achieved_at     TIMESTAMPTZ NOT NULL DEFAULT now(),
+  notified_at     TIMESTAMPTZ,
+  metadata        JSONB NOT NULL DEFAULT '{}'::jsonb,
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE (user_id, ranking_type, ranking_slug)
+);
+
+CREATE INDEX IF NOT EXISTS idx_ranking_achievements_user_created
+  ON public.ranking_achievements (user_id, achieved_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_ranking_achievements_unnotified
+  ON public.ranking_achievements (user_id, notified_at)
+  WHERE notified_at IS NULL;
+
+ALTER TABLE public.ranking_achievements ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "ranking_achievements_select_own" ON public.ranking_achievements;
+CREATE POLICY "ranking_achievements_select_own"
+  ON public.ranking_achievements
+  FOR SELECT
+  TO authenticated
+  USING (auth.uid() = user_id);
+
+REVOKE ALL ON public.ranking_achievements FROM PUBLIC;
+GRANT SELECT ON public.ranking_achievements TO authenticated;


### PR DESCRIPTION
## Summary
- Adds persisted ranking achievements for users who reach Top 3 in AIQUAA rankings.
- Shows a new `Logros de ranking` section in `/perfil` with ranking, position, score, and achievement date.
- Adds a login notification for new or improved ranking achievements, with a direct link to the profile achievements section.

## Details
- New `ranking_achievements` table stores one achievement per user/ranking and updates when the user improves position.
- Synchronization checks the global XP ranking and the exam rankings already exposed in `/ranking`.
- Achievement sync runs when exam results are saved, when XP is granted, when the profile loads, and when login notifications are checked.

## Validation
- `pnpm --filter @aiquaa/frontend type-check`
- `pnpm --filter @aiquaa/frontend test -- gamification`
- pre-commit hook: lint-staged, eslint --fix, prettier, workspace typecheck
- pre-push hook: frontend type-check