### PR TITLE
fix(security): profiles email/telefono legible publicamente via anon key

### DIFF
--- a/apps/frontend/src/app/talento/[id]/page.tsx
+++ b/apps/frontend/src/app/talento/[id]/page.tsx
@@ -38,8 +38,48 @@ function getSafeExternalUrl(value: string | null | undefined) {
   }
 }
 
+function ProfileUnavailable() {
+  return (
+    <main className="min-h-screen bg-gray-50 px-4 py-12">
+      <div className="mx-auto max-w-2xl rounded-xl border border-gray-200 bg-white p-8 text-center">
+        <h1 className="text-2xl font-bold text-gray-900">
+          Perfil no disponible
+        </h1>
+        <p className="mt-2 text-sm text-gray-600">
+          Este candidato todavía no activó su visibilidad para empresas.
+        </p>
+        <Link
+          href="/empresa/candidatos"
+          className="mt-6 inline-flex rounded-lg bg-indigo-600 px-4 py-2 text-sm font-semibold text-white hover:bg-indigo-700"
+        >
+          Volver a candidatos
+        </Link>
+      </div>
+    </main>
+  );
+}
+
 export default async function TalentProfilePage({ params }: PageProps) {
   const supabase = createClient();
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return <ProfileUnavailable />;
+  }
+
+  const { data: caller } = await supabase
+    .from('profiles')
+    .select('audience')
+    .eq('id', user.id)
+    .maybeSingle();
+
+  if (caller?.audience !== 'empresa') {
+    return <ProfileUnavailable />;
+  }
+
   const { data: profile } = await supabase
     .from('profiles')
     .select(
@@ -50,24 +90,7 @@ export default async function TalentProfilePage({ params }: PageProps) {
     .maybeSingle();
 
   if (!profile?.talent_visible_to_empresas) {
-    return (
-      <main className="min-h-screen bg-gray-50 px-4 py-12">
-        <div className="mx-auto max-w-2xl rounded-xl border border-gray-200 bg-white p-8 text-center">
-          <h1 className="text-2xl font-bold text-gray-900">
-            Perfil no disponible
-          </h1>
-          <p className="mt-2 text-sm text-gray-600">
-            Este candidato todavía no activó su visibilidad para empresas.
-          </p>
-          <Link
-            href="/empresa/candidatos"
-            className="mt-6 inline-flex rounded-lg bg-indigo-600 px-4 py-2 text-sm font-semibold text-white hover:bg-indigo-700"
-          >
-            Volver a candidatos
-          </Link>
-        </div>
-      </main>
-    );
+    return <ProfileUnavailable />;
   }
 
   const { data: results } = await supabase

--- a/apps/frontend/src/middleware.ts
+++ b/apps/frontend/src/middleware.ts
@@ -1,7 +1,7 @@
 import { createServerClient } from '@supabase/ssr';
 import { NextResponse, type NextRequest } from 'next/server';
 
-const PROTECTED_ROUTES = ['/perfil', '/dashboard', '/empresa'];
+const PROTECTED_ROUTES = ['/perfil', '/dashboard', '/empresa', '/talento'];
 const AUTH_ROUTES = ['/login', '/register'];
 const PUBLIC_PATHS = ['/empresa/registro'];
 const SUPABASE_AUTH_COOKIE_PATTERN = /^sb-.+-auth-token(?:\.\d+)?$/;
@@ -138,6 +138,7 @@ export const config = {
     '/dashboard/:path*',
     '/empresa',
     '/empresa/:path*',
+    '/talento/:path*',
     '/login',
     '/register',
   ],

--- a/supabase/migrations/20260702_000000_fix_profiles_pii_exposure.sql
+++ b/supabase/migrations/20260702_000000_fix_profiles_pii_exposure.sql
@@ -1,0 +1,101 @@
+-- SEC-CRITICAL (issue #224): profiles.email/phone readable by anyone with the
+-- public anon key. Two duplicate always-true SELECT policies on public.profiles
+-- ("Profiles public read", "profiles_select") exposed every column of every
+-- profile row to unauthenticated visitors. Replace with row policies scoped to
+-- the caller's own row, plus a narrow carve-out for empresa accounts to read
+-- opted-in, visible candidate profiles (needed by /empresa/candidatos and
+-- /talento/[id]).
+--
+-- Company vs. candidate accounts are distinguished by profiles.audience
+-- ('empresa' | 'candidato'), not profiles.role (stale/inconsistent values —
+-- see 20260428_000000_fix_profiles_rls.sql).
+
+-- Columns referenced below were added by 20260625_020000_candidate_talent_directory.sql,
+-- which had not reached this environment yet; add them defensively so this
+-- migration is self-sufficient regardless of apply order.
+ALTER TABLE public.profiles
+  ADD COLUMN IF NOT EXISTS open_to_work BOOLEAN NOT NULL DEFAULT false,
+  ADD COLUMN IF NOT EXISTS talent_visible_to_empresas BOOLEAN NOT NULL DEFAULT false,
+  ADD COLUMN IF NOT EXISTS istqb_level TEXT,
+  ADD COLUMN IF NOT EXISTS github_profile TEXT;
+
+-- ── profiles ──────────────────────────────────────────────────────────────────
+
+DROP POLICY IF EXISTS "Profiles public read" ON public.profiles;
+DROP POLICY IF EXISTS "profiles_select" ON public.profiles;
+
+CREATE OR REPLACE FUNCTION public.current_user_is_empresa()
+RETURNS boolean
+LANGUAGE sql STABLE SECURITY DEFINER SET search_path TO 'public'
+AS $$
+  SELECT EXISTS (
+    SELECT 1 FROM public.profiles
+    WHERE id = auth.uid() AND audience = 'empresa'
+  );
+$$;
+
+CREATE POLICY "profiles_select_own" ON public.profiles
+  FOR SELECT
+  USING (auth.uid() = id);
+
+CREATE POLICY "profiles_select_empresa_talent" ON public.profiles
+  FOR SELECT
+  TO authenticated
+  USING (
+    audience = 'candidato'
+    AND talent_visible_to_empresas = true
+    AND public.current_user_is_empresa()
+  );
+
+-- ── tool_usage ────────────────────────────────────────────────────────────────
+-- "tool_usage_select_own" (auth.uid() = user_id) already covers the only real
+-- usage (apps/frontend/src/hooks/useToolUsage.ts only inserts via RPC).
+
+DROP POLICY IF EXISTS "tool_usage_select_authenticated" ON public.tool_usage;
+
+-- ── process_history / process_variables / user_tasks ─────────────────────────
+-- INSERT policies allowed any authenticated user to insert arbitrary rows.
+-- Mirror the invariants their own SELECT policies already encode. 0 rows in
+-- all three tables today, so this only tightens future writes.
+
+DROP POLICY IF EXISTS "Users can insert history" ON public.process_history;
+CREATE POLICY "Users can insert history" ON public.process_history
+  FOR INSERT TO authenticated
+  WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM process_instances pi
+      WHERE pi.id = process_history.instance_id
+      AND (pi.started_by = auth.uid() OR EXISTS (
+        SELECT 1 FROM user_profiles
+        WHERE user_profiles.id = auth.uid()
+        AND user_profiles.role = ANY (ARRAY['qa_lead','dev_lead'])
+      ))
+    )
+  );
+
+DROP POLICY IF EXISTS "Users can insert variables" ON public.process_variables;
+CREATE POLICY "Users can insert variables" ON public.process_variables
+  FOR INSERT TO authenticated
+  WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM process_instances pi
+      WHERE pi.id = process_variables.instance_id
+      AND (pi.started_by = auth.uid() OR EXISTS (
+        SELECT 1 FROM user_profiles
+        WHERE user_profiles.id = auth.uid()
+        AND user_profiles.role = ANY (ARRAY['qa_lead','dev_lead'])
+      ))
+    )
+  );
+
+DROP POLICY IF EXISTS "Users can insert tasks" ON public.user_tasks;
+CREATE POLICY "Users can insert tasks" ON public.user_tasks
+  FOR INSERT TO authenticated
+  WITH CHECK (
+    assignee_id = auth.uid()
+    OR EXISTS (
+      SELECT 1 FROM user_profiles
+      WHERE user_profiles.id = auth.uid()
+      AND user_profiles.role = ANY (ARRAY['qa_lead','dev_lead'])
+    )
+  );


### PR DESCRIPTION
## Summary

Closes #224.

- `public.profiles` tenía dos policies SELECT duplicadas (`"Profiles public read"`, `"profiles_select"`) con `USING (true)` para el rol `public`, exponiendo `email`/`phone` de los 95 usuarios registrados a cualquiera con la anon key, sin login. Se reemplazan por `profiles_select_own` (propio registro) y `profiles_select_empresa_talent` (empresas autenticadas, solo candidatos opt-in con `talent_visible_to_empresas = true`), vía la función `current_user_is_empresa()` (discrimina por `audience = 'empresa'`, no por `role`, que tiene valores legacy inconsistentes).
- `apps/frontend/src/app/talento/[id]/page.tsx` no tenía ningún guard de auth. Ahora exige usuario logueado + `audience = 'empresa'` en su propio perfil antes de consultar/renderizar el perfil del candidato (incluyendo el email).
- `/talento` se agrega a `PROTECTED_ROUTES` en `middleware.ts` (igual que `/empresa`), así los visitantes anónimos son redirigidos a `/login`.
- Adicional (hallazgos M del issue): se elimina la policy redundante `tool_usage_select_authenticated` (`USING true`) y se ajustan los `WITH CHECK (true)` de INSERT en `process_history`, `process_variables` y `user_tasks` para reflejar las mismas invariantes que ya tienen sus policies SELECT (0 filas hoy en las tres tablas, sin impacto en datos existentes).

La migración (`supabase/migrations/20260702_000000_fix_profiles_pii_exposure.sql`) ya fue aplicada directamente al proyecto de producción (`cbkctkpyxwbufvbwxogp`) y verificada contra `pg_policies` — este PR deja el cambio versionado en el repo.

## Test plan

- [x] Verificado contra `pg_policies` en producción: sin policies `USING (true)` para `public` en `profiles`; `tool_usage_select_authenticated` eliminada; `WITH CHECK` de `process_history`/`process_variables`/`user_tasks` ya no son `true`.
- [ ] Manual: anónimo → `/talento/<id>` redirige a `/login`.
- [ ] Manual: usuario candidato logueado → `/talento/<id>` muestra "Perfil no disponible", sin email en el HTML.
- [ ] Manual: usuario empresa logueado → `/talento/<id>` de un candidato opt-in renderiza igual que antes (incluye email).
- [ ] `/empresa/candidatos` (tab "Talento QA") sigue funcionando para la cuenta empresa existente.
- [ ] `pnpm --filter @aiquaa/frontend test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)