### PR TITLE
fix(auth): surface PKCE error separately from expired-link

### DIFF
--- a/apps/frontend/src/app/auth/confirm-result/page.tsx
+++ b/apps/frontend/src/app/auth/confirm-result/page.tsx
@@ -17,12 +17,24 @@ export default async function ConfirmResultPage({
           </div>
 
           <div className="mx-auto flex items-center justify-center h-12 w-12 rounded-full bg-green-100">
-            <svg className="h-6 w-6 text-green-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+            <svg
+              className="h-6 w-6 text-green-600"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M5 13l4 4L19 7"
+              />
             </svg>
           </div>
 
-          <h2 className="text-2xl font-bold text-gray-900">¡Email confirmado!</h2>
+          <h2 className="text-2xl font-bold text-gray-900">
+            ¡Email confirmado!
+          </h2>
           <p className="text-gray-600">
             Tu cuenta fue verificada exitosamente. Ya podés usar AIQUAA.
           </p>
@@ -38,15 +50,26 @@ export default async function ConfirmResultPage({
     );
   }
 
+  const isPkceError = error === 'pkce_error';
   const isExpired = error === 'link_expired' || error === 'access_denied';
   const isPasswordReset = next?.includes('reset-password');
 
-  const message = isExpired
-    ? 'El enlace expiró o ya fue usado. Solicitá uno nuevo.'
-    : 'Ocurrió un error durante la confirmación. Intentá de nuevo.';
+  const message = isPkceError
+    ? 'El enlace fue abierto en un navegador o dispositivo diferente al que inició el proceso. Iniciá sesión nuevamente desde el mismo navegador.'
+    : isExpired
+      ? 'El enlace expiró o ya fue usado. Solicitá uno nuevo.'
+      : 'Ocurrió un error durante la confirmación. Intentá de nuevo.';
 
-  const actionHref = isPasswordReset ? '/auth/forgot-password' : '/register';
-  const actionLabel = isPasswordReset ? 'Solicitar nuevo link' : 'Volver al registro';
+  const actionHref = isPkceError
+    ? '/login'
+    : isPasswordReset
+      ? '/auth/forgot-password'
+      : '/register';
+  const actionLabel = isPkceError
+    ? 'Ir al login'
+    : isPasswordReset
+      ? 'Solicitar nuevo link'
+      : 'Volver al registro';
 
   return (
     <div className="min-h-screen flex items-center justify-center bg-gray-50 py-12 px-4">
@@ -56,12 +79,24 @@ export default async function ConfirmResultPage({
         </div>
 
         <div className="mx-auto flex items-center justify-center h-12 w-12 rounded-full bg-red-100">
-          <svg className="h-6 w-6 text-red-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+          <svg
+            className="h-6 w-6 text-red-600"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M6 18L18 6M6 6l12 12"
+            />
           </svg>
         </div>
 
-        <h2 className="text-2xl font-bold text-gray-900">Error de confirmación</h2>
+        <h2 className="text-2xl font-bold text-gray-900">
+          Error de confirmación
+        </h2>
         <p className="text-gray-600">{message}</p>
 
         <Link
@@ -73,7 +108,10 @@ export default async function ConfirmResultPage({
 
         {isPasswordReset && (
           <p className="text-sm text-gray-500">
-            <Link href="/login" className="text-indigo-600 hover:text-indigo-500">
+            <Link
+              href="/login"
+              className="text-indigo-600 hover:text-indigo-500"
+            >
               ← Volver al login
             </Link>
           </p>

--- a/apps/frontend/src/app/auth/confirm/route.ts
+++ b/apps/frontend/src/app/auth/confirm/route.ts
@@ -23,6 +23,8 @@ export async function GET(request: NextRequest) {
 
   const supabase = await createClient();
 
+  let failureCode = 'link_expired';
+
   if (code) {
     const { data, error } = await supabase.auth.exchangeCodeForSession(code);
     if (!error) {
@@ -38,7 +40,14 @@ export async function GET(request: NextRequest) {
       successUrl.searchParams.set('next', destination);
       return NextResponse.redirect(successUrl.toString());
     }
-    console.error('[auth/confirm] exchangeCodeForSession failed:', error?.message);
+    console.error(
+      '[auth/confirm] exchangeCodeForSession failed:',
+      error?.message
+    );
+    const msg = error?.message?.toLowerCase() ?? '';
+    if (msg.includes('code verifier') || msg.includes('pkce')) {
+      failureCode = 'pkce_error';
+    }
   }
 
   if (token_hash && type) {
@@ -47,7 +56,9 @@ export async function GET(request: NextRequest) {
       type: type as 'signup' | 'recovery' | 'invite' | 'magiclink' | 'email',
     });
     if (!error) {
-      const { data: { user } } = await supabase.auth.getUser();
+      const {
+        data: { user },
+      } = await supabase.auth.getUser();
       const audience = user?.user_metadata?.audience;
       const destination = next ?? getDefaultRedirect(audience);
 
@@ -64,11 +75,14 @@ export async function GET(request: NextRequest) {
   }
 
   if (!code && !token_hash) {
-    console.error('[auth/confirm] no code or token_hash in request. params:', Object.fromEntries(searchParams));
+    console.error(
+      '[auth/confirm] no code or token_hash in request. params:',
+      Object.fromEntries(searchParams)
+    );
   }
 
   const fallbackUrl = new URL(`${origin}/auth/confirm-result`);
-  fallbackUrl.searchParams.set('error', 'link_expired');
+  fallbackUrl.searchParams.set('error', failureCode);
   if (next) fallbackUrl.searchParams.set('next', next);
   return NextResponse.redirect(fallbackUrl.toString());
 }


### PR DESCRIPTION
## Summary

- Detects PKCE-specific `exchangeCodeForSession` failures in `/auth/confirm` and redirects with `error=pkce_error` instead of the generic `link_expired` code
- `confirm-result` page shows an actionable Spanish-language message telling the user the link was opened in a different browser/device, and routes them to `/login` (not `/register`)

## Root cause

`signInWithOAuthAction` is a Server Action that uses the **server** Supabase client to call `signInWithOAuth`. Supabase stores the PKCE `code_verifier` in a cookie tied to that browser session. If the OAuth callback URL is subsequently opened in a different browser or device (or cookies were cleared), the `code_verifier` is missing → `exchangeCodeForSession` throws `"PKCE code verifier not found in storage"` → old code fell through to generic `link_expired`, giving users no useful guidance.

## Test plan

- [ ] OAuth login (Google/GitHub) on same browser → still succeeds, redirects to app
- [ ] Simulate PKCE failure by clearing cookies mid-OAuth flow → confirm-result shows new PKCE-specific message with "Ir al login" button
- [ ] Email confirm link (token_hash flow) → still works, unaffected
- [ ] Password reset flow → still routes to forgot-password on failure

Closes #172

🤖 Generated with [Claude Code](https://claude.com/claude-code)