### PR TITLE
feat(assessments): examen teórico Infraestructura — Fundamentos (Docker + Kubernetes)

### DIFF
--- a/apps/frontend/src/actions/employer.ts
+++ b/apps/frontend/src/actions/employer.ts
@@ -354,9 +354,10 @@ function getAttemptTimeSpentSeconds(row: {
   return Math.max(0, Math.round((submitted - started) / 1000));
 }
 
-const DATABASE_ASSESSMENT_SLUGS = [
+const PROCESS_ASSESSMENT_SLUGS = [
   'database-fundamentals',
   'database-practice',
+  'infrastructure-fundamentals',
 ];
 
 async function fetchAssessmentAttemptsForProcessCodes(
@@ -373,7 +374,7 @@ async function fetchAssessmentAttemptsForProcessCodes(
     .or(
       processCodes.map((code) => `metadata->>processCode.eq.${code}`).join(',')
     )
-    .in('assessments.slug', DATABASE_ASSESSMENT_SLUGS)
+    .in('assessments.slug', PROCESS_ASSESSMENT_SLUGS)
     .eq('status', 'graded');
 
   if (error) return { data: [], error: error.message };
@@ -527,14 +528,19 @@ export async function getEmpresaDashboardStatsAction(): Promise<{
         .single()
     : Promise.resolve({ data: null, error: null });
 
-  const [resultsResp, prospectsResp, invitacionesResp, funnelResp, profileViewsResp] =
-    await Promise.all([
-      fetchEmpresaResultsForProcessCodes(supabase, processCodes),
-      fetchPendingProspects,
-      fetchPendingInvitaciones,
-      fetchInvitacionesFunnel,
-      fetchProfileViews,
-    ]);
+  const [
+    resultsResp,
+    prospectsResp,
+    invitacionesResp,
+    funnelResp,
+    profileViewsResp,
+  ] = await Promise.all([
+    fetchEmpresaResultsForProcessCodes(supabase, processCodes),
+    fetchPendingProspects,
+    fetchPendingInvitaciones,
+    fetchInvitacionesFunnel,
+    fetchProfileViews,
+  ]);
 
   if (resultsResp.error) return { error: resultsResp.error, data: null };
 

--- a/apps/frontend/src/actions/exams.ts
+++ b/apps/frontend/src/actions/exams.ts
@@ -17,7 +17,8 @@ interface SaveExamResultPayload {
     | 'api-testing-fundamentals'
     | 'api-banking'
     | 'database-fundamentals'
-    | 'database-practice';
+    | 'database-practice'
+    | 'infrastructure-fundamentals';
   exam_mode: 'exam' | 'training';
   participant_name?: string;
   participant_email?: string;
@@ -97,13 +98,19 @@ export async function saveExamResultAction(payload: SaveExamResultPayload) {
       if (process?.id) {
         await supabase
           .from('empresa_invitaciones')
-          .update({ status: 'completada', completed_at: new Date().toISOString() })
+          .update({
+            status: 'completada',
+            completed_at: new Date().toISOString(),
+          })
           .eq('candidate_email', resolvedEmail)
           .eq('process_id', process.id)
           .in('status', ['pendiente', 'vista']);
       }
     } catch (invErr) {
-      console.warn('[empresa-invitaciones] update to completada failed', invErr);
+      console.warn(
+        '[empresa-invitaciones] update to completada failed',
+        invErr
+      );
     }
   }
 
@@ -127,7 +134,8 @@ export async function getLeaderboardAction(
     | 'api-testing-fundamentals'
     | 'api-banking'
     | 'database-fundamentals'
-    | 'database-practice',
+    | 'database-practice'
+    | 'infrastructure-fundamentals',
   limit = 20
 ) {
   const supabase = createClient();

--- a/apps/frontend/src/app/assessments/_shared/registry.ts
+++ b/apps/frontend/src/app/assessments/_shared/registry.ts
@@ -25,6 +25,15 @@ import {
   buildDatabasePracticeGamificationEvents,
 } from '../database-practice/lib/gamification';
 import { ensureDatabasePracticeSeeded } from '../database-practice/lib/seed';
+import {
+  INFRASTRUCTURE_FUNDAMENTALS_SEED_VERSION,
+  INFRASTRUCTURE_FUNDAMENTALS_SLUG,
+} from '../infrastructure-fundamentals/data/assessment-definition';
+import {
+  INFRASTRUCTURE_FUNDAMENTALS_GAMIFICATION_RULES,
+  buildInfrastructureFundamentalsGamificationEvents,
+} from '../infrastructure-fundamentals/lib/gamification';
+import { ensureInfrastructureFundamentalsSeeded } from '../infrastructure-fundamentals/lib/seed';
 import type {
   AssessmentGamificationEvent,
   AssessmentGamificationRule,
@@ -33,7 +42,8 @@ import type {
 export type AssessmentExamType =
   | 'api-testing-fundamentals'
   | 'database-fundamentals'
-  | 'database-practice';
+  | 'database-practice'
+  | 'infrastructure-fundamentals';
 
 export interface AssessmentGamificationEventInput {
   attemptId: string;
@@ -85,5 +95,14 @@ export const ASSESSMENT_REGISTRY: Record<string, AssessmentRegistryEntry> = {
     gamificationSource: 'DATABASE_PRACTICE',
     gamificationRules: DATABASE_PRACTICE_GAMIFICATION_RULES,
     buildGamificationEvents: buildDatabasePracticeGamificationEvents,
+  },
+  [INFRASTRUCTURE_FUNDAMENTALS_SLUG]: {
+    slug: INFRASTRUCTURE_FUNDAMENTALS_SLUG,
+    seedVersion: INFRASTRUCTURE_FUNDAMENTALS_SEED_VERSION,
+    ensureSeeded: ensureInfrastructureFundamentalsSeeded,
+    examType: 'infrastructure-fundamentals',
+    gamificationSource: 'INFRASTRUCTURE_FUNDAMENTALS',
+    gamificationRules: INFRASTRUCTURE_FUNDAMENTALS_GAMIFICATION_RULES,
+    buildGamificationEvents: buildInfrastructureFundamentalsGamificationEvents,
   },
 };

--- a/apps/frontend/src/app/assessments/infrastructure-fundamentals/__tests__/definition.test.ts
+++ b/apps/frontend/src/app/assessments/infrastructure-fundamentals/__tests__/definition.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { assertAssessmentDefinitionConsistency } from '../../_shared/testing/assessment-definition-checks';
+import {
+  INFRASTRUCTURE_FUNDAMENTALS_SEED_VERSION,
+  INFRASTRUCTURE_FUNDAMENTALS_SLUG,
+  infrastructureFundamentalsDefinition,
+} from '../data/assessment-definition';
+import { ASSESSMENT_REGISTRY } from '../../_shared/registry';
+
+describe('infrastructure-fundamentals definition', () => {
+  it('mantiene presupuestos de puntos y answer keys consistentes', () => {
+    assertAssessmentDefinitionConsistency(infrastructureFundamentalsDefinition);
+  });
+
+  it('define 3 niveles teóricos sobre 100 puntos', () => {
+    expect(infrastructureFundamentalsDefinition.sections).toHaveLength(3);
+    expect(infrastructureFundamentalsDefinition.total_score).toBe(100);
+    expect(infrastructureFundamentalsDefinition.slug).toBe(
+      INFRASTRUCTURE_FUNDAMENTALS_SLUG
+    );
+  });
+
+  it('está registrado con el seedVersion correcto', () => {
+    const entry = ASSESSMENT_REGISTRY[INFRASTRUCTURE_FUNDAMENTALS_SLUG];
+    expect(entry).toBeDefined();
+    expect(entry.seedVersion).toBe(INFRASTRUCTURE_FUNDAMENTALS_SEED_VERSION);
+    expect(entry.examType).toBe('infrastructure-fundamentals');
+  });
+});

--- a/apps/frontend/src/app/assessments/infrastructure-fundamentals/data/assessment-definition.ts
+++ b/apps/frontend/src/app/assessments/infrastructure-fundamentals/data/assessment-definition.ts
@@ -1,0 +1,687 @@
+import type { AssessmentSeedDefinition } from '../../_shared/types';
+
+export const INFRASTRUCTURE_FUNDAMENTALS_SLUG = 'infrastructure-fundamentals';
+
+// Bumpear cuando cambie la definición (secciones/preguntas) para forzar re-seed.
+export const INFRASTRUCTURE_FUNDAMENTALS_SEED_VERSION = 1;
+
+export const infrastructureFundamentalsDefinition: AssessmentSeedDefinition = {
+  slug: INFRASTRUCTURE_FUNDAMENTALS_SLUG,
+  title: 'Infraestructura — Fundamentos',
+  description:
+    'Evaluación teórica de infraestructura para QA: contenedores e imágenes Docker, conceptos de Kubernetes y diferencias con otras tecnologías, y arquitectura de un clúster (control plane, nodos y pods).',
+  level: 'Junior a Semi Senior',
+  type: 'QA Infraestructura',
+  duration_minutes: 35,
+  total_score: 100,
+  is_active: true,
+  metadata: {
+    moduleName: 'AIQUAA Assessments / Infrastructure Fundamentals',
+    passingScore: 70,
+    candidateBands: [
+      { min: 0, max: 39, label: 'Inicial' },
+      { min: 40, max: 69, label: 'Junior en formación' },
+      { min: 70, max: 79, label: 'Junior' },
+      { min: 80, max: 89, label: 'Junior avanzado' },
+      { min: 90, max: 100, label: 'Semi Senior' },
+    ],
+  },
+  sections: [
+    {
+      slug: 'nivel-1-docker-basicos',
+      title: 'Nivel 1: Fundamentos de Docker',
+      description:
+        'Validá tu conocimiento sobre contenedores, imágenes, aislamiento, registries y las diferencias con las máquinas virtuales.',
+      order_index: 1,
+      max_score: 36,
+      metadata: {
+        instructions:
+          'Combinación de selección múltiple y verdadero/falso basada en la documentación oficial de Docker.',
+        suggestedMinutes: 12,
+      },
+      questions: [
+        {
+          question_type: 'multiple_choice',
+          prompt: '¿Qué describe mejor a un contenedor?',
+          options: [
+            {
+              label:
+                'Un proceso aislado con su propio sistema de archivos, que incluye todo lo necesario para ejecutar la aplicación',
+              value: 'a',
+            },
+            {
+              label:
+                'Una máquina virtual liviana con su propio sistema operativo completo',
+              value: 'b',
+            },
+            {
+              label: 'Un servidor físico dedicado a una sola aplicación',
+              value: 'c',
+            },
+            {
+              label: 'Un lenguaje de scripting para automatizar despliegues',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'a' },
+          explanation:
+            'Un contenedor es un proceso aislado del host, con su propio filesystem y dependencias empaquetadas. No es una VM: no virtualiza hardware ni trae un SO completo.',
+          points: 4,
+          order_index: 1,
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            '¿Cuál es la diferencia principal entre un contenedor y una máquina virtual?',
+          options: [
+            {
+              label:
+                'La VM virtualiza el hardware y corre un sistema operativo invitado completo; el contenedor comparte el kernel del host',
+              value: 'a',
+            },
+            {
+              label: 'El contenedor es más lento porque emula todo el hardware',
+              value: 'b',
+            },
+            {
+              label:
+                'La VM solo puede correr en la nube; el contenedor solo en local',
+              value: 'c',
+            },
+            {
+              label: 'No hay diferencia: contenedor y VM son sinónimos',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'a' },
+          explanation:
+            'Las VMs virtualizan una máquina completa con su propio SO. Los contenedores comparten el kernel del host y aíslan solo el proceso, por eso son más livianos y arrancan más rápido.',
+          points: 4,
+          order_index: 2,
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt: '¿Qué es una imagen Docker?',
+          options: [
+            {
+              label: 'Una captura de pantalla del estado del contenedor',
+              value: 'a',
+            },
+            {
+              label:
+                'Una plantilla de solo lectura con el filesystem, dependencias y configuración necesarios para crear contenedores',
+              value: 'b',
+            },
+            {
+              label: 'Un archivo de log generado al detener un contenedor',
+              value: 'c',
+            },
+            {
+              label: 'El disco duro virtual de una máquina virtual',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'b' },
+          explanation:
+            'La imagen es un paquete estandarizado e inmutable: incluye archivos, binarios, librerías y configuración. A partir de ella se crean los contenedores.',
+          points: 4,
+          order_index: 3,
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt: '¿Cuál es la relación entre una imagen y un contenedor?',
+          options: [
+            {
+              label: 'Son lo mismo: imagen y contenedor son intercambiables',
+              value: 'a',
+            },
+            {
+              label:
+                'La imagen se genera automáticamente al borrar el contenedor',
+              value: 'b',
+            },
+            {
+              label:
+                'El contenedor es una instancia en ejecución de una imagen; de una misma imagen pueden crearse varios contenedores',
+              value: 'c',
+            },
+            {
+              label: 'Cada contenedor solo puede ejecutarse una vez por imagen',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'c' },
+          explanation:
+            'La imagen es la plantilla; el contenedor es la instancia corriendo. Podés levantar múltiples contenedores desde la misma imagen, cada uno aislado.',
+          points: 4,
+          order_index: 4,
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt: '¿Qué es un registry (por ejemplo, Docker Hub)?',
+          options: [
+            {
+              label:
+                'Un repositorio centralizado para almacenar, versionar y distribuir imágenes de contenedores',
+              value: 'a',
+            },
+            {
+              label:
+                'Una base de datos donde los contenedores guardan sus logs',
+              value: 'b',
+            },
+            {
+              label: 'Un registro del kernel con los procesos aislados',
+              value: 'c',
+            },
+            {
+              label: 'El archivo de configuración principal de Docker',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'a' },
+          explanation:
+            'Un registry almacena y distribuye imágenes. Docker Hub es el registry público más usado; también existen registries privados para equipos y empresas.',
+          points: 4,
+          order_index: 5,
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            'Por defecto, ¿qué puede "ver" un contenedor del host donde se ejecuta?',
+          options: [
+            {
+              label: 'Todos los procesos y archivos del host',
+              value: 'a',
+            },
+            {
+              label:
+                'Nada del host: está aislado y no ve otros procesos ni archivos fuera de su propio filesystem',
+              value: 'b',
+            },
+            {
+              label: 'Solo los archivos del usuario que lo ejecutó',
+              value: 'c',
+            },
+            {
+              label: 'Los procesos de otros contenedores, pero no los del host',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'b' },
+          explanation:
+            'El aislamiento es la característica central: el contenedor no interactúa con procesos ni archivos del host salvo que se lo configure explícitamente (volúmenes, redes).',
+          points: 4,
+          order_index: 6,
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            '¿Por qué los contenedores resuelven el clásico problema de "en mi máquina funciona"?',
+          options: [
+            {
+              label:
+                'Porque obligan a todos los devs a usar el mismo sistema operativo',
+              value: 'a',
+            },
+            {
+              label: 'Porque eliminan la necesidad de dependencias externas',
+              value: 'b',
+            },
+            {
+              label: 'Porque solo se ejecutan en servidores de producción',
+              value: 'c',
+            },
+            {
+              label:
+                'Porque son autosuficientes y portables: incluyen todas sus dependencias y corren igual en cualquier entorno',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'd' },
+          explanation:
+            'El contenedor empaqueta la app con todas sus dependencias, sin depender de lo instalado en el host. La misma imagen corre igual en desarrollo, testing y producción.',
+          points: 4,
+          order_index: 7,
+        },
+        {
+          question_type: 'true_false',
+          prompt:
+            'Un contenedor incluye su propio kernel de sistema operativo.',
+          correct_answer: { value: false },
+          explanation:
+            'Los contenedores comparten el kernel del host. Solo empaquetan filesystem, librerías y binarios; por eso son mucho más livianos que una VM.',
+          points: 4,
+          order_index: 8,
+        },
+        {
+          question_type: 'true_false',
+          prompt:
+            'Las imágenes Docker son inmutables: para cambiar su contenido hay que construir una imagen nueva.',
+          correct_answer: { value: true },
+          explanation:
+            'Una imagen no se modifica en caliente: cualquier cambio implica un nuevo build (y normalmente un nuevo tag). Esto garantiza despliegues reproducibles.',
+          points: 4,
+          order_index: 9,
+        },
+      ],
+    },
+    {
+      slug: 'nivel-2-kubernetes-conceptos',
+      title: 'Nivel 2: Conceptos de Kubernetes',
+      description:
+        'Demostrá que entendés qué es Kubernetes, qué problemas resuelve, qué provee (y qué no), y en qué se diferencia de otras tecnologías.',
+      order_index: 2,
+      max_score: 32,
+      metadata: {
+        instructions:
+          'Preguntas conceptuales basadas en el overview oficial de Kubernetes: evolución del despliegue, capacidades y límites de la plataforma.',
+        suggestedMinutes: 11,
+      },
+      questions: [
+        {
+          question_type: 'multiple_choice',
+          prompt: '¿Qué es Kubernetes?',
+          options: [
+            {
+              label:
+                'Una plataforma portable y extensible para orquestar cargas de trabajo en contenedores, automatizando su despliegue y operación',
+              value: 'a',
+            },
+            {
+              label: 'Un hipervisor para crear máquinas virtuales',
+              value: 'b',
+            },
+            {
+              label: 'Un lenguaje de programación para microservicios',
+              value: 'c',
+            },
+            {
+              label: 'Una herramienta para construir imágenes de contenedores',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'a' },
+          explanation:
+            'Kubernetes orquesta contenedores: automatiza despliegue, escalado y operación de aplicaciones contenerizadas sobre un clúster de máquinas.',
+          points: 4,
+          order_index: 1,
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            'En la evolución del despliegue de aplicaciones (era tradicional → virtualización → contenedores), ¿qué problema resolvió la virtualización?',
+          options: [
+            {
+              label: 'Eliminó por completo la necesidad de servidores físicos',
+              value: 'a',
+            },
+            {
+              label:
+                'Permitió correr varias VMs aisladas sobre un mismo servidor físico, mejorando el uso de recursos frente a una app por servidor',
+              value: 'b',
+            },
+            {
+              label: 'Hizo que las aplicaciones compartieran el mismo kernel',
+              value: 'c',
+            },
+            {
+              label: 'Introdujo los registries de imágenes',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'b' },
+          explanation:
+            'En la era tradicional, una app acaparaba un servidor físico y los recursos se desperdiciaban. La virtualización permitió múltiples VMs aisladas por servidor, con mejor utilización y escalabilidad.',
+          points: 4,
+          order_index: 2,
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            '¿Por qué los contenedores se volvieron el estándar para desplegar aplicaciones frente a las VMs?',
+          options: [
+            {
+              label:
+                'Porque ofrecen mayor aislamiento de seguridad que las VMs',
+              value: 'a',
+            },
+            {
+              label:
+                'Porque cada contenedor incluye su propio sistema operativo',
+              value: 'b',
+            },
+            {
+              label:
+                'Porque son más livianos, arrancan rápido, usan imágenes inmutables y desacoplan la app de la infraestructura',
+              value: 'c',
+            },
+            {
+              label: 'Porque solo funcionan en la nube pública',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'c' },
+          explanation:
+            'Los contenedores comparten el kernel del host: son livianos, con builds e imágenes inmutables, despliegues consistentes entre entornos y mayor densidad de aplicaciones por máquina.',
+          points: 4,
+          order_index: 3,
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt: '¿Cuál de estas capacidades provee Kubernetes?',
+          options: [
+            {
+              label: 'Compilación y build automático del código fuente (CI/CD)',
+              value: 'a',
+            },
+            {
+              label:
+                'Service discovery, balanceo de carga, self-healing, rollouts/rollbacks automatizados y gestión de secrets y configuración',
+              value: 'b',
+            },
+            {
+              label: 'Bases de datos y middleware como servicios integrados',
+              value: 'c',
+            },
+            {
+              label: 'Un editor visual para diseñar interfaces de usuario',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'b' },
+          explanation:
+            'Kubernetes provee service discovery y load balancing, orquestación de almacenamiento, rollouts/rollbacks automatizados, bin packing, self-healing, gestión de secrets/config y escalado horizontal.',
+          points: 4,
+          order_index: 4,
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt: '¿Qué NO es Kubernetes?',
+          options: [
+            {
+              label: 'Una plataforma extensible mediante APIs declarativas',
+              value: 'a',
+            },
+            {
+              label: 'Un orquestador de contenedores multi-nodo',
+              value: 'b',
+            },
+            {
+              label: 'Un sistema con self-healing para cargas contenerizadas',
+              value: 'c',
+            },
+            {
+              label:
+                'Un PaaS tradicional todo-en-uno: no hace CI/CD, ni provee middleware o bases de datos como servicios integrados',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'd' },
+          explanation:
+            'Kubernetes no es un PaaS clásico: no despliega código fuente ni buildea la app, no provee middleware, bases de datos ni pipelines de CI/CD integrados, y no limita los tipos de aplicaciones soportadas.',
+          points: 4,
+          order_index: 5,
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            '¿Cuál es la diferencia entre usar Docker solo y usar Kubernetes?',
+          options: [
+            {
+              label:
+                'Docker crea y corre contenedores en un host; Kubernetes orquesta contenedores a través de un clúster de nodos: scheduling, escalado y recuperación ante fallos',
+              value: 'a',
+            },
+            {
+              label: 'Kubernetes reemplaza a los contenedores por VMs',
+              value: 'b',
+            },
+            {
+              label:
+                'Docker es para producción y Kubernetes solo para desarrollo local',
+              value: 'c',
+            },
+            {
+              label: 'Son productos idénticos de empresas distintas',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'a' },
+          explanation:
+            'Docker resuelve el empaquetado y ejecución de contenedores en una máquina. Kubernetes opera a nivel clúster: decide dónde corre cada contenedor, escala réplicas y reemplaza instancias caídas.',
+          points: 4,
+          order_index: 6,
+        },
+        {
+          question_type: 'true_false',
+          prompt:
+            'Kubernetes reemplaza a los contenedores: con Kubernetes ya no se usan tecnologías como Docker o containerd.',
+          correct_answer: { value: false },
+          explanation:
+            'Kubernetes orquesta contenedores, no los reemplaza: necesita un container runtime (como containerd) en cada nodo para ejecutarlos.',
+          points: 4,
+          order_index: 7,
+        },
+        {
+          question_type: 'true_false',
+          prompt:
+            'Si un contenedor falla, Kubernetes puede reiniciarlo o reemplazarlo automáticamente (self-healing).',
+          correct_answer: { value: true },
+          explanation:
+            'El self-healing es una capacidad central: Kubernetes reinicia contenedores que fallan, reemplaza Pods y no enruta tráfico hacia instancias que no están listas.',
+          points: 4,
+          order_index: 8,
+        },
+      ],
+    },
+    {
+      slug: 'nivel-3-kubernetes-arquitectura',
+      title: 'Nivel 3: Arquitectura de Kubernetes',
+      description:
+        'Demostrá que conocés los componentes de un clúster: control plane, nodos, kubelet, kube-proxy, container runtime y Pods.',
+      order_index: 3,
+      max_score: 32,
+      metadata: {
+        instructions:
+          'Preguntas conceptuales basadas en la documentación oficial de arquitectura de clúster de Kubernetes.',
+        suggestedMinutes: 12,
+      },
+      questions: [
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            '¿Cuáles son los componentes principales del control plane de Kubernetes?',
+          options: [
+            {
+              label: 'kubelet, kube-proxy y container runtime',
+              value: 'a',
+            },
+            {
+              label:
+                'kube-apiserver, etcd, kube-scheduler y kube-controller-manager',
+              value: 'b',
+            },
+            {
+              label: 'Docker Hub, containerd y CoreDNS',
+              value: 'c',
+            },
+            {
+              label: 'Ingress, Service y Deployment',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'b' },
+          explanation:
+            'El control plane gestiona el estado global del clúster: kube-apiserver (API), etcd (almacenamiento), kube-scheduler (asignación de Pods) y kube-controller-manager (controladores). kubelet y kube-proxy corren en los nodos.',
+          points: 4,
+          order_index: 1,
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt: '¿Cuál es el rol del kube-apiserver?',
+          options: [
+            {
+              label:
+                'Es el frontend del control plane: expone la API de Kubernetes por la que pasa toda la comunicación del clúster',
+              value: 'a',
+            },
+            {
+              label: 'Ejecuta los contenedores en los worker nodes',
+              value: 'b',
+            },
+            {
+              label: 'Almacena los datos persistentes de las aplicaciones',
+              value: 'c',
+            },
+            {
+              label: 'Distribuye imágenes a los registries',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'a' },
+          explanation:
+            'El kube-apiserver expone la API HTTP del clúster. kubectl, los nodos y los controladores interactúan con el clúster a través de él; está diseñado para escalar horizontalmente.',
+          points: 4,
+          order_index: 2,
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt: '¿Qué es etcd dentro de un clúster de Kubernetes?',
+          options: [
+            {
+              label: 'El agente que corre en cada nodo worker',
+              value: 'a',
+            },
+            {
+              label: 'El componente que balancea el tráfico entre Pods',
+              value: 'b',
+            },
+            {
+              label:
+                'Un almacén clave-valor consistente y de alta disponibilidad que guarda todo el estado del clúster',
+              value: 'c',
+            },
+            {
+              label: 'El sistema de logs centralizado del control plane',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'c' },
+          explanation:
+            'etcd es la fuente de verdad del clúster: un key-value store consistente donde Kubernetes persiste toda su configuración y estado. Por eso requiere backups.',
+          points: 4,
+          order_index: 3,
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt: '¿Qué hace el kube-scheduler?',
+          options: [
+            {
+              label: 'Programa tareas cron dentro de los contenedores',
+              value: 'a',
+            },
+            {
+              label:
+                'Detecta Pods recién creados sin nodo asignado y elige en qué nodo deben ejecutarse según recursos y restricciones',
+              value: 'b',
+            },
+            {
+              label: 'Reinicia los contenedores que fallan en cada nodo',
+              value: 'c',
+            },
+            {
+              label: 'Define los horarios de mantenimiento del clúster',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'b' },
+          explanation:
+            'El scheduler decide la asignación Pod → nodo considerando recursos disponibles, afinidades, taints/tolerations y otras restricciones. No ejecuta los contenedores.',
+          points: 4,
+          order_index: 4,
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            '¿Qué componentes corren en cada nodo worker y cuál es su función?',
+          options: [
+            {
+              label:
+                'etcd para guardar el estado y kube-scheduler para asignar Pods',
+              value: 'a',
+            },
+            {
+              label:
+                'Solo el container runtime: los nodos no necesitan agentes',
+              value: 'b',
+            },
+            {
+              label:
+                'kube-controller-manager para reconciliar el estado y kube-apiserver para exponer la API',
+              value: 'c',
+            },
+            {
+              label:
+                'kubelet (garantiza que los contenedores de los Pods estén corriendo) y kube-proxy (reglas de red para los Services)',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'd' },
+          explanation:
+            'Cada nodo corre kubelet (agente que asegura que los contenedores descritos en los PodSpecs estén sanos y corriendo), kube-proxy (reglas de red para Services) y un container runtime.',
+          points: 4,
+          order_index: 5,
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt: '¿Qué es un Pod?',
+          options: [
+            {
+              label: 'Un nodo físico del clúster',
+              value: 'a',
+            },
+            {
+              label:
+                'La unidad mínima desplegable en Kubernetes: uno o más contenedores que comparten red y almacenamiento',
+              value: 'b',
+            },
+            {
+              label: 'Una copia de seguridad de etcd',
+              value: 'c',
+            },
+            {
+              label: 'El archivo YAML donde se define un Deployment',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'b' },
+          explanation:
+            'El Pod es la unidad mínima que Kubernetes despliega y gestiona. Sus contenedores comparten IP, red y volúmenes, y se programan juntos en el mismo nodo.',
+          points: 4,
+          order_index: 6,
+        },
+        {
+          question_type: 'true_false',
+          prompt:
+            'El container runtime (por ejemplo, containerd) corre en cada worker node del clúster.',
+          correct_answer: { value: true },
+          explanation:
+            'Cada nodo necesita un container runtime para ejecutar los contenedores de los Pods. Kubernetes se integra con runtimes compatibles con CRI, como containerd o CRI-O.',
+          points: 4,
+          order_index: 7,
+        },
+        {
+          question_type: 'true_false',
+          prompt:
+            'El kube-scheduler ejecuta directamente los contenedores en los nodos.',
+          correct_answer: { value: false },
+          explanation:
+            'El scheduler solo decide en qué nodo va cada Pod. La ejecución la realizan el kubelet y el container runtime de ese nodo.',
+          points: 4,
+          order_index: 8,
+        },
+      ],
+    },
+  ],
+};

--- a/apps/frontend/src/app/assessments/infrastructure-fundamentals/lib/gamification.ts
+++ b/apps/frontend/src/app/assessments/infrastructure-fundamentals/lib/gamification.ts
@@ -1,0 +1,16 @@
+import { createAssessmentGamification } from '../../_shared/lib/gamification';
+
+const gamification = createAssessmentGamification({
+  prefix: 'INFRASTRUCTURE_FUNDAMENTALS',
+  descriptions: {
+    completed: 'Completar el assessment Infrastructure Fundamentals',
+    passed: 'Aprobar el assessment Infrastructure Fundamentals (score >= 70)',
+    highScore: 'Score sobresaliente en Infrastructure Fundamentals (>= 90)',
+  },
+});
+
+export const INFRASTRUCTURE_FUNDAMENTALS_GAMIFICATION_RULES =
+  gamification.rules;
+
+export const buildInfrastructureFundamentalsGamificationEvents =
+  gamification.buildEvents;

--- a/apps/frontend/src/app/assessments/infrastructure-fundamentals/lib/seed.ts
+++ b/apps/frontend/src/app/assessments/infrastructure-fundamentals/lib/seed.ts
@@ -1,0 +1,12 @@
+import { ensureAssessmentSeeded } from '../../_shared/lib/seed';
+import {
+  INFRASTRUCTURE_FUNDAMENTALS_SEED_VERSION,
+  infrastructureFundamentalsDefinition,
+} from '../data/assessment-definition';
+
+export async function ensureInfrastructureFundamentalsSeeded() {
+  return ensureAssessmentSeeded(
+    infrastructureFundamentalsDefinition,
+    INFRASTRUCTURE_FUNDAMENTALS_SEED_VERSION
+  );
+}

--- a/apps/frontend/src/app/assessments/infrastructure-fundamentals/page.tsx
+++ b/apps/frontend/src/app/assessments/infrastructure-fundamentals/page.tsx
@@ -1,0 +1,91 @@
+import { Metadata } from 'next';
+import { infrastructureFundamentalsDefinition } from './data/assessment-definition';
+import AssessmentWelcome from '../_shared/components/AssessmentWelcome';
+
+export const metadata: Metadata = {
+  title: 'Infraestructura — Fundamentos | AIQUAA',
+  description:
+    'Prueba técnica teórica sobre contenedores Docker, conceptos de Kubernetes y arquitectura de clúster: control plane, nodos y pods.',
+  keywords: [
+    'infraestructura',
+    'Docker',
+    'contenedores',
+    'Kubernetes',
+    'orquestación',
+    'control plane',
+    'pods',
+    'QA',
+    'testing',
+    'AIQUAA',
+    'evaluación técnica',
+    'DevOps',
+  ],
+  openGraph: {
+    title: 'Infraestructura — Fundamentos | AIQUAA',
+    description:
+      'Prueba técnica teórica sobre contenedores Docker, conceptos de Kubernetes y arquitectura de clúster.',
+    url: 'https://aiquaa.com/assessments/infrastructure-fundamentals',
+    siteName: 'AIQUAA',
+    type: 'website',
+    locale: 'es_PY',
+    images: [
+      {
+        url: '/api/og?title=Infraestructura%20-%20Fundamentos&subtitle=Docker%20y%20Kubernetes%20para%20QA&section=Assessments',
+        width: 1200,
+        height: 630,
+        alt: 'Infraestructura Fundamentos - AIQUAA',
+      },
+    ],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Infraestructura — Fundamentos | AIQUAA',
+    description: 'Prueba técnica sobre Docker y arquitectura de Kubernetes.',
+    images: [
+      '/api/og?title=Infraestructura%20-%20Fundamentos&subtitle=Docker%20y%20Kubernetes&section=Assessments',
+    ],
+    creator: '@stevenayal',
+  },
+  alternates: {
+    canonical: 'https://aiquaa.com/assessments/infrastructure-fundamentals',
+  },
+};
+
+export default function InfrastructureFundamentalsPage() {
+  const overview = {
+    assessment: {
+      id: 'static-infrastructure-fundamentals',
+      slug: infrastructureFundamentalsDefinition.slug,
+      title: infrastructureFundamentalsDefinition.title,
+      description: infrastructureFundamentalsDefinition.description,
+      level: infrastructureFundamentalsDefinition.level,
+      type: infrastructureFundamentalsDefinition.type,
+      duration_minutes: infrastructureFundamentalsDefinition.duration_minutes,
+      total_score: infrastructureFundamentalsDefinition.total_score,
+      is_active: infrastructureFundamentalsDefinition.is_active,
+      metadata: infrastructureFundamentalsDefinition.metadata,
+    },
+    sections: infrastructureFundamentalsDefinition.sections.map(
+      (section, index) => ({
+        id: `static-section-${index + 1}`,
+        assessment_id: 'static-infrastructure-fundamentals',
+        slug: section.slug,
+        title: section.title,
+        description: section.description,
+        order_index: section.order_index,
+        max_score: section.max_score,
+        metadata: section.metadata,
+      })
+    ),
+  };
+
+  return (
+    <AssessmentWelcome
+      overview={overview}
+      startHref="/assessments/infrastructure-fundamentals/start"
+      evaluatesCopy="Contenedores vs VMs, imágenes, aislamiento, registries; qué es Kubernetes, qué provee y qué no, diferencias vs otras tecnologías; arquitectura: control plane, nodos y pods."
+      scoringCopy="Automático en los 3 niveles: selección múltiple y verdadero/falso."
+      resultCopy="Score total, score por nivel, fortalezas, debilidades y temas a reforzar."
+    />
+  );
+}

--- a/apps/frontend/src/app/assessments/infrastructure-fundamentals/result/page.tsx
+++ b/apps/frontend/src/app/assessments/infrastructure-fundamentals/result/page.tsx
@@ -1,0 +1,19 @@
+import { Suspense } from 'react';
+import AssessmentResultClient from '../../_shared/components/AssessmentResultClient';
+
+export default function InfrastructureFundamentalsResultPage() {
+  return (
+    <Suspense
+      fallback={
+        <div className="min-h-screen flex items-center justify-center bg-slate-950">
+          <div className="h-10 w-10 animate-spin rounded-full border-t-2 border-cyan-400" />
+        </div>
+      }
+    >
+      <AssessmentResultClient
+        startHref="/assessments/infrastructure-fundamentals/start"
+        fallbackRecommendation="Repasá los conceptos de contenedores y la arquitectura de Kubernetes en la documentación oficial de Docker y Kubernetes."
+      />
+    </Suspense>
+  );
+}

--- a/apps/frontend/src/app/assessments/infrastructure-fundamentals/section/[sectionId]/page.tsx
+++ b/apps/frontend/src/app/assessments/infrastructure-fundamentals/section/[sectionId]/page.tsx
@@ -1,0 +1,9 @@
+'use client';
+
+import AssessmentSectionScreen from '../../../_shared/components/AssessmentSectionScreen';
+
+export default function InfrastructureFundamentalsSectionPage() {
+  return (
+    <AssessmentSectionScreen basePath="/assessments/infrastructure-fundamentals" />
+  );
+}

--- a/apps/frontend/src/app/assessments/infrastructure-fundamentals/start/page.tsx
+++ b/apps/frontend/src/app/assessments/infrastructure-fundamentals/start/page.tsx
@@ -1,0 +1,133 @@
+'use client';
+
+import { useEffect, useState, useTransition } from 'react';
+import { useRouter } from 'next/navigation';
+import { useTheme } from '@/contexts/ThemeContext';
+import { startAssessmentAttemptAction } from '@/actions/assessments';
+import ProcessCodeInput from '@/components/labs/ProcessCodeInput';
+import { INFRASTRUCTURE_FUNDAMENTALS_SLUG } from '../data/assessment-definition';
+
+export default function StartInfrastructureFundamentalsPage() {
+  const router = useRouter();
+  const { isDarkMode } = useTheme();
+  const [processCode, setProcessCode] = useState('');
+  const [error, setError] = useState('');
+  const [isPending, startTransition] = useTransition();
+
+  // Pre-fill desde ?code= (links de invitaciones/procesos de empresa)
+  useEffect(() => {
+    const codeParam = new URLSearchParams(window.location.search).get('code');
+    if (codeParam) setProcessCode(codeParam);
+  }, []);
+
+  function handleStart() {
+    setError('');
+    startTransition(async () => {
+      try {
+        const result = await startAssessmentAttemptAction({
+          slug: INFRASTRUCTURE_FUNDAMENTALS_SLUG,
+          processCode,
+        });
+
+        if ('error' in result) {
+          setError(result.error);
+          return;
+        }
+
+        const { attempt, sectionSlug } = result;
+
+        if (!sectionSlug) {
+          setError('No se encontró la primera sección del assessment.');
+          return;
+        }
+
+        router.push(
+          `/assessments/infrastructure-fundamentals/section/${sectionSlug}?attempt=${attempt.id}`
+        );
+      } catch (startError) {
+        setError(
+          startError instanceof Error
+            ? startError.message
+            : 'No se pudo iniciar el assessment.'
+        );
+      }
+    });
+  }
+
+  return (
+    <div
+      className={`min-h-screen px-4 py-12 ${
+        isDarkMode ? 'bg-slate-950 text-white' : 'bg-slate-50 text-slate-900'
+      }`}
+    >
+      <div className="mx-auto max-w-3xl rounded-3xl border border-slate-800 bg-slate-900/80 p-8 text-slate-50 shadow-2xl shadow-cyan-950/20">
+        <p className="text-sm font-semibold uppercase tracking-[0.18em] text-cyan-200">
+          Preparación del intento
+        </p>
+        <h1 className="mt-3 text-3xl font-bold">
+          Infraestructura — Fundamentos
+        </h1>
+        <p className="mt-3 text-slate-300">
+          Vas a completar 3 niveles teóricos con autosave, scoring por sección y
+          resultado final consolidado.
+        </p>
+
+        <div className="mt-8 grid gap-4 rounded-2xl border border-slate-800 bg-slate-950/70 p-5 md:grid-cols-3">
+          <div>
+            <p className="text-xs uppercase tracking-[0.18em] text-slate-400">
+              Duración sugerida
+            </p>
+            <p className="mt-2 text-lg font-semibold">~35 minutos</p>
+          </div>
+          <div>
+            <p className="text-xs uppercase tracking-[0.18em] text-slate-400">
+              Modalidad
+            </p>
+            <p className="mt-2 text-lg font-semibold">Conceptual</p>
+          </div>
+          <div>
+            <p className="text-xs uppercase tracking-[0.18em] text-slate-400">
+              Resultado
+            </p>
+            <p className="mt-2 text-lg font-semibold">Score total sobre 100</p>
+          </div>
+        </div>
+
+        <div className="mt-8">
+          <ProcessCodeInput
+            value={processCode}
+            onChange={setProcessCode}
+            onNormalizedCode={setProcessCode}
+            autoValidate
+          />
+        </div>
+
+        {error ? (
+          <div className="mt-6 rounded-2xl border border-red-500/30 bg-red-500/10 px-4 py-3 text-sm text-red-200">
+            {error}
+          </div>
+        ) : null}
+
+        <div className="mt-8 flex flex-col gap-3 sm:flex-row">
+          <button
+            type="button"
+            onClick={handleStart}
+            disabled={isPending}
+            className="inline-flex items-center justify-center rounded-2xl bg-cyan-400 px-5 py-3 text-sm font-semibold text-slate-950 transition hover:bg-cyan-300 disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {isPending ? 'Preparando intento...' : 'Iniciar o reanudar'}
+          </button>
+          <button
+            type="button"
+            onClick={() =>
+              router.push('/assessments/infrastructure-fundamentals')
+            }
+            className="inline-flex items-center justify-center rounded-2xl border border-slate-700 px-5 py-3 text-sm font-semibold text-slate-200 transition hover:bg-slate-800"
+          >
+            Volver al overview
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/src/app/assessments/page.tsx
+++ b/apps/frontend/src/app/assessments/page.tsx
@@ -2,10 +2,11 @@ import Link from 'next/link';
 import { apiTestingFundamentalsDefinition } from './api-testing-fundamentals/data/assessment-definition';
 import { databaseFundamentalsDefinition } from './database-fundamentals/data/assessment-definition';
 import { databasePracticeDefinition } from './database-practice/data/assessment-definition';
+import { infrastructureFundamentalsDefinition } from './infrastructure-fundamentals/data/assessment-definition';
 
 export default function AssessmentsIndexPage() {
   const overview = apiTestingFundamentalsDefinition;
-  const databaseAssessments = [
+  const assessmentCards = [
     {
       definition: databaseFundamentalsDefinition,
       badge: 'Examen teórico · Auto-corregido',
@@ -19,6 +20,13 @@ export default function AssessmentsIndexPage() {
       badgeColor: 'text-emerald-300',
       accentColor: 'text-emerald-200',
       buttonClass: 'bg-emerald-500 hover:bg-emerald-400',
+    },
+    {
+      definition: infrastructureFundamentalsDefinition,
+      badge: 'Examen teórico · Auto-corregido',
+      badgeColor: 'text-amber-300',
+      accentColor: 'text-sky-200',
+      buttonClass: 'bg-sky-500 hover:bg-sky-400',
     },
   ];
 
@@ -93,8 +101,8 @@ export default function AssessmentsIndexPage() {
             </div>
           </div>
 
-          {/* Database Fundamentals + Database Practice */}
-          {databaseAssessments.map((card) => (
+          {/* Database Fundamentals + Database Practice + Infrastructure Fundamentals */}
+          {assessmentCards.map((card) => (
             <div
               key={card.definition.slug}
               className="rounded-3xl border border-slate-800 bg-slate-900/80 p-8 shadow-2xl shadow-cyan-950/20"

--- a/apps/frontend/src/app/dashboard/page.tsx
+++ b/apps/frontend/src/app/dashboard/page.tsx
@@ -80,6 +80,7 @@ export default function DashboardPage() {
     'api-banking',
     'database-fundamentals',
     'database-practice',
+    'infrastructure-fundamentals',
   ];
   const recommended = allTypes.find((t) => !passedTypes.has(t)) ?? null;
   const allPassed = allTypes.every((t) => passedTypes.has(t));

--- a/apps/frontend/src/app/employer/[code]/page.tsx
+++ b/apps/frontend/src/app/employer/[code]/page.tsx
@@ -20,6 +20,7 @@ const EXAM_LABELS: Record<string, string> = {
   'api-banking': 'API Testing Challenge',
   'database-fundamentals': 'Bases de Datos — Fundamentos',
   'database-practice': 'Bases de Datos — Práctica SQL',
+  'infrastructure-fundamentals': 'Infraestructura — Fundamentos',
 };
 
 function formatTime(seconds: number) {

--- a/apps/frontend/src/app/employer/nuevo/page.tsx
+++ b/apps/frontend/src/app/employer/nuevo/page.tsx
@@ -20,6 +20,10 @@ const EXAM_OPTIONS = [
   { value: 'api-banking', label: 'API Testing - Challenge practico' },
   { value: 'database-fundamentals', label: 'Bases de Datos — Fundamentos' },
   { value: 'database-practice', label: 'Bases de Datos — Práctica SQL' },
+  {
+    value: 'infrastructure-fundamentals',
+    label: 'Infraestructura — Fundamentos',
+  },
 ];
 
 export default function NuevoProcesoPage() {

--- a/apps/frontend/src/app/employer/page.tsx
+++ b/apps/frontend/src/app/employer/page.tsx
@@ -35,6 +35,7 @@ const EXAM_LABELS: Record<string, string> = {
   'api-banking': 'API Testing Challenge',
   'database-fundamentals': 'Bases de Datos — Fundamentos',
   'database-practice': 'Bases de Datos — Práctica SQL',
+  'infrastructure-fundamentals': 'Infraestructura — Fundamentos',
 };
 
 function formatDate(iso: string) {

--- a/apps/frontend/src/app/empresa/candidatos/page.tsx
+++ b/apps/frontend/src/app/empresa/candidatos/page.tsx
@@ -68,11 +68,13 @@ const EXAM_LABELS: Record<string, string> = {
   'api-banking': 'API Testing Challenge',
   'database-fundamentals': 'Bases de Datos — Fundamentos',
   'database-practice': 'Bases de Datos — Práctica SQL',
+  'infrastructure-fundamentals': 'Infraestructura — Fundamentos',
 };
 
 const DATABASE_ASSESSMENT_SLUGS = [
   'database-fundamentals',
   'database-practice',
+  'infrastructure-fundamentals',
 ];
 
 const ISTQB_LEVEL_LABELS: Record<string, string> = {
@@ -273,9 +275,7 @@ export default function CandidatosPage() {
         // #205: section breakdown for assessment_attempts lives in
         // assessment_scores (one row per section). Fetch and group by attempt
         // so recruiters see per-area performance, not just the total score.
-        const attemptIds = attemptRows
-          .map((r: any) => r.id)
-          .filter(Boolean);
+        const attemptIds = attemptRows.map((r: any) => r.id).filter(Boolean);
         const sectionScoresByAttempt: Record<string, SectionScore[]> = {};
         if (attemptIds.length > 0) {
           const { data: scoreRows } = await supabase
@@ -704,7 +704,9 @@ export default function CandidatosPage() {
 
   const availableCountries = useMemo(
     () =>
-      [...new Set(talentCandidates.map((c) => c.country).filter(Boolean))].sort() as string[],
+      [
+        ...new Set(talentCandidates.map((c) => c.country).filter(Boolean)),
+      ].sort() as string[],
     [talentCandidates]
   );
 
@@ -724,7 +726,15 @@ export default function CandidatosPage() {
 
   const exportCSV = () => {
     const rows = [
-      ['Nombre', 'Email', 'Examen', 'Puntaje', 'Estado', 'Código proceso', 'Fecha'],
+      [
+        'Nombre',
+        'Email',
+        'Examen',
+        'Puntaje',
+        'Estado',
+        'Código proceso',
+        'Fecha',
+      ],
       ...filtered.map((r) => [
         r.participant_name ?? '',
         r.participant_email ?? '',
@@ -757,7 +767,9 @@ export default function CandidatosPage() {
   const sendInvite = async () => {
     if (!inviteEmail) return;
     setInviteSending(true);
-    const { error } = await createInvitacionAction({ candidate_email: inviteEmail });
+    const { error } = await createInvitacionAction({
+      candidate_email: inviteEmail,
+    });
     setInviteSending(false);
     setInviteModalOpen(false);
     setInviteEmail(null);
@@ -1812,10 +1824,12 @@ export default function CandidatosPage() {
             >
               Invitar a evaluación
             </h3>
-            <p className={`text-sm ${isDarkMode ? 'text-slate-300' : 'text-gray-600'}`}>
+            <p
+              className={`text-sm ${isDarkMode ? 'text-slate-300' : 'text-gray-600'}`}
+            >
               Se enviará una invitación por email a{' '}
-              <span className="font-semibold">{inviteEmail}</span> con el link para
-              acceder a la evaluación.
+              <span className="font-semibold">{inviteEmail}</span> con el link
+              para acceder a la evaluación.
             </p>
             <div className="flex gap-2 pt-1">
               <button

--- a/apps/frontend/src/app/empresa/eventos/[id]/page.tsx
+++ b/apps/frontend/src/app/empresa/eventos/[id]/page.tsx
@@ -29,6 +29,7 @@ const EXAM_LABELS: Record<string, string> = {
   'api-banking': 'API Testing Practico',
   'database-fundamentals': 'BD Fundamentos',
   'database-practice': 'BD Práctica SQL',
+  'infrastructure-fundamentals': 'Infraestructura',
 };
 
 function getEffectiveStatus(

--- a/apps/frontend/src/app/empresa/procesos/[id]/page.tsx
+++ b/apps/frontend/src/app/empresa/procesos/[id]/page.tsx
@@ -112,6 +112,7 @@ const EXAM_LABELS: Record<string, string> = {
   'api-banking': 'API Testing Challenge',
   'database-fundamentals': 'Bases de Datos — Fundamentos',
   'database-practice': 'Bases de Datos — Práctica SQL',
+  'infrastructure-fundamentals': 'Infraestructura — Fundamentos',
 };
 
 const SOURCES = [

--- a/apps/frontend/src/app/empresa/procesos/nuevo/page.tsx
+++ b/apps/frontend/src/app/empresa/procesos/nuevo/page.tsx
@@ -59,6 +59,12 @@ const EXAM_OPTIONS = [
     description:
       'Predicción de resultados, detección de bugs en queries y escritura de SQL — auto-corregido, 100 pts',
   },
+  {
+    id: 'infrastructure-fundamentals',
+    label: 'Infraestructura — Fundamentos (Examen teórico)',
+    description:
+      'Contenedores Docker, conceptos de Kubernetes y arquitectura de clúster — auto-corregido, 3 niveles',
+  },
 ];
 
 function generateCode(positionName: string): string {

--- a/apps/frontend/src/app/invitacion/[token]/page.tsx
+++ b/apps/frontend/src/app/invitacion/[token]/page.tsx
@@ -11,6 +11,7 @@ const EXAM_LABELS: Record<string, string> = {
   'api-banking': 'API Testing Challenge',
   'database-fundamentals': 'Bases de Datos — Fundamentos',
   'database-practice': 'Bases de Datos — Práctica SQL',
+  'infrastructure-fundamentals': 'Infraestructura — Fundamentos',
 };
 
 const EXAM_URLS: Record<string, string> = {
@@ -21,6 +22,8 @@ const EXAM_URLS: Record<string, string> = {
   'api-banking': '/assessments/api-banking/start',
   'database-fundamentals': '/assessments/database-fundamentals/start',
   'database-practice': '/assessments/database-practice/start',
+  'infrastructure-fundamentals':
+    '/assessments/infrastructure-fundamentals/start',
 };
 
 function examHref(examType: string, code: string) {

--- a/apps/frontend/src/app/invitaciones/[token]/page.tsx
+++ b/apps/frontend/src/app/invitaciones/[token]/page.tsx
@@ -12,6 +12,7 @@ const EXAM_LABELS: Record<string, string> = {
   'api-banking': 'API Testing Challenge',
   'database-fundamentals': 'Bases de Datos — Fundamentos',
   'database-practice': 'Bases de Datos — Práctica SQL',
+  'infrastructure-fundamentals': 'Infraestructura — Fundamentos',
 };
 
 type Props = { params: Promise<{ token: string }> };

--- a/apps/frontend/src/app/perfil/page.tsx
+++ b/apps/frontend/src/app/perfil/page.tsx
@@ -36,7 +36,8 @@ interface ExamResultRow {
     | 'api-testing-fundamentals'
     | 'api-banking'
     | 'database-fundamentals'
-    | 'database-practice';
+    | 'database-practice'
+    | 'infrastructure-fundamentals';
   exam_mode: 'exam' | 'training';
   score: number;
   total_questions: number;

--- a/apps/frontend/src/app/ranking/page.tsx
+++ b/apps/frontend/src/app/ranking/page.tsx
@@ -56,7 +56,8 @@ type ExamSlug =
   | 'api-testing-fundamentals'
   | 'api-banking'
   | 'database-fundamentals'
-  | 'database-practice';
+  | 'database-practice'
+  | 'infrastructure-fundamentals';
 
 const EXAM_SLUGS: ExamSlug[] = [
   'git',
@@ -67,6 +68,7 @@ const EXAM_SLUGS: ExamSlug[] = [
   'api-banking',
   'database-fundamentals',
   'database-practice',
+  'infrastructure-fundamentals',
 ];
 
 interface Category {
@@ -122,6 +124,13 @@ const CATEGORIES: Category[] = [
     teorico: 'performance',
   },
   {
+    key: 'infraestructura',
+    label: 'Infraestructura',
+    emoji: '🐳',
+    color: 'from-blue-500 to-indigo-600',
+    teorico: 'infrastructure-fundamentals',
+  },
+  {
     key: 'comunidad',
     label: 'Comunidad',
     emoji: '🚀',
@@ -141,6 +150,7 @@ const EXAM_TAB_URLS: Record<string, string> = {
   'api-banking': '/assessments/api-banking',
   'database-fundamentals': '/assessments/database-fundamentals',
   'database-practice': '/assessments/database-practice',
+  'infrastructure-fundamentals': '/assessments/infrastructure-fundamentals',
 };
 
 const MEDAL = ['🥇', '🥈', '🥉'];
@@ -998,8 +1008,7 @@ export default function RankingPage() {
   const { user } = useSupabaseAuth();
   const searchParams = useSearchParams();
   const router = useRouter();
-  const [activeCategory, setActiveCategory] =
-    useState<CategoryKey>('database');
+  const [activeCategory, setActiveCategory] = useState<CategoryKey>('database');
   const [examData, setExamData] = useState<Record<string, LeaderboardEntry[]>>({
     git: [],
     'git-practico': [],
@@ -1009,6 +1018,7 @@ export default function RankingPage() {
     'api-banking': [],
     'database-fundamentals': [],
     'database-practice': [],
+    'infrastructure-fundamentals': [],
   });
   const [examLoading, setExamLoading] = useState<Record<string, boolean>>({
     git: true,
@@ -1019,6 +1029,7 @@ export default function RankingPage() {
     'api-banking': true,
     'database-fundamentals': true,
     'database-practice': true,
+    'infrastructure-fundamentals': true,
   });
   const [showWelcome, setShowWelcome] = useState(false);
 
@@ -1137,7 +1148,9 @@ export default function RankingPage() {
                 if (e.key === 'ArrowRight') {
                   setActiveCategory(keys[(idx + 1) % keys.length]);
                 } else if (e.key === 'ArrowLeft') {
-                  setActiveCategory(keys[(idx - 1 + keys.length) % keys.length]);
+                  setActiveCategory(
+                    keys[(idx - 1 + keys.length) % keys.length]
+                  );
                 }
               }}
               className={`flex-1 flex items-center justify-center gap-2 py-2.5 px-3 rounded-lg text-sm font-semibold transition-all min-w-[100px] ${

--- a/apps/frontend/src/app/talento/[id]/page.tsx
+++ b/apps/frontend/src/app/talento/[id]/page.tsx
@@ -10,6 +10,7 @@ const EXAM_LABELS: Record<string, string> = {
   'api-banking': 'API Testing Challenge',
   'database-fundamentals': 'Bases de Datos — Fundamentos',
   'database-practice': 'Bases de Datos — Práctica SQL',
+  'infrastructure-fundamentals': 'Infraestructura — Fundamentos',
 };
 
 const ISTQB_LEVEL_LABELS: Record<string, string> = {

--- a/apps/frontend/src/lib/exams.ts
+++ b/apps/frontend/src/lib/exams.ts
@@ -11,7 +11,8 @@ export type ExamType =
   | 'api-testing-fundamentals'
   | 'api-banking'
   | 'database-fundamentals'
-  | 'database-practice';
+  | 'database-practice'
+  | 'infrastructure-fundamentals';
 
 export interface ExamMeta {
   emoji: string;
@@ -57,6 +58,11 @@ export const EXAM_META: Record<ExamType, ExamMeta> = {
     label: 'Bases de Datos — Práctica SQL',
     href: '/assessments/database-practice',
   },
+  'infrastructure-fundamentals': {
+    emoji: '🐳',
+    label: 'Infraestructura — Fundamentos',
+    href: '/assessments/infrastructure-fundamentals',
+  },
 };
 
 export const EXAM_TYPES = Object.keys(EXAM_META) as ExamType[];
@@ -68,6 +74,7 @@ export const POINTS_BASED_TYPES = new Set<ExamType>([
   'api-banking',
   'database-fundamentals',
   'database-practice',
+  'infrastructure-fundamentals',
 ]);
 
 export interface ExamScoreFields {

--- a/apps/frontend/src/lib/labsCatalog.ts
+++ b/apps/frontend/src/lib/labsCatalog.ts
@@ -92,6 +92,17 @@ export const toolCategories: LabCategory[] = [
         featured: true,
         implementedDate: 'Jun 2026',
       },
+      {
+        id: 'infrastructure-fundamentals',
+        name: 'Infraestructura — Fundamentos',
+        description:
+          'Prueba técnica teórica sobre contenedores Docker, conceptos de Kubernetes y arquitectura de clúster: control plane, nodos y pods',
+        icon: '🐳',
+        color: 'from-blue-500 to-indigo-600',
+        href: '/assessments/infrastructure-fundamentals',
+        featured: true,
+        implementedDate: 'Jul 2026',
+      },
     ],
   },
   {

--- a/apps/frontend/src/lib/ranking-achievements.ts
+++ b/apps/frontend/src/lib/ranking-achievements.ts
@@ -46,11 +46,13 @@ const RANKED_EXAM_TYPES: ExamType[] = [
   'api-banking',
   'database-fundamentals',
   'database-practice',
+  'infrastructure-fundamentals',
 ];
 
 const ASSESSMENT_RANKING_TYPES = new Set<ExamType>([
   'database-fundamentals',
   'database-practice',
+  'infrastructure-fundamentals',
 ]);
 
 function isMissingAchievementsTableError(error: { code?: string } | null) {

--- a/supabase/migrations/20260702_010000_infrastructure_fundamentals.sql
+++ b/supabase/migrations/20260702_010000_infrastructure_fundamentals.sql
@@ -1,0 +1,41 @@
+-- Habilita el assessment de infraestructura (Docker + Kubernetes) en el
+-- ecosistema de resultados/ranking:
+-- 1. Amplía el CHECK de exam_results.exam_type con infrastructure-fundamentals
+--    (sin esto los inserts fallan en silencio).
+-- 2. Reglas XP para el assessment (espejo de database-fundamentals).
+
+-- 1. exam_results.exam_type
+ALTER TABLE public.exam_results
+  DROP CONSTRAINT IF EXISTS exam_results_exam_type_check;
+
+ALTER TABLE public.exam_results
+  ADD CONSTRAINT exam_results_exam_type_check
+  CHECK (
+    exam_type = ANY (
+      ARRAY[
+        'git'::text,
+        'git-practico'::text,
+        'istqb'::text,
+        'performance'::text,
+        'test-app'::text,
+        'api-testing-fundamentals'::text,
+        'api-banking'::text,
+        'database-fundamentals'::text,
+        'database-practice'::text,
+        'infrastructure-fundamentals'::text
+      ]
+    )
+  );
+
+-- 2. Reglas XP para el assessment de infraestructura
+INSERT INTO public.xp_rules (event_type, xp_amount, description, daily_limit, is_active)
+VALUES
+  ('INFRASTRUCTURE_FUNDAMENTALS_COMPLETED', 70, 'Completar el assessment Infrastructure Fundamentals', 3, true),
+  ('INFRASTRUCTURE_FUNDAMENTALS_PASSED', 120, 'Aprobar el assessment Infrastructure Fundamentals (score >= 70)', 3, true),
+  ('INFRASTRUCTURE_FUNDAMENTALS_HIGH_SCORE', 160, 'Score sobresaliente en Infrastructure Fundamentals (>= 90)', 3, true)
+ON CONFLICT (event_type) DO UPDATE SET
+  xp_amount = EXCLUDED.xp_amount,
+  description = EXCLUDED.description,
+  daily_limit = EXCLUDED.daily_limit,
+  is_active = EXCLUDED.is_active,
+  updated_at = now();


### PR DESCRIPTION
## Resumen

- Nuevo examen teórico `infrastructure-fundamentals` con 3 secciones (Docker básico, conceptos de Kubernetes/overview, arquitectura de clúster), 25 preguntas, 100 pts, passing 70%. Basado en la doc oficial de Docker y Kubernetes.
- Registrado en el catálogo de assessments, ranking (nuevo tab "Infraestructura"), dashboard/perfil, `/labs`, y los flujos de empresa (procesos, invitaciones, candidatos, eventos).
- Sigue el patrón existente de `database-fundamentals`: seed lazy e idempotente, gamificación (XP por completar/aprobar/score alto).

## Sin impacto en datos existentes

La única migración SQL (`20260702_010000_infrastructure_fundamentals.sql`) es puramente aditiva:
- Amplía el `CHECK` de `exam_results.exam_type` (DROP + ADD del mismo constraint con un valor más) — no toca filas existentes.
- Hace `INSERT ... ON CONFLICT DO UPDATE` de 3 reglas de XP nuevas — no borra ni modifica reglas existentes.

No hay `DELETE`, `TRUNCATE`, ni cambios de esquema destructivos. Ningún dato de estudiantes (resultados de exámenes, intentos, XP, perfiles) se ve afectado.

## Test plan

- [x] `vitest run` — 45 tests pasan (incluye 3 nuevos de la definición del assessment)
- [x] `tsc --noEmit` — sin errores
- [x] `eslint` sobre archivos tocados — sin errores nuevos
- [ ] Aplicar la migración en el proyecto Supabase real
- [ ] Verificar manualmente en dev: `/assessments` → card visible, completar el examen, ver resultado y tab "Infraestructura" en `/ranking`

🤖 Generated with [Claude Code](https://claude.com/claude-code)