### PR TITLE
fix(empresa): mark invitacion as completada after exam submission

### DIFF
--- a/apps/frontend/src/actions/exams.ts
+++ b/apps/frontend/src/actions/exams.ts
@@ -84,6 +84,29 @@ export async function saveExamResultAction(payload: SaveExamResultPayload) {
   });
 
   if (error) return { error: error.message };
+
+  // Mark empresa_invitacion as completada when exam is submitted with a process code
+  if (payload.process_code && resolvedEmail) {
+    try {
+      const { data: process } = await supabase
+        .from('hiring_processes')
+        .select('id')
+        .eq('code', payload.process_code)
+        .maybeSingle();
+
+      if (process?.id) {
+        await supabase
+          .from('empresa_invitaciones')
+          .update({ status: 'completada', completed_at: new Date().toISOString() })
+          .eq('candidate_email', resolvedEmail)
+          .eq('process_id', process.id)
+          .in('status', ['pendiente', 'vista']);
+      }
+    } catch (invErr) {
+      console.warn('[empresa-invitaciones] update to completada failed', invErr);
+    }
+  }
+
   try {
     await syncRankingAchievementsForUser(user.id);
   } catch (achievementError) {


### PR DESCRIPTION
## Summary

- After a candidate submits any exam with a `process_code`, `saveExamResultAction` now looks up the matching `hiring_process` and updates the corresponding `empresa_invitacion` (status `pendiente` or `vista`) to `completada` with `completed_at = now()`
- Failure to update the invitation is caught and logged as a warning — it never blocks exam result saving
- Covers both assessment-type exams (via `assessments.ts → saveExamResultAction`) and labs exams (git, ISTQB, performance, etc.)

## Test plan

- [ ] Candidate opens invitation link (`/invitacion/[token]`) → status becomes `vista`
- [ ] Candidate signs in and submits exam using the process code
- [ ] Empresa dashboard (`/empresa/invitaciones`) shows the invitation as **completada**
- [ ] Completion rate metric shows > 0%
- [ ] Submitting an exam **without** a process code leaves invitaciones unchanged

Closes #174

🤖 Generated with [Claude Code](https://claude.com/claude-code)