### PR TITLE
[codex] Fix empresa candidate directory

### DIFF
--- a/apps/frontend/src/actions/profile.ts
+++ b/apps/frontend/src/actions/profile.ts
@@ -12,24 +12,47 @@ export async function updateProfileAction(formData: FormData) {
   const country = (formData.get('country') as string)?.trim();
   const githubProfile = (formData.get('github_profile') as string)?.trim();
   const istqbLevel = (formData.get('istqb_level') as string)?.trim();
+  const openToWork = formData.get('open_to_work') === 'true';
+  const talentVisibleToEmpresas =
+    formData.get('talent_visible_to_empresas') === 'true';
 
-  const { data: { user }, error: userError } = await supabase.auth.getUser();
+  const {
+    data: { user },
+    error: userError,
+  } = await supabase.auth.getUser();
   if (userError || !user) return { error: 'No autenticado' };
 
   const { error } = await supabase.auth.updateUser({
-    data: { full_name: fullName, bio, username, role, country, github_profile: githubProfile, istqb_level: istqbLevel },
+    data: {
+      full_name: fullName,
+      bio,
+      username,
+      role,
+      country,
+      github_profile: githubProfile,
+      istqb_level: istqbLevel,
+      open_to_work: openToWork,
+      talent_visible_to_empresas: talentVisibleToEmpresas,
+    },
   });
 
   if (error) return { error: error.message };
 
   // Sync to profiles table
-  await supabase.from('profiles').upsert({
-    id: user.id,
-    display_name: fullName || username || null,
-    email: user.email,
-    role: role || null,
-    country: country || null,
-  }, { onConflict: 'id' });
+  await supabase.from('profiles').upsert(
+    {
+      id: user.id,
+      display_name: fullName || username || null,
+      email: user.email,
+      role: role || null,
+      country: country || null,
+      istqb_level: istqbLevel || null,
+      github_profile: githubProfile || null,
+      open_to_work: openToWork,
+      talent_visible_to_empresas: talentVisibleToEmpresas,
+    },
+    { onConflict: 'id' }
+  );
 
   revalidatePath('/perfil');
   return { success: true };
@@ -57,13 +80,18 @@ export async function changePasswordAction(formData: FormData) {
 export async function uploadAvatarAction(formData: FormData) {
   const supabase = createClient();
 
-  const { data: { user }, error: userError } = await supabase.auth.getUser();
+  const {
+    data: { user },
+    error: userError,
+  } = await supabase.auth.getUser();
   if (userError || !user) return { error: 'No autenticado' };
 
   const file = formData.get('avatar') as File;
   if (!file || file.size === 0) return { error: 'Archivo requerido' };
-  if (file.size > 5 * 1024 * 1024) return { error: 'El archivo debe pesar menos de 5MB' };
-  if (!file.type.startsWith('image/')) return { error: 'Solo se permiten imágenes' };
+  if (file.size > 5 * 1024 * 1024)
+    return { error: 'El archivo debe pesar menos de 5MB' };
+  if (!file.type.startsWith('image/'))
+    return { error: 'Solo se permiten imágenes' };
 
   const ext = file.name.split('.').pop() || 'jpg';
   const path = `${user.id}/avatar.${ext}`;
@@ -74,9 +102,9 @@ export async function uploadAvatarAction(formData: FormData) {
 
   if (uploadError) return { error: uploadError.message };
 
-  const { data: { publicUrl } } = supabase.storage
-    .from('avatars')
-    .getPublicUrl(path);
+  const {
+    data: { publicUrl },
+  } = supabase.storage.from('avatars').getPublicUrl(path);
 
   const avatarUrl = `${publicUrl}?t=${Date.now()}`;
 

--- a/apps/frontend/src/app/empresa/candidatos/__tests__/candidateDirectory.test.ts
+++ b/apps/frontend/src/app/empresa/candidatos/__tests__/candidateDirectory.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'vitest';
+import { buildTalentDirectory, buildFavoriteMap } from '../candidateDirectory';
+
+const results = [
+  {
+    id: 'r1',
+    user_id: 'candidate-1',
+    participant_name: 'Ana QA',
+    participant_email: 'ana@example.com',
+    exam_type: 'istqb',
+    percentage: 82,
+    passed: true,
+    created_at: '2026-06-20T10:00:00Z',
+  },
+  {
+    id: 'r2',
+    user_id: 'candidate-1',
+    participant_name: 'Ana QA',
+    participant_email: 'ana@example.com',
+    exam_type: 'performance',
+    percentage: 91,
+    passed: true,
+    created_at: '2026-06-21T10:00:00Z',
+  },
+  {
+    id: 'r3',
+    user_id: 'candidate-2',
+    participant_name: 'Bruno QA',
+    participant_email: 'bruno@example.com',
+    exam_type: 'git',
+    percentage: 99,
+    passed: true,
+    created_at: '2026-06-22T10:00:00Z',
+  },
+];
+
+describe('candidate talent directory', () => {
+  it('only includes candidates who opted into empresa visibility', () => {
+    const directory = buildTalentDirectory(
+      results,
+      [
+        {
+          id: 'candidate-1',
+          display_name: 'Ana Testing',
+          email: 'ana@example.com',
+          role: 'QA Automation',
+          country: 'PY',
+          open_to_work: true,
+          talent_visible_to_empresas: true,
+        },
+        {
+          id: 'candidate-2',
+          display_name: 'Bruno Testing',
+          email: 'bruno@example.com',
+          open_to_work: true,
+          talent_visible_to_empresas: false,
+        },
+      ],
+      []
+    );
+
+    expect(directory).toHaveLength(1);
+    expect(directory[0]).toMatchObject({
+      userId: 'candidate-1',
+      name: 'Ana Testing',
+      bestScore: 91,
+      bestExamType: 'performance',
+      passedAssessments: 2,
+      totalAssessments: 2,
+      openToWork: true,
+    });
+  });
+
+  it('attaches favorite state by candidate id', () => {
+    const favorites = [
+      {
+        id: 'fav-1',
+        candidate_id: 'candidate-1',
+        notes: 'Buen perfil API',
+        created_at: '2026-06-23T10:00:00Z',
+      },
+    ];
+    const map = buildFavoriteMap(favorites);
+    const directory = buildTalentDirectory(
+      results.slice(0, 1),
+      [
+        {
+          id: 'candidate-1',
+          display_name: 'Ana Testing',
+          email: 'ana@example.com',
+          talent_visible_to_empresas: true,
+        },
+      ],
+      favorites
+    );
+
+    expect(map.get('candidate-1')?.id).toBe('fav-1');
+    expect(directory[0].favoriteId).toBe('fav-1');
+    expect(directory[0].favoriteNotes).toBe('Buen perfil API');
+  });
+});

--- a/apps/frontend/src/app/empresa/candidatos/candidateDirectory.ts
+++ b/apps/frontend/src/app/empresa/candidatos/candidateDirectory.ts
@@ -1,0 +1,134 @@
+export type CandidateProfile = {
+  id: string;
+  display_name: string | null;
+  email: string | null;
+  role?: string | null;
+  country?: string | null;
+  istqb_level?: string | null;
+  github_profile?: string | null;
+  open_to_work?: boolean | null;
+  talent_visible_to_empresas?: boolean | null;
+};
+
+export type CandidateResult = {
+  id: string;
+  user_id: string | null;
+  participant_name: string | null;
+  participant_email: string | null;
+  exam_type: string;
+  percentage: number;
+  passed: boolean;
+  created_at: string;
+};
+
+export type FavoriteRow = {
+  id: string;
+  candidate_id: string;
+  notes: string | null;
+  created_at: string;
+};
+
+export type TalentCandidate = {
+  userId: string;
+  name: string;
+  email: string | null;
+  role: string | null;
+  country: string | null;
+  istqbLevel: string | null;
+  githubProfile: string | null;
+  openToWork: boolean;
+  visibleToEmpresas: boolean;
+  bestScore: number;
+  bestExamType: string;
+  passedAssessments: number;
+  totalAssessments: number;
+  lastActivityAt: string;
+  favoriteId: string | null;
+  favoriteCreatedAt: string | null;
+  favoriteNotes: string | null;
+};
+
+export function getCandidateKey(result: CandidateResult) {
+  return result.user_id ?? result.participant_email ?? result.id;
+}
+
+export function buildFavoriteMap(favorites: FavoriteRow[]) {
+  return new Map(
+    favorites.map((favorite) => [favorite.candidate_id, favorite])
+  );
+}
+
+export function buildTalentDirectory(
+  results: CandidateResult[],
+  profiles: CandidateProfile[],
+  favorites: FavoriteRow[] = []
+) {
+  const profileMap = new Map(profiles.map((profile) => [profile.id, profile]));
+  const favoriteMap = buildFavoriteMap(favorites);
+  const grouped = new Map<string, CandidateResult[]>();
+
+  for (const result of results) {
+    if (!result.user_id) continue;
+    const profile = profileMap.get(result.user_id);
+    if (!profile?.talent_visible_to_empresas) continue;
+
+    const rows = grouped.get(result.user_id) ?? [];
+    rows.push(result);
+    grouped.set(result.user_id, rows);
+  }
+
+  return Array.from(grouped.entries())
+    .map(([userId, candidateResults]) => {
+      const profile = profileMap.get(userId)!;
+      const sorted = [...candidateResults].sort((a, b) => {
+        if (b.percentage !== a.percentage) return b.percentage - a.percentage;
+        return (
+          new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
+        );
+      });
+      const best = sorted[0];
+      const favorite = favoriteMap.get(userId) ?? null;
+
+      return {
+        userId,
+        name:
+          profile.display_name ||
+          best.participant_name ||
+          profile.email ||
+          best.participant_email ||
+          'Sin nombre',
+        email: profile.email ?? best.participant_email ?? null,
+        role: profile.role ?? null,
+        country: profile.country ?? null,
+        istqbLevel: profile.istqb_level ?? null,
+        githubProfile: profile.github_profile ?? null,
+        openToWork: Boolean(profile.open_to_work),
+        visibleToEmpresas: Boolean(profile.talent_visible_to_empresas),
+        bestScore: Number(best.percentage ?? 0),
+        bestExamType: best.exam_type,
+        passedAssessments: candidateResults.filter((result) => result.passed)
+          .length,
+        totalAssessments: candidateResults.length,
+        lastActivityAt: candidateResults.reduce(
+          (latest, result) =>
+            new Date(result.created_at).getTime() > new Date(latest).getTime()
+              ? result.created_at
+              : latest,
+          best.created_at
+        ),
+        favoriteId: favorite?.id ?? null,
+        favoriteCreatedAt: favorite?.created_at ?? null,
+        favoriteNotes: favorite?.notes ?? null,
+      } satisfies TalentCandidate;
+    })
+    .sort((a, b) => {
+      if (Number(b.openToWork) !== Number(a.openToWork)) {
+        return Number(b.openToWork) - Number(a.openToWork);
+      }
+      if (b.bestScore !== a.bestScore) return b.bestScore - a.bestScore;
+      return (
+        new Date(b.lastActivityAt).getTime() -
+        new Date(a.lastActivityAt).getTime()
+      );
+    });
+}

--- a/apps/frontend/src/app/empresa/candidatos/page.tsx
+++ b/apps/frontend/src/app/empresa/candidatos/page.tsx
@@ -16,6 +16,14 @@ import {
   XAxis,
   YAxis,
 } from 'recharts';
+import {
+  buildFavoriteMap,
+  buildTalentDirectory,
+  type CandidateProfile,
+  type CandidateResult,
+  type FavoriteRow,
+  type TalentCandidate,
+} from './candidateDirectory';
 
 type SectionScore = {
   section: string;
@@ -41,6 +49,8 @@ type ExamResult = {
   profiles?: { display_name: string | null }[] | null;
 };
 
+type ViewMode = 'evaluados' | 'talento' | 'favoritos';
+
 type HiringProcess = {
   id: string;
   code: string;
@@ -63,6 +73,15 @@ const DATABASE_ASSESSMENT_SLUGS = [
   'database-fundamentals',
   'database-practice',
 ];
+
+const ISTQB_LEVEL_LABELS: Record<string, string> = {
+  ctfl: 'Foundation Level (CTFL)',
+  ctal_ta: 'Advanced Level — Test Analyst',
+  ctal_tm: 'Advanced Level — Test Manager',
+  ctal_tta: 'Advanced Level — Technical Test Analyst',
+  expert: 'Expert Level',
+  en_proceso: 'En proceso de certificación',
+};
 
 function getAttemptProcessCode(metadata: unknown) {
   if (!metadata || typeof metadata !== 'object' || Array.isArray(metadata)) {
@@ -93,27 +112,99 @@ export default function CandidatosPage() {
   const { isDarkMode } = useTheme();
   const [processes, setProcesses] = useState<HiringProcess[]>([]);
   const [results, setResults] = useState<ExamResult[]>([]);
+  const [talentCandidates, setTalentCandidates] = useState<TalentCandidate[]>(
+    []
+  );
+  const [favorites, setFavorites] = useState<FavoriteRow[]>([]);
+  const [empresaId, setEmpresaId] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
+  const [actionMessage, setActionMessage] = useState<string | null>(null);
 
   // Filters
+  const [viewMode, setViewMode] = useState<ViewMode>('evaluados');
   const [search, setSearch] = useState('');
   const [selectedCode, setSelectedCode] = useState<string>('all');
   const [filterExam, setFilterExam] = useState<string>('all');
+  const [filterIstqbLevel, setFilterIstqbLevel] = useState<string>('all');
   const [filterPassed, setFilterPassed] = useState<'all' | 'passed' | 'failed'>(
     'all'
   );
   const [sortKey, setSortKey] = useState<SortKey>('percentage');
   const [sortDir, setSortDir] = useState<SortDir>('desc');
   const [expandedId, setExpandedId] = useState<string | null>(null);
+  const [selectedCandidateIds, setSelectedCandidateIds] = useState<string[]>(
+    []
+  );
 
   useEffect(() => {
     const load = async () => {
       const supabase = createClient();
+      const {
+        data: { user },
+      } = await supabase.auth.getUser();
+
+      let currentEmpresaId: string | null = null;
+      if (user?.id) {
+        const { data: currentProfile } = await supabase
+          .from('profiles')
+          .select('empresa_id')
+          .eq('id', user.id)
+          .maybeSingle();
+
+        currentEmpresaId = currentProfile?.empresa_id ?? null;
+        setEmpresaId(currentEmpresaId);
+      }
 
       const { data: procs } = await supabase
         .from('hiring_processes')
         .select('id, code, position_name, status')
         .order('created_at', { ascending: false });
+
+      const [favoritesRes, talentResultsRes] = await Promise.all([
+        currentEmpresaId
+          ? supabase
+              .from('empresa_favoritos')
+              .select('id, candidate_id, notes, created_at')
+              .eq('empresa_id', currentEmpresaId)
+          : Promise.resolve({ data: [], error: null }),
+        supabase
+          .from('exam_results')
+          .select(
+            'id, user_id, participant_name, participant_email, exam_type, percentage, passed, created_at'
+          )
+          .not('user_id', 'is', null)
+          .lte('percentage', 100)
+          .order('created_at', { ascending: false })
+          .limit(500),
+      ]);
+
+      const favoriteRows = ((favoritesRes.data ?? []) as FavoriteRow[]).filter(
+        (favorite) => Boolean(favorite.candidate_id)
+      );
+      setFavorites(favoriteRows);
+
+      const talentResults = (talentResultsRes.data ?? []) as CandidateResult[];
+      const talentUserIds = [
+        ...new Set(talentResults.map((row) => row.user_id).filter(Boolean)),
+      ] as string[];
+      let visibleProfiles: CandidateProfile[] = [];
+
+      if (talentUserIds.length > 0) {
+        const { data: profiles } = await supabase
+          .from('profiles')
+          .select(
+            'id, display_name, email, role, country, istqb_level, github_profile, open_to_work, talent_visible_to_empresas'
+          )
+          .in('id', talentUserIds)
+          .eq('audience', 'candidato')
+          .eq('talent_visible_to_empresas', true);
+
+        visibleProfiles = (profiles ?? []) as CandidateProfile[];
+      }
+
+      setTalentCandidates(
+        buildTalentDirectory(talentResults, visibleProfiles, favoriteRows)
+      );
 
       // Filtro server-side: solo traer exam_results de los procesos de esta
       // empresa (.in), en vez de cargar toda la plataforma y filtrar en cliente.
@@ -276,6 +367,112 @@ export default function CandidatosPage() {
     sortDir,
   ]);
 
+  const favoriteMap = useMemo(() => buildFavoriteMap(favorites), [favorites]);
+
+  const evaluatedCandidates = useMemo(() => {
+    const groups = new Map<string, ExamResult[]>();
+    for (const result of results) {
+      if (!result.user_id) continue;
+      const rows = groups.get(result.user_id) ?? [];
+      rows.push(result);
+      groups.set(result.user_id, rows);
+    }
+
+    return Array.from(groups.entries()).map(([userId, rows]) => {
+      const sorted = [...rows].sort((a, b) => {
+        if (b.percentage !== a.percentage) return b.percentage - a.percentage;
+        return (
+          new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
+        );
+      });
+      const best = sorted[0];
+      const favorite = favoriteMap.get(userId) ?? null;
+
+      return {
+        userId,
+        name: best.participant_name || best.participant_email || 'Sin nombre',
+        email: best.participant_email,
+        role: null,
+        country: null,
+        istqbLevel: null,
+        githubProfile: null,
+        openToWork: false,
+        visibleToEmpresas: false,
+        bestScore: Number(best.percentage ?? 0),
+        bestExamType: best.exam_type,
+        passedAssessments: rows.filter((result) => result.passed).length,
+        totalAssessments: rows.length,
+        lastActivityAt: rows.reduce(
+          (latest, result) =>
+            new Date(result.created_at).getTime() > new Date(latest).getTime()
+              ? result.created_at
+              : latest,
+          best.created_at
+        ),
+        favoriteId: favorite?.id ?? null,
+        favoriteCreatedAt: favorite?.created_at ?? null,
+        favoriteNotes: favorite?.notes ?? null,
+      } satisfies TalentCandidate;
+    });
+  }, [favoriteMap, results]);
+
+  const filteredTalentCandidates = useMemo(() => {
+    const q = search.toLowerCase();
+    return talentCandidates.filter((candidate) => {
+      const matchesLevel =
+        filterIstqbLevel === 'all' || candidate.istqbLevel === filterIstqbLevel;
+      const matchesSearch =
+        !q ||
+        candidate.name.toLowerCase().includes(q) ||
+        (candidate.email?.toLowerCase().includes(q) ?? false) ||
+        (candidate.role?.toLowerCase().includes(q) ?? false) ||
+        (candidate.country?.toLowerCase().includes(q) ?? false) ||
+        (candidate.istqbLevel
+          ? (ISTQB_LEVEL_LABELS[candidate.istqbLevel] ?? candidate.istqbLevel)
+              .toLowerCase()
+              .includes(q)
+          : false);
+
+      return matchesLevel && matchesSearch;
+    });
+  }, [filterIstqbLevel, talentCandidates, search]);
+
+  const favoriteCandidates = useMemo(
+    () =>
+      Array.from(
+        new Map(
+          [
+            ...filteredTalentCandidates,
+            ...evaluatedCandidates.filter(
+              (candidate) =>
+                filterIstqbLevel === 'all' ||
+                candidate.istqbLevel === filterIstqbLevel
+            ),
+          ]
+            .filter((candidate) => favoriteMap.has(candidate.userId))
+            .map((candidate) => [candidate.userId, candidate])
+        ).values()
+      ),
+    [
+      evaluatedCandidates,
+      favoriteMap,
+      filterIstqbLevel,
+      filteredTalentCandidates,
+    ]
+  );
+
+  const selectedForComparison = useMemo(() => {
+    const byId = new Map(
+      [...talentCandidates, ...evaluatedCandidates].map((candidate) => [
+        candidate.userId,
+        candidate,
+      ])
+    );
+    return selectedCandidateIds
+      .map((id) => byId.get(id))
+      .filter((candidate): candidate is TalentCandidate => Boolean(candidate));
+  }, [evaluatedCandidates, selectedCandidateIds, talentCandidates]);
+
   // --- Chart data (all based on `filtered` so they respect active filters) ---
 
   const topCandidatesData = useMemo(() => {
@@ -391,6 +588,82 @@ export default function CandidatosPage() {
     }
   };
 
+  const toggleFavorite = async (candidateId: string) => {
+    setActionMessage(null);
+    if (!empresaId) {
+      setActionMessage('No se pudo identificar la empresa activa.');
+      return;
+    }
+
+    const supabase = createClient();
+    const existing = favoriteMap.get(candidateId);
+
+    if (existing) {
+      const { error } = await supabase
+        .from('empresa_favoritos')
+        .delete()
+        .eq('id', existing.id);
+
+      if (error) {
+        setActionMessage(error.message);
+        return;
+      }
+
+      setFavorites((prev) => prev.filter((item) => item.id !== existing.id));
+      setTalentCandidates((prev) =>
+        prev.map((candidate) =>
+          candidate.userId === candidateId
+            ? {
+                ...candidate,
+                favoriteId: null,
+                favoriteCreatedAt: null,
+                favoriteNotes: null,
+              }
+            : candidate
+        )
+      );
+      setActionMessage('Candidato quitado de favoritos.');
+      return;
+    }
+
+    const { data, error } = await supabase
+      .from('empresa_favoritos')
+      .insert({ empresa_id: empresaId, candidate_id: candidateId })
+      .select('id, candidate_id, notes, created_at')
+      .single();
+
+    if (error) {
+      setActionMessage(error.message);
+      return;
+    }
+
+    const favorite = data as FavoriteRow;
+    setFavorites((prev) => [...prev, favorite]);
+    setTalentCandidates((prev) =>
+      prev.map((candidate) =>
+        candidate.userId === candidateId
+          ? {
+              ...candidate,
+              favoriteId: favorite.id,
+              favoriteCreatedAt: favorite.created_at,
+              favoriteNotes: favorite.notes,
+            }
+          : candidate
+      )
+    );
+    setActionMessage('Candidato guardado en favoritos.');
+  };
+
+  const toggleCompare = (candidateId: string) => {
+    setSelectedCandidateIds((prev) => {
+      if (prev.includes(candidateId)) {
+        return prev.filter((id) => id !== candidateId);
+      }
+      if (prev.length >= 4) return prev;
+      return [...prev, candidateId];
+    });
+  };
+
   const passCount = filtered.filter((r) => r.passed).length;
   const avgScore = filtered.length
     ? Math.round(
@@ -418,6 +691,178 @@ export default function CandidatosPage() {
       <span className="ml-1">↑</span>
     );
 
+  const renderTalentTable = (
+    candidates: TalentCandidate[],
+    emptyTitle: string,
+    emptyDescription: string
+  ) => {
+    if (candidates.length === 0) {
+      return (
+        <div
+          className={`text-center py-14 rounded-xl border-2 border-dashed ${isDarkMode ? 'border-slate-700 text-slate-500' : 'border-gray-200 text-gray-400'}`}
+        >
+          <p className="font-medium mb-1">{emptyTitle}</p>
+          <p className="text-sm">{emptyDescription}</p>
+        </div>
+      );
+    }
+
+    return (
+      <div className={`rounded-xl border overflow-hidden ${card}`}>
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className={isDarkMode ? 'bg-slate-800/60' : 'bg-gray-50'}>
+                <th
+                  className={`px-5 py-3 text-left text-xs font-semibold uppercase tracking-wide ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}
+                >
+                  Talento
+                </th>
+                <th
+                  className={`px-5 py-3 text-left text-xs font-semibold uppercase tracking-wide ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}
+                >
+                  Mejor resultado
+                </th>
+                <th
+                  className={`px-5 py-3 text-left text-xs font-semibold uppercase tracking-wide ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}
+                >
+                  Evidencia
+                </th>
+                <th
+                  className={`px-5 py-3 text-left text-xs font-semibold uppercase tracking-wide ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}
+                >
+                  Acciones
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {candidates.map((candidate) => {
+                const isFavorite = favoriteMap.has(candidate.userId);
+                const isSelected = selectedCandidateIds.includes(
+                  candidate.userId
+                );
+
+                return (
+                  <tr
+                    key={candidate.userId}
+                    className={`border-t ${isDarkMode ? 'border-slate-700' : 'border-gray-100'}`}
+                  >
+                    <td className="px-5 py-4">
+                      <div className="flex items-start gap-3">
+                        <input
+                          type="checkbox"
+                          checked={isSelected}
+                          onChange={() => toggleCompare(candidate.userId)}
+                          className="mt-1 h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500"
+                          aria-label={`Comparar ${candidate.name}`}
+                        />
+                        <div>
+                          <div className="flex items-center gap-2 flex-wrap">
+                            <Link
+                              href={`/talento/${candidate.userId}`}
+                              className={`font-semibold hover:underline ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
+                            >
+                              {candidate.name}
+                            </Link>
+                            {candidate.openToWork && (
+                              <span className="text-xs px-2 py-0.5 rounded-full bg-emerald-100 text-emerald-700">
+                                Disponible
+                              </span>
+                            )}
+                            {isFavorite && (
+                              <span className="text-xs px-2 py-0.5 rounded-full bg-amber-100 text-amber-700">
+                                Shortlist
+                              </span>
+                            )}
+                          </div>
+                          <p
+                            className={`text-xs mt-1 ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}
+                          >
+                            {[candidate.role, candidate.country]
+                              .filter(Boolean)
+                              .join(' · ') || 'Perfil QA'}
+                            {candidate.istqbLevel
+                              ? ` · ${ISTQB_LEVEL_LABELS[candidate.istqbLevel] ?? candidate.istqbLevel}`
+                              : ''}
+                          </p>
+                          {candidate.email && (
+                            <p
+                              className={`text-xs mt-0.5 ${isDarkMode ? 'text-slate-500' : 'text-gray-400'}`}
+                            >
+                              {candidate.email}
+                            </p>
+                          )}
+                        </div>
+                      </div>
+                    </td>
+                    <td className="px-5 py-4">
+                      <p className="text-lg font-bold text-indigo-500">
+                        {candidate.bestScore}%
+                      </p>
+                      <p
+                        className={`text-xs ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}
+                      >
+                        {EXAM_LABELS[candidate.bestExamType] ??
+                          candidate.bestExamType}
+                      </p>
+                    </td>
+                    <td className="px-5 py-4">
+                      <p
+                        className={`text-xs ${isDarkMode ? 'text-slate-300' : 'text-gray-700'}`}
+                      >
+                        {candidate.passedAssessments}/
+                        {candidate.totalAssessments} aprobados
+                      </p>
+                      <p
+                        className={`text-xs mt-1 ${isDarkMode ? 'text-slate-500' : 'text-gray-400'}`}
+                      >
+                        Última actividad{' '}
+                        {new Date(candidate.lastActivityAt).toLocaleDateString(
+                          'es-PY'
+                        )}
+                      </p>
+                    </td>
+                    <td className="px-5 py-4">
+                      <div className="flex flex-wrap gap-2">
+                        <button
+                          type="button"
+                          onClick={() => toggleFavorite(candidate.userId)}
+                          className={`px-3 py-1.5 rounded-lg text-xs font-semibold transition-colors ${
+                            isFavorite
+                              ? isDarkMode
+                                ? 'bg-amber-900/40 text-amber-200 hover:bg-amber-900/60'
+                                : 'bg-amber-100 text-amber-700 hover:bg-amber-200'
+                              : 'bg-indigo-600 text-white hover:bg-indigo-700'
+                          }`}
+                        >
+                          {isFavorite ? 'Quitar' : 'Guardar'}
+                        </button>
+                        {candidate.email && (
+                          <a
+                            href={`mailto:${candidate.email}`}
+                            className={`px-3 py-1.5 rounded-lg text-xs font-semibold border transition-colors ${isDarkMode ? 'border-slate-600 text-slate-300 hover:bg-slate-700' : 'border-gray-300 text-gray-700 hover:bg-gray-50'}`}
+                          >
+                            Contactar
+                          </a>
+                        )}
+                        <Link
+                          href={`/talento/${candidate.userId}`}
+                          className={`px-3 py-1.5 rounded-lg text-xs font-semibold border transition-colors ${isDarkMode ? 'border-slate-600 text-slate-300 hover:bg-slate-700' : 'border-gray-300 text-gray-700 hover:bg-gray-50'}`}
+                        >
+                          Perfil
+                        </Link>
+                      </div>
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    );
+  };
+
   return (
     <div
       className={`min-h-screen transition-colors duration-300 ${isDarkMode ? 'bg-dark-bg' : 'bg-gray-50'}`}
@@ -428,14 +873,103 @@ export default function CandidatosPage() {
           <h1
             className={`text-2xl font-bold ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
           >
-            Candidatos
+            Candidatos y talento QA
           </h1>
           <p
             className={`text-sm mt-1 ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}
           >
-            Resultados de exámenes técnicos de todos tus procesos
+            Revisá resultados por proceso, descubrí talento opt-in y armá una
+            shortlist para contactar.
           </p>
         </div>
+
+        <div className={`rounded-xl border p-1 flex flex-wrap gap-1 ${card}`}>
+          {[
+            {
+              key: 'evaluados' as const,
+              label: 'Evaluados',
+              count: results.length,
+            },
+            {
+              key: 'talento' as const,
+              label: 'Talento QA',
+              count: talentCandidates.length,
+            },
+            {
+              key: 'favoritos' as const,
+              label: 'Shortlist',
+              count: favorites.length,
+            },
+          ].map((tab) => (
+            <button
+              key={tab.key}
+              type="button"
+              onClick={() => setViewMode(tab.key)}
+              className={`px-4 py-2 rounded-lg text-sm font-semibold transition-colors ${
+                viewMode === tab.key
+                  ? 'bg-indigo-600 text-white'
+                  : isDarkMode
+                    ? 'text-slate-300 hover:bg-slate-700'
+                    : 'text-gray-600 hover:bg-gray-100'
+              }`}
+            >
+              {tab.label}
+              <span className="ml-2 text-xs opacity-75">{tab.count}</span>
+            </button>
+          ))}
+        </div>
+
+        {actionMessage && (
+          <div
+            className={`rounded-lg border px-4 py-3 text-sm ${isDarkMode ? 'border-slate-700 bg-slate-800 text-slate-200' : 'border-indigo-100 bg-indigo-50 text-indigo-700'}`}
+          >
+            {actionMessage}
+          </div>
+        )}
+
+        {selectedForComparison.length >= 2 && (
+          <div className={`rounded-xl border p-4 ${card}`}>
+            <div className="flex items-center justify-between gap-3 mb-3">
+              <p
+                className={`text-sm font-semibold ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
+              >
+                Comparación rápida
+              </p>
+              <button
+                type="button"
+                onClick={() => setSelectedCandidateIds([])}
+                className={`text-xs ${isDarkMode ? 'text-slate-400 hover:text-slate-200' : 'text-gray-500 hover:text-gray-700'}`}
+              >
+                Limpiar selección
+              </button>
+            </div>
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3">
+              {selectedForComparison.map((candidate) => (
+                <div
+                  key={candidate.userId}
+                  className={`rounded-lg border p-3 ${isDarkMode ? 'border-slate-700 bg-slate-800/60' : 'border-gray-200 bg-gray-50'}`}
+                >
+                  <p
+                    className={`font-semibold text-sm ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
+                  >
+                    {candidate.name}
+                  </p>
+                  <p className="text-xl font-bold text-indigo-500 mt-2">
+                    {candidate.bestScore}%
+                  </p>
+                  <p
+                    className={`text-xs mt-1 ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}
+                  >
+                    {EXAM_LABELS[candidate.bestExamType] ??
+                      candidate.bestExamType}{' '}
+                    · {candidate.passedAssessments}/{candidate.totalAssessments}{' '}
+                    aprobados
+                  </p>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
 
         {/* Stats */}
         {!loading && results.length > 0 && (
@@ -511,6 +1045,20 @@ export default function CandidatosPage() {
                 </option>
               ))}
             </select>
+            {viewMode !== 'evaluados' && (
+              <select
+                value={filterIstqbLevel}
+                onChange={(e) => setFilterIstqbLevel(e.target.value)}
+                className={inputClass}
+              >
+                <option value="all">Todos los niveles ISTQB</option>
+                {Object.entries(ISTQB_LEVEL_LABELS).map(([value, label]) => (
+                  <option key={value} value={value}>
+                    {label}
+                  </option>
+                ))}
+              </select>
+            )}
             <select
               value={filterPassed}
               onChange={(e) =>
@@ -527,12 +1075,14 @@ export default function CandidatosPage() {
           {(search ||
             selectedCode !== 'all' ||
             filterExam !== 'all' ||
+            filterIstqbLevel !== 'all' ||
             filterPassed !== 'all') && (
             <button
               onClick={() => {
                 setSearch('');
                 setSelectedCode('all');
                 setFilterExam('all');
+                setFilterIstqbLevel('all');
                 setFilterPassed('all');
               }}
               className={`text-xs ${isDarkMode ? 'text-slate-400 hover:text-slate-200' : 'text-gray-400 hover:text-gray-600'} transition-colors`}
@@ -542,281 +1092,358 @@ export default function CandidatosPage() {
           )}
         </div>
 
+        {viewMode === 'talento' &&
+          renderTalentTable(
+            filteredTalentCandidates,
+            'Sin talento visible todavía',
+            'Los candidatos aparecerán cuando activen la visibilidad para empresas desde su perfil.'
+          )}
+
+        {viewMode === 'favoritos' &&
+          renderTalentTable(
+            favoriteCandidates,
+            'Tu shortlist está vacía',
+            'Guardá candidatos desde el directorio o desde la tabla de resultados para compararlos y contactarlos después.'
+          )}
+
         {/* Table */}
-        {loading ? (
-          <div
-            className={`text-center py-16 ${isDarkMode ? 'text-slate-400' : 'text-gray-400'}`}
-          >
-            Cargando...
-          </div>
-        ) : results.length === 0 ? (
-          <div
-            className={`text-center py-16 rounded-xl border-2 border-dashed ${isDarkMode ? 'border-slate-700 text-slate-500' : 'border-gray-200 text-gray-400'}`}
-          >
-            <p className="text-4xl mb-3">👥</p>
-            <p className="font-medium mb-1">Sin resultados todavía</p>
-            <p className="text-sm mb-5">
-              Compartí el código de un proceso con tus candidatos
-            </p>
-            <Link
-              href="/empresa/procesos"
-              className="text-sm text-indigo-400 hover:underline"
+        {viewMode === 'evaluados' &&
+          (loading ? (
+            <div
+              className={`text-center py-16 ${isDarkMode ? 'text-slate-400' : 'text-gray-400'}`}
             >
-              Ver mis procesos →
-            </Link>
-          </div>
-        ) : filtered.length === 0 ? (
-          <div className={`text-center py-12 rounded-xl border ${card}`}>
-            <p
-              className={`text-sm ${isDarkMode ? 'text-slate-500' : 'text-gray-400'}`}
+              Cargando...
+            </div>
+          ) : results.length === 0 ? (
+            <div
+              className={`text-center py-16 rounded-xl border-2 border-dashed ${isDarkMode ? 'border-slate-700 text-slate-500' : 'border-gray-200 text-gray-400'}`}
             >
-              Sin resultados para los filtros aplicados
-            </p>
-          </div>
-        ) : (
-          <div className={`rounded-xl border overflow-hidden ${card}`}>
-            <div className="overflow-x-auto">
-              <table className="w-full text-sm">
-                <thead>
-                  <tr className={isDarkMode ? 'bg-slate-800/60' : 'bg-gray-50'}>
-                    <th
-                      className={`px-5 py-3 text-left text-xs font-semibold uppercase tracking-wide cursor-pointer select-none ${isDarkMode ? 'text-slate-400 hover:text-slate-200' : 'text-gray-500 hover:text-gray-700'}`}
-                      onClick={() => toggleSort('participant_name')}
+              <p className="text-4xl mb-3">👥</p>
+              <p className="font-medium mb-1">Sin resultados todavía</p>
+              <p className="text-sm mb-5">
+                Compartí el código de un proceso con tus candidatos
+              </p>
+              <Link
+                href="/empresa/procesos"
+                className="text-sm text-indigo-400 hover:underline"
+              >
+                Ver mis procesos →
+              </Link>
+            </div>
+          ) : filtered.length === 0 ? (
+            <div className={`text-center py-12 rounded-xl border ${card}`}>
+              <p
+                className={`text-sm ${isDarkMode ? 'text-slate-500' : 'text-gray-400'}`}
+              >
+                Sin resultados para los filtros aplicados
+              </p>
+            </div>
+          ) : (
+            <div className={`rounded-xl border overflow-hidden ${card}`}>
+              <div className="overflow-x-auto">
+                <table className="w-full text-sm">
+                  <thead>
+                    <tr
+                      className={isDarkMode ? 'bg-slate-800/60' : 'bg-gray-50'}
                     >
-                      Candidato <SortIcon k="participant_name" />
-                    </th>
-                    <th
-                      className={`px-5 py-3 text-left text-xs font-semibold uppercase tracking-wide ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}
-                    >
-                      Examen
-                    </th>
-                    <th
-                      className={`px-5 py-3 text-left text-xs font-semibold uppercase tracking-wide ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}
-                    >
-                      Proceso
-                    </th>
-                    <th
-                      className={`px-5 py-3 text-left text-xs font-semibold uppercase tracking-wide cursor-pointer select-none ${isDarkMode ? 'text-slate-400 hover:text-slate-200' : 'text-gray-500 hover:text-gray-700'}`}
-                      onClick={() => toggleSort('percentage')}
-                    >
-                      Puntaje <SortIcon k="percentage" />
-                    </th>
-                    <th
-                      className={`px-5 py-3 text-left text-xs font-semibold uppercase tracking-wide ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}
-                    >
-                      Tiempo
-                    </th>
-                    <th
-                      className={`px-5 py-3 text-left text-xs font-semibold uppercase tracking-wide cursor-pointer select-none ${isDarkMode ? 'text-slate-400 hover:text-slate-200' : 'text-gray-500 hover:text-gray-700'}`}
-                      onClick={() => toggleSort('created_at')}
-                    >
-                      Fecha <SortIcon k="created_at" />
-                    </th>
-                    <th className="px-5 py-3 w-8" />
-                  </tr>
-                </thead>
-                <tbody>
-                  {filtered.map((r, i) => {
-                    const proc = processes.find(
-                      (p) => p.code === r.process_code
-                    );
-                    return (
-                      <React.Fragment key={r.id}>
-                        <tr
-                          className={`border-t ${isDarkMode ? 'border-slate-700' : 'border-gray-100'} ${
-                            i % 2 === 0
-                              ? isDarkMode
-                                ? 'bg-dark-secondary'
-                                : 'bg-white'
-                              : isDarkMode
-                                ? 'bg-slate-800/30'
-                                : 'bg-gray-50/50'
-                          } cursor-pointer`}
-                          onClick={() =>
-                            setExpandedId((prev) =>
-                              prev === r.id ? null : r.id
-                            )
-                          }
-                        >
-                          <td className="px-5 py-3">
-                            <div className="flex items-center gap-2 flex-wrap">
-                              <span
-                                className={`font-medium ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
-                              >
-                                {r.participant_name || (
+                      <th
+                        className={`px-5 py-3 text-left text-xs font-semibold uppercase tracking-wide cursor-pointer select-none ${isDarkMode ? 'text-slate-400 hover:text-slate-200' : 'text-gray-500 hover:text-gray-700'}`}
+                        onClick={() => toggleSort('participant_name')}
+                      >
+                        Candidato <SortIcon k="participant_name" />
+                      </th>
+                      <th
+                        className={`px-5 py-3 text-left text-xs font-semibold uppercase tracking-wide ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}
+                      >
+                        Examen
+                      </th>
+                      <th
+                        className={`px-5 py-3 text-left text-xs font-semibold uppercase tracking-wide ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}
+                      >
+                        Proceso
+                      </th>
+                      <th
+                        className={`px-5 py-3 text-left text-xs font-semibold uppercase tracking-wide cursor-pointer select-none ${isDarkMode ? 'text-slate-400 hover:text-slate-200' : 'text-gray-500 hover:text-gray-700'}`}
+                        onClick={() => toggleSort('percentage')}
+                      >
+                        Puntaje <SortIcon k="percentage" />
+                      </th>
+                      <th
+                        className={`px-5 py-3 text-left text-xs font-semibold uppercase tracking-wide ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}
+                      >
+                        Tiempo
+                      </th>
+                      <th
+                        className={`px-5 py-3 text-left text-xs font-semibold uppercase tracking-wide cursor-pointer select-none ${isDarkMode ? 'text-slate-400 hover:text-slate-200' : 'text-gray-500 hover:text-gray-700'}`}
+                        onClick={() => toggleSort('created_at')}
+                      >
+                        Fecha <SortIcon k="created_at" />
+                      </th>
+                      <th
+                        className={`px-5 py-3 text-left text-xs font-semibold uppercase tracking-wide ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}
+                      >
+                        Acciones
+                      </th>
+                      <th className="px-5 py-3 w-8" />
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {filtered.map((r, i) => {
+                      const proc = processes.find(
+                        (p) => p.code === r.process_code
+                      );
+                      return (
+                        <React.Fragment key={r.id}>
+                          <tr
+                            className={`border-t ${isDarkMode ? 'border-slate-700' : 'border-gray-100'} ${
+                              i % 2 === 0
+                                ? isDarkMode
+                                  ? 'bg-dark-secondary'
+                                  : 'bg-white'
+                                : isDarkMode
+                                  ? 'bg-slate-800/30'
+                                  : 'bg-gray-50/50'
+                            } cursor-pointer`}
+                            onClick={() =>
+                              setExpandedId((prev) =>
+                                prev === r.id ? null : r.id
+                              )
+                            }
+                          >
+                            <td className="px-5 py-3">
+                              <div className="flex items-center gap-2 flex-wrap">
+                                <span
+                                  className={`font-medium ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
+                                >
+                                  {r.participant_name || (
+                                    <span
+                                      className={`italic ${isDarkMode ? 'text-slate-500' : 'text-gray-400'}`}
+                                    >
+                                      Sin nombre
+                                    </span>
+                                  )}
+                                </span>
+                                {(attemptInfo.totalMap.get(r.id) ?? 1) > 1 && (
                                   <span
-                                    className={`italic ${isDarkMode ? 'text-slate-500' : 'text-gray-400'}`}
+                                    className={`text-xs px-1.5 py-0.5 rounded font-mono ${isDarkMode ? 'bg-slate-700 text-slate-300' : 'bg-gray-100 text-gray-500'}`}
                                   >
-                                    Sin nombre
+                                    intento {attemptInfo.indexMap.get(r.id)}/
+                                    {attemptInfo.totalMap.get(r.id)}
                                   </span>
                                 )}
-                              </span>
-                              {(attemptInfo.totalMap.get(r.id) ?? 1) > 1 && (
-                                <span
-                                  className={`text-xs px-1.5 py-0.5 rounded font-mono ${isDarkMode ? 'bg-slate-700 text-slate-300' : 'bg-gray-100 text-gray-500'}`}
+                              </div>
+                              {r.participant_email && (
+                                <div
+                                  className={`text-xs mt-0.5 ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}
                                 >
-                                  intento {attemptInfo.indexMap.get(r.id)}/
-                                  {attemptInfo.totalMap.get(r.id)}
+                                  {r.participant_email}
+                                </div>
+                              )}
+                            </td>
+                            <td className="px-5 py-3">
+                              <span
+                                className={`font-mono text-xs px-2 py-0.5 rounded ${isDarkMode ? 'bg-slate-700 text-slate-300' : 'bg-gray-100 text-gray-600'}`}
+                              >
+                                {EXAM_LABELS[r.exam_type] ?? r.exam_type}
+                              </span>
+                            </td>
+                            <td className="px-5 py-3">
+                              {proc ? (
+                                <Link
+                                  href={`/empresa/procesos/${proc.id}`}
+                                  className={`text-xs hover:underline ${isDarkMode ? 'text-indigo-400' : 'text-indigo-600'}`}
+                                >
+                                  {proc.position_name}
+                                </Link>
+                              ) : (
+                                <span
+                                  className={`text-xs font-mono ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}
+                                >
+                                  {r.process_code}
                                 </span>
                               )}
-                            </div>
-                            {r.participant_email && (
-                              <div
-                                className={`text-xs mt-0.5 ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}
-                              >
-                                {r.participant_email}
+                            </td>
+                            <td className="px-5 py-3">
+                              <div className="flex items-center gap-2">
+                                <span
+                                  className={`font-bold text-base ${r.passed ? 'text-green-500' : 'text-red-500'}`}
+                                >
+                                  {r.percentage}%
+                                </span>
+                                <span
+                                  className={`text-xs px-1.5 py-0.5 rounded-full font-medium ${
+                                    r.passed
+                                      ? isDarkMode
+                                        ? 'bg-green-900/40 text-green-300'
+                                        : 'bg-green-50 text-green-700'
+                                      : isDarkMode
+                                        ? 'bg-red-900/40 text-red-300'
+                                        : 'bg-red-50 text-red-700'
+                                  }`}
+                                >
+                                  {r.passed ? '✓' : '✗'}
+                                </span>
                               </div>
-                            )}
-                          </td>
-                          <td className="px-5 py-3">
-                            <span
-                              className={`font-mono text-xs px-2 py-0.5 rounded ${isDarkMode ? 'bg-slate-700 text-slate-300' : 'bg-gray-100 text-gray-600'}`}
+                            </td>
+                            <td
+                              className={`px-5 py-3 text-xs ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}
                             >
-                              {EXAM_LABELS[r.exam_type] ?? r.exam_type}
-                            </span>
-                          </td>
-                          <td className="px-5 py-3">
-                            {proc ? (
-                              <Link
-                                href={`/empresa/procesos/${proc.id}`}
-                                className={`text-xs hover:underline ${isDarkMode ? 'text-indigo-400' : 'text-indigo-600'}`}
-                              >
-                                {proc.position_name}
-                              </Link>
-                            ) : (
-                              <span
-                                className={`text-xs font-mono ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}
-                              >
-                                {r.process_code}
-                              </span>
-                            )}
-                          </td>
-                          <td className="px-5 py-3">
-                            <div className="flex items-center gap-2">
-                              <span
-                                className={`font-bold text-base ${r.passed ? 'text-green-500' : 'text-red-500'}`}
-                              >
-                                {r.percentage}%
-                              </span>
-                              <span
-                                className={`text-xs px-1.5 py-0.5 rounded-full font-medium ${
-                                  r.passed
-                                    ? isDarkMode
-                                      ? 'bg-green-900/40 text-green-300'
-                                      : 'bg-green-50 text-green-700'
-                                    : isDarkMode
-                                      ? 'bg-red-900/40 text-red-300'
-                                      : 'bg-red-50 text-red-700'
-                                }`}
-                              >
-                                {r.passed ? '✓' : '✗'}
-                              </span>
-                            </div>
-                          </td>
-                          <td
-                            className={`px-5 py-3 text-xs ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}
-                          >
-                            {mins(r.time_spent)}
-                          </td>
-                          <td
-                            className={`px-5 py-3 text-xs ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}
-                          >
-                            {new Date(r.created_at).toLocaleDateString('es-PY')}
-                          </td>
-                          <td className="px-3 py-3 text-center">
-                            <span
-                              className={`text-xs transition-transform inline-block ${isDarkMode ? 'text-slate-400' : 'text-gray-400'}`}
-                              style={{
-                                transform:
-                                  expandedId === r.id
-                                    ? 'rotate(90deg)'
-                                    : 'rotate(0deg)',
-                              }}
+                              {mins(r.time_spent)}
+                            </td>
+                            <td
+                              className={`px-5 py-3 text-xs ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}
                             >
-                              ▶
-                            </span>
-                          </td>
-                        </tr>
-                        {expandedId === r.id &&
-                          (() => {
-                            const scores = getSectionScores(r);
-                            return (
-                              <tr
-                                key={`${r.id}-detail`}
-                                className={`border-t ${isDarkMode ? 'border-slate-700 bg-slate-800/50' : 'border-gray-100 bg-gray-50'}`}
-                              >
-                                <td colSpan={7} className="px-6 py-4">
-                                  {scores && scores.length > 0 ? (
-                                    <div className="space-y-2">
-                                      <p
-                                        className={`text-xs font-semibold uppercase tracking-wide mb-3 ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}
-                                      >
-                                        Desglose por área
-                                      </p>
-                                      {scores.map((s) => (
-                                        <div
-                                          key={s.section}
-                                          className="flex items-center gap-3"
-                                        >
-                                          <span
-                                            className={`text-xs w-48 shrink-0 truncate ${isDarkMode ? 'text-slate-300' : 'text-gray-700'}`}
-                                            title={s.section}
-                                          >
-                                            {s.section}
-                                          </span>
-                                          <div
-                                            className={`flex-1 rounded-full h-2 ${isDarkMode ? 'bg-slate-700' : 'bg-gray-200'}`}
-                                          >
-                                            <div
-                                              className={`h-2 rounded-full transition-all ${s.percentage >= 60 ? 'bg-green-500' : 'bg-red-400'}`}
-                                              style={{
-                                                width: `${s.percentage}%`,
-                                              }}
-                                            />
-                                          </div>
-                                          <span
-                                            className={`text-xs w-20 shrink-0 text-right font-mono ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}
-                                          >
-                                            {s.correct}/{s.total} (
-                                            {s.percentage}%)
-                                          </span>
-                                          <span className="text-xs w-4 shrink-0">
-                                            {s.percentage >= 60 ? (
-                                              <span className="text-green-500">
-                                                ✓
-                                              </span>
-                                            ) : (
-                                              <span className="text-red-400">
-                                                ✗
-                                              </span>
-                                            )}
-                                          </span>
-                                        </div>
-                                      ))}
-                                    </div>
-                                  ) : (
-                                    <p
-                                      className={`text-xs ${isDarkMode ? 'text-slate-500' : 'text-gray-400'}`}
+                              {new Date(r.created_at).toLocaleDateString(
+                                'es-PY'
+                              )}
+                            </td>
+                            <td className="px-5 py-3">
+                              {r.user_id ? (
+                                <div
+                                  className="flex flex-wrap gap-2 items-center"
+                                  onClick={(event) => event.stopPropagation()}
+                                >
+                                  <input
+                                    type="checkbox"
+                                    checked={selectedCandidateIds.includes(
+                                      r.user_id
+                                    )}
+                                    onChange={() => toggleCompare(r.user_id!)}
+                                    className="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500"
+                                    aria-label={`Comparar ${r.participant_name ?? r.participant_email ?? 'candidato'}`}
+                                  />
+                                  <button
+                                    type="button"
+                                    onClick={() => toggleFavorite(r.user_id!)}
+                                    className={`px-2.5 py-1 rounded-lg text-xs font-semibold transition-colors ${
+                                      favoriteMap.has(r.user_id)
+                                        ? isDarkMode
+                                          ? 'bg-amber-900/40 text-amber-200 hover:bg-amber-900/60'
+                                          : 'bg-amber-100 text-amber-700 hover:bg-amber-200'
+                                        : 'bg-indigo-600 text-white hover:bg-indigo-700'
+                                    }`}
+                                  >
+                                    {favoriteMap.has(r.user_id)
+                                      ? 'Guardado'
+                                      : 'Guardar'}
+                                  </button>
+                                  {r.participant_email && (
+                                    <a
+                                      href={`mailto:${r.participant_email}`}
+                                      className={`px-2.5 py-1 rounded-lg text-xs font-semibold border transition-colors ${isDarkMode ? 'border-slate-600 text-slate-300 hover:bg-slate-700' : 'border-gray-300 text-gray-700 hover:bg-gray-50'}`}
                                     >
-                                      Sin desglose disponible para este tipo de
-                                      examen
-                                    </p>
+                                      Contactar
+                                    </a>
                                   )}
-                                </td>
-                              </tr>
-                            );
-                          })()}
-                      </React.Fragment>
-                    );
-                  })}
-                </tbody>
-              </table>
+                                  <Link
+                                    href={`/talento/${r.user_id}`}
+                                    className={`px-2.5 py-1 rounded-lg text-xs font-semibold border transition-colors ${isDarkMode ? 'border-slate-600 text-slate-300 hover:bg-slate-700' : 'border-gray-300 text-gray-700 hover:bg-gray-50'}`}
+                                  >
+                                    Perfil
+                                  </Link>
+                                </div>
+                              ) : (
+                                <span
+                                  className={`text-xs ${isDarkMode ? 'text-slate-500' : 'text-gray-400'}`}
+                                >
+                                  Sin usuario
+                                </span>
+                              )}
+                            </td>
+                            <td className="px-3 py-3 text-center">
+                              <span
+                                className={`text-xs transition-transform inline-block ${isDarkMode ? 'text-slate-400' : 'text-gray-400'}`}
+                                style={{
+                                  transform:
+                                    expandedId === r.id
+                                      ? 'rotate(90deg)'
+                                      : 'rotate(0deg)',
+                                }}
+                              >
+                                ▶
+                              </span>
+                            </td>
+                          </tr>
+                          {expandedId === r.id &&
+                            (() => {
+                              const scores = getSectionScores(r);
+                              return (
+                                <tr
+                                  key={`${r.id}-detail`}
+                                  className={`border-t ${isDarkMode ? 'border-slate-700 bg-slate-800/50' : 'border-gray-100 bg-gray-50'}`}
+                                >
+                                  <td colSpan={8} className="px-6 py-4">
+                                    {scores && scores.length > 0 ? (
+                                      <div className="space-y-2">
+                                        <p
+                                          className={`text-xs font-semibold uppercase tracking-wide mb-3 ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}
+                                        >
+                                          Desglose por área
+                                        </p>
+                                        {scores.map((s) => (
+                                          <div
+                                            key={s.section}
+                                            className="flex items-center gap-3"
+                                          >
+                                            <span
+                                              className={`text-xs w-48 shrink-0 truncate ${isDarkMode ? 'text-slate-300' : 'text-gray-700'}`}
+                                              title={s.section}
+                                            >
+                                              {s.section}
+                                            </span>
+                                            <div
+                                              className={`flex-1 rounded-full h-2 ${isDarkMode ? 'bg-slate-700' : 'bg-gray-200'}`}
+                                            >
+                                              <div
+                                                className={`h-2 rounded-full transition-all ${s.percentage >= 60 ? 'bg-green-500' : 'bg-red-400'}`}
+                                                style={{
+                                                  width: `${s.percentage}%`,
+                                                }}
+                                              />
+                                            </div>
+                                            <span
+                                              className={`text-xs w-20 shrink-0 text-right font-mono ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}
+                                            >
+                                              {s.correct}/{s.total} (
+                                              {s.percentage}%)
+                                            </span>
+                                            <span className="text-xs w-4 shrink-0">
+                                              {s.percentage >= 60 ? (
+                                                <span className="text-green-500">
+                                                  ✓
+                                                </span>
+                                              ) : (
+                                                <span className="text-red-400">
+                                                  ✗
+                                                </span>
+                                              )}
+                                            </span>
+                                          </div>
+                                        ))}
+                                      </div>
+                                    ) : (
+                                      <p
+                                        className={`text-xs ${isDarkMode ? 'text-slate-500' : 'text-gray-400'}`}
+                                      >
+                                        Sin desglose disponible para este tipo
+                                        de examen
+                                      </p>
+                                    )}
+                                  </td>
+                                </tr>
+                              );
+                            })()}
+                        </React.Fragment>
+                      );
+                    })}
+                  </tbody>
+                </table>
+              </div>
             </div>
-          </div>
-        )}
+          ))}
 
         {/* Charts */}
-        {!loading && filtered.length > 0 && (
+        {viewMode === 'evaluados' && !loading && filtered.length > 0 && (
           <div className="space-y-6">
             <h2
               className={`text-base font-semibold ${isDarkMode ? 'text-white' : 'text-gray-900'}`}

--- a/apps/frontend/src/app/empresa/page.tsx
+++ b/apps/frontend/src/app/empresa/page.tsx
@@ -39,8 +39,8 @@ const BASE_LINKS = [
   {
     href: '/empresa/candidatos',
     emoji: '👥',
-    title: 'Candidatos evaluados',
-    description: 'Revisá los resultados de exámenes por proceso',
+    title: 'Candidatos y talento QA',
+    description: 'Revisá evaluados, directorio opt-in y shortlist',
   },
   {
     href: '/empresa/invitaciones',

--- a/apps/frontend/src/app/perfil/page.tsx
+++ b/apps/frontend/src/app/perfil/page.tsx
@@ -119,6 +119,8 @@ export default function PerfilPage() {
     country: '',
     github_profile: '',
     istqb_level: '',
+    open_to_work: false,
+    talent_visible_to_empresas: false,
   });
   const [initialized, setInitialized] = useState(false);
   const [xpProfile, setXpProfile] = useState<{
@@ -141,6 +143,10 @@ export default function PerfilPage() {
         country: user.user_metadata?.country || '',
         github_profile: user.user_metadata?.github_profile || '',
         istqb_level: user.user_metadata?.istqb_level || '',
+        open_to_work: Boolean(user.user_metadata?.open_to_work),
+        talent_visible_to_empresas: Boolean(
+          user.user_metadata?.talent_visible_to_empresas
+        ),
       });
       setInitialized(true);
     }
@@ -271,6 +277,11 @@ export default function PerfilPage() {
     fd.set('country', formData.country);
     fd.set('github_profile', formData.github_profile);
     fd.set('istqb_level', formData.istqb_level);
+    fd.set('open_to_work', String(formData.open_to_work));
+    fd.set(
+      'talent_visible_to_empresas',
+      String(formData.talent_visible_to_empresas)
+    );
     startTransition(async () => {
       const result = await updateProfileAction(fd);
       if (result.error) {
@@ -586,6 +597,59 @@ export default function PerfilPage() {
           {/* Role — candidatos only */}
           {!isEmpresa && (
             <div>
+              <div
+                className={`rounded-lg border p-4 mb-5 space-y-3 ${isDarkMode ? 'border-slate-700 bg-slate-900/40' : 'border-indigo-100 bg-indigo-50/60'}`}
+              >
+                <div>
+                  <p
+                    className={`text-sm font-semibold ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
+                  >
+                    Visibilidad para empresas
+                  </p>
+                  <p
+                    className={`text-xs mt-1 ${isDarkMode ? 'text-slate-400' : 'text-gray-600'}`}
+                  >
+                    Permití que recruiters de empresas registradas encuentren tu
+                    perfil cuando busquen talento QA en AIQUAA.
+                  </p>
+                </div>
+                <label className="flex gap-3 items-start text-sm">
+                  <input
+                    type="checkbox"
+                    checked={formData.talent_visible_to_empresas}
+                    onChange={(e) =>
+                      setFormData((p) => ({
+                        ...p,
+                        talent_visible_to_empresas: e.target.checked,
+                      }))
+                    }
+                    className="mt-1 h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500"
+                  />
+                  <span
+                    className={isDarkMode ? 'text-slate-300' : 'text-gray-700'}
+                  >
+                    Mostrar mi perfil en el directorio de talento para empresas
+                  </span>
+                </label>
+                <label className="flex gap-3 items-start text-sm">
+                  <input
+                    type="checkbox"
+                    checked={formData.open_to_work}
+                    onChange={(e) =>
+                      setFormData((p) => ({
+                        ...p,
+                        open_to_work: e.target.checked,
+                      }))
+                    }
+                    className="mt-1 h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500"
+                  />
+                  <span
+                    className={isDarkMode ? 'text-slate-300' : 'text-gray-700'}
+                  >
+                    Estoy disponible para ser contactado por oportunidades QA
+                  </span>
+                </label>
+              </div>
               <label className={labelClass}>Tu rol en QA</label>
               <div className="grid grid-cols-2 gap-2">
                 {Object.entries(ROLES).map(([value, { label, emoji }]) => {

--- a/apps/frontend/src/app/talento/[id]/page.tsx
+++ b/apps/frontend/src/app/talento/[id]/page.tsx
@@ -1,0 +1,204 @@
+import Link from 'next/link';
+import { createClient } from '@/lib/supabase/server';
+
+const EXAM_LABELS: Record<string, string> = {
+  istqb: 'ISTQB CTFL',
+  git: 'Git',
+  'git-practico': 'Git Práctica',
+  performance: 'Performance',
+  'api-testing-fundamentals': 'API Testing Fundamentals',
+  'api-banking': 'API Testing Challenge',
+  'database-fundamentals': 'Bases de Datos — Fundamentos',
+  'database-practice': 'Bases de Datos — Práctica SQL',
+};
+
+const ISTQB_LEVEL_LABELS: Record<string, string> = {
+  ctfl: 'Foundation Level (CTFL)',
+  ctal_ta: 'Advanced Level — Test Analyst',
+  ctal_tm: 'Advanced Level — Test Manager',
+  ctal_tta: 'Advanced Level — Technical Test Analyst',
+  expert: 'Expert Level',
+  en_proceso: 'En proceso de certificación',
+};
+
+type PageProps = {
+  params: { id: string };
+};
+
+function getSafeExternalUrl(value: string | null | undefined) {
+  if (!value) return null;
+  try {
+    const url = new URL(value);
+    return url.protocol === 'https:' || url.protocol === 'http:'
+      ? url.toString()
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+export default async function TalentProfilePage({ params }: PageProps) {
+  const supabase = createClient();
+  const { data: profile } = await supabase
+    .from('profiles')
+    .select(
+      'id, display_name, email, role, country, istqb_level, github_profile, open_to_work, talent_visible_to_empresas'
+    )
+    .eq('id', params.id)
+    .eq('audience', 'candidato')
+    .maybeSingle();
+
+  if (!profile?.talent_visible_to_empresas) {
+    return (
+      <main className="min-h-screen bg-gray-50 px-4 py-12">
+        <div className="mx-auto max-w-2xl rounded-xl border border-gray-200 bg-white p-8 text-center">
+          <h1 className="text-2xl font-bold text-gray-900">
+            Perfil no disponible
+          </h1>
+          <p className="mt-2 text-sm text-gray-600">
+            Este candidato todavía no activó su visibilidad para empresas.
+          </p>
+          <Link
+            href="/empresa/candidatos"
+            className="mt-6 inline-flex rounded-lg bg-indigo-600 px-4 py-2 text-sm font-semibold text-white hover:bg-indigo-700"
+          >
+            Volver a candidatos
+          </Link>
+        </div>
+      </main>
+    );
+  }
+
+  const { data: results } = await supabase
+    .from('exam_results')
+    .select('id, exam_type, percentage, passed, created_at')
+    .eq('user_id', params.id)
+    .lte('percentage', 100)
+    .order('percentage', { ascending: false })
+    .limit(8);
+
+  const bestScore = results?.length ? Number(results[0].percentage ?? 0) : null;
+  const passedCount = (results ?? []).filter((result) => result.passed).length;
+  const githubUrl = getSafeExternalUrl(profile.github_profile);
+
+  return (
+    <main className="min-h-screen bg-gray-50 px-4 py-12">
+      <div className="mx-auto max-w-3xl space-y-6">
+        <Link
+          href="/empresa/candidatos"
+          className="text-sm text-gray-500 hover:text-gray-700"
+        >
+          ← Volver a candidatos
+        </Link>
+
+        <section className="rounded-xl border border-gray-200 bg-white p-6">
+          <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-wide text-indigo-600">
+                Talento QA AIQUAA
+              </p>
+              <h1 className="mt-1 text-3xl font-bold text-gray-900">
+                {profile.display_name || profile.email || 'Candidato QA'}
+              </h1>
+              <p className="mt-2 text-sm text-gray-600">
+                {[profile.role, profile.country].filter(Boolean).join(' · ') ||
+                  'Perfil QA'}
+              </p>
+              {profile.istqb_level && (
+                <p className="mt-1 text-sm text-gray-500">
+                  ISTQB:{' '}
+                  {ISTQB_LEVEL_LABELS[profile.istqb_level] ??
+                    profile.istqb_level}
+                </p>
+              )}
+              {profile.email && (
+                <p className="mt-1 text-sm text-gray-500">{profile.email}</p>
+              )}
+              {githubUrl && (
+                <a
+                  href={githubUrl}
+                  className="mt-2 inline-flex text-sm font-semibold text-indigo-600 hover:text-indigo-700"
+                  rel="noreferrer"
+                  target="_blank"
+                >
+                  Ver GitHub
+                </a>
+              )}
+            </div>
+            {profile.open_to_work && (
+              <span className="rounded-full bg-emerald-100 px-3 py-1 text-xs font-bold text-emerald-700">
+                Disponible para contacto
+              </span>
+            )}
+          </div>
+
+          <div className="mt-6 grid grid-cols-1 gap-3 sm:grid-cols-3">
+            <div className="rounded-lg border border-gray-200 bg-gray-50 p-4">
+              <p className="text-xs font-semibold uppercase text-gray-500">
+                Mejor score
+              </p>
+              <p className="mt-1 text-2xl font-bold text-indigo-600">
+                {bestScore != null ? `${bestScore}%` : '—'}
+              </p>
+            </div>
+            <div className="rounded-lg border border-gray-200 bg-gray-50 p-4">
+              <p className="text-xs font-semibold uppercase text-gray-500">
+                Evaluaciones
+              </p>
+              <p className="mt-1 text-2xl font-bold text-gray-900">
+                {results?.length ?? 0}
+              </p>
+            </div>
+            <div className="rounded-lg border border-gray-200 bg-gray-50 p-4">
+              <p className="text-xs font-semibold uppercase text-gray-500">
+                Aprobadas
+              </p>
+              <p className="mt-1 text-2xl font-bold text-emerald-600">
+                {passedCount}
+              </p>
+            </div>
+          </div>
+        </section>
+
+        <section className="rounded-xl border border-gray-200 bg-white p-6">
+          <h2 className="text-base font-semibold text-gray-900">
+            Evidencia de evaluaciones
+          </h2>
+          <div className="mt-4 divide-y divide-gray-100">
+            {(results ?? []).length === 0 ? (
+              <p className="py-6 text-sm text-gray-500">
+                Sin evaluaciones visibles todavía.
+              </p>
+            ) : (
+              (results ?? []).map((result) => (
+                <div
+                  key={result.id}
+                  className="flex items-center justify-between gap-4 py-3"
+                >
+                  <div>
+                    <p className="text-sm font-semibold text-gray-900">
+                      {EXAM_LABELS[result.exam_type] ?? result.exam_type}
+                    </p>
+                    <p className="text-xs text-gray-500">
+                      {new Date(result.created_at).toLocaleDateString('es-PY')}
+                    </p>
+                  </div>
+                  <div className="text-right">
+                    <p className="text-lg font-bold text-indigo-600">
+                      {Number(result.percentage ?? 0)}%
+                    </p>
+                    <p
+                      className={`text-xs font-semibold ${result.passed ? 'text-emerald-600' : 'text-red-500'}`}
+                    >
+                      {result.passed ? 'Aprobado' : 'No aprobado'}
+                    </p>
+                  </div>
+                </div>
+              ))
+            )}
+          </div>
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/supabase/migrations/20260625_020000_candidate_talent_directory.sql
+++ b/supabase/migrations/20260625_020000_candidate_talent_directory.sql
@@ -1,0 +1,9 @@
+-- Candidate opt-in fields for the empresa talent directory.
+ALTER TABLE public.profiles
+  ADD COLUMN IF NOT EXISTS open_to_work BOOLEAN NOT NULL DEFAULT false,
+  ADD COLUMN IF NOT EXISTS talent_visible_to_empresas BOOLEAN NOT NULL DEFAULT false,
+  ADD COLUMN IF NOT EXISTS istqb_level TEXT,
+  ADD COLUMN IF NOT EXISTS github_profile TEXT;
+
+CREATE INDEX IF NOT EXISTS profiles_talent_directory_idx
+  ON public.profiles (talent_visible_to_empresas, open_to_work, audience, istqb_level);


### PR DESCRIPTION
## Summary
- Reworks `/empresa/candidatos` into a clearer “Candidatos y talento QA” workspace with tabs for evaluated candidates, opt-in talent directory, and shortlist.
- Adds persistent empresa favorites/shortlist UI backed by `empresa_favoritos`, including save/remove actions from both directory and evaluated results.
- Adds candidate actions: contact by email, open public talent profile, and compare 2-4 candidates side by side.
- Adds candidate opt-in controls in `/perfil` and stores `open_to_work`, `talent_visible_to_empresas`, `istqb_level`, and `github_profile` in `profiles`.
- Adds `/talento/[id]` public profile view gated by the candidate visibility opt-in.
- Updates the empresa dashboard copy so it no longer promises only “candidatos evaluados”.

## Root Cause
The empresa candidates page only represented exam results from the company’s own process codes, but the B2B product promise implied recruiters could discover available QA talent and manage a shortlist. The existing `empresa_favoritos` table had no UI, and candidates had no opt-in visibility flag for recruiter discovery.

## Validation
- `pnpm --filter @aiquaa/frontend test -- src/app/empresa/candidatos/__tests__/candidateDirectory.test.ts`
- `pnpm --filter @aiquaa/frontend type-check`
- `pnpm --filter @aiquaa/frontend lint` (passes with existing warnings)
- pre-commit lint-staged/typecheck
- pre-push type-check
- Local dev server smoke check: `/empresa/candidatos` redirects to login as expected without session; `/talento/test-user` returns 200.

Fixes #159