### PR TITLE
[codex] Fix auth refresh token burst

### DIFF
--- a/apps/frontend/src/middleware.ts
+++ b/apps/frontend/src/middleware.ts
@@ -4,8 +4,84 @@ import { NextResponse, type NextRequest } from 'next/server';
 const PROTECTED_ROUTES = ['/perfil', '/dashboard', '/empresa'];
 const AUTH_ROUTES = ['/login', '/register'];
 const PUBLIC_PATHS = ['/empresa/registro'];
+const SUPABASE_AUTH_COOKIE_PATTERN = /^sb-.+-auth-token(?:\.\d+)?$/;
+
+type CookieLike = {
+  name: string;
+};
+
+export function isSupabaseAuthCookie(name: string) {
+  return (
+    name === 'supabase-auth-token' || SUPABASE_AUTH_COOKIE_PATTERN.test(name)
+  );
+}
+
+export function hasSupabaseAuthCookie(cookies: CookieLike[]) {
+  return cookies.some((cookie) => isSupabaseAuthCookie(cookie.name));
+}
+
+export function isProtectedPath(pathname: string) {
+  return (
+    PROTECTED_ROUTES.some((route) => pathname.startsWith(route)) &&
+    !PUBLIC_PATHS.some((path) => pathname.startsWith(path))
+  );
+}
+
+export function isAuthPath(pathname: string) {
+  return AUTH_ROUTES.some((route) => pathname === route);
+}
+
+export function shouldVerifySupabaseUser(
+  pathname: string,
+  cookies: CookieLike[]
+) {
+  return isProtectedPath(pathname) && hasSupabaseAuthCookie(cookies);
+}
+
+function redirectToLogin(request: NextRequest) {
+  const loginUrl = request.nextUrl.clone();
+  const { pathname } = request.nextUrl;
+
+  loginUrl.pathname = '/login';
+  if (pathname.startsWith('/') && !pathname.startsWith('//')) {
+    loginUrl.searchParams.set('redirectedFrom', pathname);
+  }
+
+  return NextResponse.redirect(loginUrl);
+}
+
+function clearSupabaseAuthCookies(
+  request: NextRequest,
+  response: NextResponse
+) {
+  request.cookies
+    .getAll()
+    .filter((cookie) => isSupabaseAuthCookie(cookie.name))
+    .forEach((cookie) => {
+      response.cookies.set(cookie.name, '', {
+        expires: new Date(0),
+        maxAge: 0,
+        path: '/',
+      });
+    });
+}
 
 export async function middleware(request: NextRequest) {
+  const { pathname } = request.nextUrl;
+  const requestCookies = request.cookies.getAll();
+
+  if (isAuthPath(pathname)) {
+    return NextResponse.next({ request });
+  }
+
+  if (!isProtectedPath(pathname)) {
+    return NextResponse.next({ request });
+  }
+
+  if (!shouldVerifySupabaseUser(pathname, requestCookies)) {
+    return redirectToLogin(request);
+  }
+
   let supabaseResponse = NextResponse.next({ request });
 
   const supabase = createServerClient(
@@ -29,31 +105,27 @@ export async function middleware(request: NextRequest) {
     }
   );
 
-  // Verify session only for matched routes — avoids Supabase rate limiting from
-  // calling getUser() on every single request across the entire site.
   const {
     data: { user },
+    error,
   } = await supabase.auth.getUser();
-  const { pathname } = request.nextUrl;
 
-  // Redirect unauthenticated users away from protected routes
-  const isProtected =
-    PROTECTED_ROUTES.some((route) => pathname.startsWith(route)) &&
-    !PUBLIC_PATHS.some((path) => pathname.startsWith(path));
-  if (!user && isProtected) {
-    const loginUrl = request.nextUrl.clone();
-    loginUrl.pathname = '/login';
-    // Only store relative paths — prevents open redirect (e.g. ?redirectedFrom=//evil.com)
-    if (pathname.startsWith('/') && !pathname.startsWith('//')) {
-      loginUrl.searchParams.set('redirectedFrom', pathname);
-    }
-    return NextResponse.redirect(loginUrl);
+  if (error) {
+    console.warn('[auth middleware] Supabase user lookup failed', {
+      code: error.code,
+      message: error.message,
+      pathname,
+      referer: request.headers.get('referer'),
+      userAgent: request.headers.get('user-agent'),
+    });
+
+    const response = redirectToLogin(request);
+    clearSupabaseAuthCookies(request, response);
+    return response;
   }
 
-  // Redirect authenticated users away from auth pages
-  const isAuthRoute = AUTH_ROUTES.some((route) => pathname === route);
-  if (user && isAuthRoute) {
-    return NextResponse.redirect(new URL('/ranking', request.url));
+  if (!user) {
+    return redirectToLogin(request);
   }
 
   return supabaseResponse;

--- a/apps/frontend/test/middleware.auth.test.ts
+++ b/apps/frontend/test/middleware.auth.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import {
+  hasSupabaseAuthCookie,
+  isAuthPath,
+  isProtectedPath,
+  isSupabaseAuthCookie,
+  shouldVerifySupabaseUser,
+} from '../src/middleware';
+
+describe('auth middleware route guards', () => {
+  it('detects Supabase auth cookies including chunked cookies', () => {
+    expect(isSupabaseAuthCookie('sb-projectref-auth-token')).toBe(true);
+    expect(isSupabaseAuthCookie('sb-projectref-auth-token.0')).toBe(true);
+    expect(isSupabaseAuthCookie('supabase-auth-token')).toBe(true);
+    expect(isSupabaseAuthCookie('sb-projectref-code-verifier')).toBe(false);
+    expect(isSupabaseAuthCookie('next-auth.session-token')).toBe(false);
+  });
+
+  it('requires user verification only for protected paths with auth cookies', () => {
+    const cookies = [{ name: 'sb-projectref-auth-token' }];
+
+    expect(shouldVerifySupabaseUser('/perfil', cookies)).toBe(true);
+    expect(shouldVerifySupabaseUser('/dashboard/settings', cookies)).toBe(true);
+    expect(shouldVerifySupabaseUser('/empresa/procesos', cookies)).toBe(true);
+
+    expect(shouldVerifySupabaseUser('/perfil', [])).toBe(false);
+    expect(shouldVerifySupabaseUser('/login', cookies)).toBe(false);
+    expect(shouldVerifySupabaseUser('/register', cookies)).toBe(false);
+    expect(shouldVerifySupabaseUser('/empresa/registro', cookies)).toBe(false);
+  });
+
+  it('keeps auth routes out of server-side Supabase refresh checks', () => {
+    expect(isAuthPath('/login')).toBe(true);
+    expect(isAuthPath('/register')).toBe(true);
+    expect(isAuthPath('/login/help')).toBe(false);
+  });
+
+  it('keeps only private areas protected', () => {
+    expect(isProtectedPath('/perfil')).toBe(true);
+    expect(isProtectedPath('/dashboard')).toBe(true);
+    expect(isProtectedPath('/empresa')).toBe(true);
+    expect(isProtectedPath('/empresa/registro')).toBe(false);
+    expect(isProtectedPath('/ranking')).toBe(false);
+  });
+
+  it('does not treat unrelated cookies as an authenticated Supabase session', () => {
+    expect(
+      hasSupabaseAuthCookie([
+        { name: 'theme' },
+        { name: 'next-auth.csrf-token' },
+      ])
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Avoids server-side Supabase user lookups on `/login` and `/register`, preventing auth pages from triggering refresh attempts for stale cookies.
- Skips Supabase calls on protected routes when there is no Supabase auth cookie and redirects directly to login.
- Logs sanitized middleware context when `getUser()` fails on a protected route and clears Supabase auth cookies in the redirect response.
- Adds unit coverage for route/cookie guard decisions.

## Root Cause
The middleware matched auth and protected routes, then called `supabase.auth.getUser()` before deciding whether a server-side auth check was actually needed. Requests with stale Supabase auth cookies could therefore trigger refresh attempts from middleware, contributing to `refresh_token_not_found` bursts in Supabase Auth logs.

## Validation
- `pnpm --filter @aiquaa/frontend test -- test/middleware.auth.test.ts`
- `pnpm --filter @aiquaa/frontend type-check`
- `pnpm --filter @aiquaa/frontend lint` (passes with existing warnings)
- pre-commit lint-staged/typecheck
- pre-push type-check

Fixes #167