### PR TITLE
fix(assessments): wrap result pages in Suspense to fix webpack chunk error

### DIFF
--- a/apps/frontend/src/app/assessments/api-testing-fundamentals/result/page.tsx
+++ b/apps/frontend/src/app/assessments/api-testing-fundamentals/result/page.tsx
@@ -1,9 +1,16 @@
-'use client';
-
+import { Suspense } from 'react';
 import AssessmentResultClient from '../../_shared/components/AssessmentResultClient';
 
 export default function AssessmentResultPage() {
   return (
-    <AssessmentResultClient startHref="/assessments/api-testing-fundamentals/start" />
+    <Suspense
+      fallback={
+        <div className="min-h-screen flex items-center justify-center bg-slate-950">
+          <div className="h-10 w-10 animate-spin rounded-full border-t-2 border-cyan-400" />
+        </div>
+      }
+    >
+      <AssessmentResultClient startHref="/assessments/api-testing-fundamentals/start" />
+    </Suspense>
   );
 }

--- a/apps/frontend/src/app/assessments/database-fundamentals/result/page.tsx
+++ b/apps/frontend/src/app/assessments/database-fundamentals/result/page.tsx
@@ -1,12 +1,19 @@
-'use client';
-
+import { Suspense } from 'react';
 import AssessmentResultClient from '../../_shared/components/AssessmentResultClient';
 
 export default function DatabaseFundamentalsResultPage() {
   return (
-    <AssessmentResultClient
-      startHref="/assessments/database-fundamentals/start"
-      fallbackRecommendation="Seguí practicando consultas SQL y modelado relacional con casos reales."
-    />
+    <Suspense
+      fallback={
+        <div className="min-h-screen flex items-center justify-center bg-slate-950">
+          <div className="h-10 w-10 animate-spin rounded-full border-t-2 border-cyan-400" />
+        </div>
+      }
+    >
+      <AssessmentResultClient
+        startHref="/assessments/database-fundamentals/start"
+        fallbackRecommendation="Seguí practicando consultas SQL y modelado relacional con casos reales."
+      />
+    </Suspense>
   );
 }

--- a/apps/frontend/src/app/assessments/database-practice/result/page.tsx
+++ b/apps/frontend/src/app/assessments/database-practice/result/page.tsx
@@ -1,12 +1,19 @@
-'use client';
-
+import { Suspense } from 'react';
 import AssessmentResultClient from '../../_shared/components/AssessmentResultClient';
 
 export default function DatabasePracticeResultPage() {
   return (
-    <AssessmentResultClient
-      startHref="/assessments/database-practice/start"
-      fallbackRecommendation="Seguí practicando queries de validación de datos sobre esquemas reales."
-    />
+    <Suspense
+      fallback={
+        <div className="min-h-screen flex items-center justify-center bg-slate-950">
+          <div className="h-10 w-10 animate-spin rounded-full border-t-2 border-cyan-400" />
+        </div>
+      }
+    >
+      <AssessmentResultClient
+        startHref="/assessments/database-practice/start"
+        fallbackRecommendation="Seguí practicando queries de validación de datos sobre esquemas reales."
+      />
+    </Suspense>
   );
 }


### PR DESCRIPTION
## Summary

- Removes `'use client'` from the three assessment result page files — unnecessary since they only render a client component
- Wraps `<AssessmentResultClient>` in `<Suspense>` in all three result pages (`database-fundamentals`, `api-testing-fundamentals`, `database-practice`)

## Root cause

`AssessmentResultClient` calls `useSearchParams()` at the top level. Per Next.js App Router rules, any component using `useSearchParams()` must be wrapped in a `<Suspense>` boundary. Without it, webpack generates an undefined module factory for the dynamic chunk, which causes `TypeError: Cannot read properties of undefined (reading 'call')` at runtime — exactly the error reported in Vercel.

## Test plan

- [ ] Navigate to `/assessments/database-fundamentals/result?attempt=<id>` and confirm result screen loads
- [ ] Navigate to `/assessments/api-testing-fundamentals/result?attempt=<id>` and confirm result screen loads
- [ ] Navigate to `/assessments/database-practice/result?attempt=<id>` and confirm result screen loads
- [ ] Verify the spinner fallback appears briefly while the client component hydrates
- [ ] Confirm no webpack TypeError in Vercel runtime errors after next deploy

Closes #173

🤖 Generated with [Claude Code](https://claude.com/claude-code)