### PR TITLE
[codex] add B2B candidate search

### DIFF
--- a/apps/frontend/src/actions/__tests__/empresa-invitaciones.test.ts
+++ b/apps/frontend/src/actions/__tests__/empresa-invitaciones.test.ts
@@ -1,0 +1,154 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createInvitacionToCandidateAction } from '../empresa-invitaciones';
+
+const getUser = vi.fn();
+const singleResponses: unknown[] = [];
+const maybeSingleResponses: unknown[] = [];
+const inserts: unknown[] = [];
+
+vi.mock('@/lib/resend', () => ({
+  sendEmail: vi.fn(),
+}));
+
+vi.mock('@/lib/supabase/server', () => ({
+  createClient: () => ({
+    auth: {
+      getUser,
+    },
+    from: (table: string) => {
+      const builder = {
+        table,
+        select: vi.fn(() => builder),
+        eq: vi.fn(() => builder),
+        in: vi.fn(() => builder),
+        order: vi.fn(() => builder),
+        insert: vi.fn((payload: unknown) => {
+          inserts.push(payload);
+          return builder;
+        }),
+        update: vi.fn(() => builder),
+        delete: vi.fn(() => builder),
+        single: vi.fn(() => singleResponses.shift()),
+        maybeSingle: vi.fn(() => maybeSingleResponses.shift()),
+      };
+      return builder;
+    },
+  }),
+}));
+
+function ok<T>(data: T) {
+  return { data, error: null };
+}
+
+function authUser() {
+  getUser.mockResolvedValue({
+    data: { user: { id: 'empresa-user' } },
+    error: null,
+  });
+}
+
+describe('createInvitacionToCandidateAction', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    singleResponses.length = 0;
+    maybeSingleResponses.length = 0;
+    inserts.length = 0;
+    authUser();
+  });
+
+  it('creates an invitation by visible candidate id without exposing email to the caller', async () => {
+    singleResponses.push(
+      ok({ empresa_id: 'empresa-1', role: 'admin' }),
+      ok({ empresa_id: 'empresa-1', role: 'admin' }),
+      ok({
+        id: 'invite-1',
+        empresa_id: 'empresa-1',
+        process_id: null,
+        invited_by: 'empresa-user',
+        candidate_id: 'candidate-1',
+        candidate_email: 'ana@example.com',
+        candidate_name: 'Ana QA',
+        message: null,
+        status: 'pendiente',
+        token: 'token-1',
+        sent_at: '2026-07-02T00:00:00Z',
+        viewed_at: null,
+        completed_at: null,
+        email_sent: false,
+        email_error: null,
+        created_at: '2026-07-02T00:00:00Z',
+      })
+    );
+    maybeSingleResponses.push(
+      ok({
+        id: 'candidate-1',
+        email: 'ana@example.com',
+        display_name: 'Ana QA',
+        full_name: null,
+      }),
+      ok(null)
+    );
+
+    const result = await createInvitacionToCandidateAction({
+      candidate_id: 'candidate-1',
+    });
+
+    expect(result.error).toBeNull();
+    expect(result.data?.candidate_id).toBe('candidate-1');
+    expect(inserts[0]).toMatchObject({
+      candidate_id: 'candidate-1',
+      candidate_email: 'ana@example.com',
+    });
+  });
+
+  it('rejects users without active company membership', async () => {
+    singleResponses.push(ok(null));
+
+    const result = await createInvitacionToCandidateAction({
+      candidate_id: 'candidate-1',
+    });
+
+    expect(result.data).toBeNull();
+    expect(result.error).toBe('Sin membresia activa');
+    expect(inserts).toHaveLength(0);
+  });
+
+  it('rejects candidates that are not visible to companies', async () => {
+    singleResponses.push(ok({ empresa_id: 'empresa-1', role: 'admin' }));
+    maybeSingleResponses.push(ok(null));
+
+    const result = await createInvitacionToCandidateAction({
+      candidate_id: 'candidate-1',
+    });
+
+    expect(result.data).toBeNull();
+    expect(result.error).toBe('Candidato no disponible para invitacion');
+    expect(inserts).toHaveLength(0);
+  });
+
+  it('rejects duplicate active invitations', async () => {
+    singleResponses.push(
+      ok({ empresa_id: 'empresa-1', role: 'admin' }),
+      ok({ empresa_id: 'empresa-1', role: 'admin' })
+    );
+    maybeSingleResponses.push(
+      ok({
+        id: 'candidate-1',
+        email: 'ana@example.com',
+        display_name: 'Ana QA',
+        full_name: null,
+      }),
+      ok({ id: 'invite-1', status: 'pendiente' })
+    );
+
+    const result = await createInvitacionToCandidateAction({
+      candidate_id: 'candidate-1',
+    });
+
+    expect(result.data).toBeNull();
+    expect(result.error).toBe(
+      'Ya existe una invitacion activa para ese candidato'
+    );
+    expect(inserts).toHaveLength(0);
+  });
+});

--- a/apps/frontend/src/actions/empresa-invitaciones.ts
+++ b/apps/frontend/src/actions/empresa-invitaciones.ts
@@ -3,9 +3,6 @@
 import { createClient } from '@/lib/supabase/server';
 import { sendEmail } from '@/lib/resend';
 
-// Email sending is gated by EMAIL_SENDING_ENABLED so it can be turned on per
-// environment without code changes. Set to 'true' in Vercel env vars when Resend
-// is configured (RESEND_API_KEY + RESEND_FROM_EMAIL).
 const EMAIL_SENDING_ENABLED = process.env.EMAIL_SENDING_ENABLED === 'true';
 
 export interface EmpresaInvitacion {
@@ -13,6 +10,7 @@ export interface EmpresaInvitacion {
   empresa_id: string;
   process_id: string | null;
   invited_by: string;
+  candidate_id: string | null;
   candidate_email: string;
   candidate_name: string | null;
   message: string | null;
@@ -41,6 +39,68 @@ async function getCallerEmpresaId(
   return data;
 }
 
+async function sendInvitacionEmailIfEnabled(
+  supabase: Awaited<ReturnType<typeof createClient>>,
+  inv: EmpresaInvitacion
+) {
+  if (!EMAIL_SENDING_ENABLED || !inv.token) return inv;
+
+  const { data: empresaRow } = await supabase
+    .from('empresas')
+    .select('razon_social, nombre_comercial')
+    .eq('id', inv.empresa_id)
+    .single();
+
+  const empresaNombre =
+    empresaRow?.nombre_comercial || empresaRow?.razon_social || 'Una empresa';
+  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? 'https://aiquaa.com';
+  const link = `${siteUrl}/invitaciones/${inv.token}`;
+  const candidateName = inv.candidate_name ?? inv.candidate_email;
+  const subject = `${empresaNombre} te invita a rendir una evaluacion tecnica QA`;
+  const html = `
+<!DOCTYPE html>
+<html lang="es">
+<head><meta charset="UTF-8" /></head>
+<body style="font-family:sans-serif;background:#f9fafb;padding:24px">
+  <div style="max-width:480px;margin:0 auto;background:#fff;border-radius:12px;padding:32px;border:1px solid #e5e7eb">
+    <h2 style="margin:0 0 8px;font-size:20px;color:#111827">Hola, ${candidateName}</h2>
+    <p style="color:#374151;font-size:14px;line-height:1.6;margin:0 0 16px">
+      <strong>${empresaNombre}</strong> te invita a rendir una evaluacion tecnica QA en AIQUAA.
+    </p>
+    ${inv.message ? `<blockquote style="border-left:3px solid #6366f1;margin:0 0 16px;padding:8px 16px;color:#4b5563;font-size:13px">${inv.message}</blockquote>` : ''}
+    <a href="${link}" style="display:inline-block;background:#4f46e5;color:#fff;text-decoration:none;font-size:14px;font-weight:600;padding:12px 24px;border-radius:8px;margin-bottom:16px">
+      Ver mi invitacion
+    </a>
+    <p style="color:#9ca3af;font-size:12px;margin:0">
+      O copia este enlace: ${link}
+    </p>
+    <hr style="border:none;border-top:1px solid #f3f4f6;margin:24px 0" />
+    <p style="color:#9ca3af;font-size:11px;margin:0">
+      AIQUAA - Plataforma de evaluacion tecnica QA para LATAM
+    </p>
+  </div>
+</body>
+</html>`;
+
+  const { error: emailErr } = await sendEmail(
+    inv.candidate_email,
+    subject,
+    html
+  );
+
+  const { data: updated } = await supabase
+    .from('empresa_invitaciones')
+    .update({
+      email_sent: !emailErr,
+      email_error: emailErr ?? null,
+    })
+    .eq('id', inv.id)
+    .select('*, hiring_processes(position_name, code)')
+    .single();
+
+  return updated ? (updated as EmpresaInvitacion) : inv;
+}
+
 export async function getEmpresaInvitacionesAction(): Promise<{
   data: EmpresaInvitacion[] | null;
   error: string | null;
@@ -53,7 +113,7 @@ export async function getEmpresaInvitacionesAction(): Promise<{
   if (authErr || !user) return { data: null, error: 'No autenticado' };
 
   const membership = await getCallerEmpresaId(supabase, user.id);
-  if (!membership) return { data: null, error: 'Sin membresía activa' };
+  if (!membership) return { data: null, error: 'Sin membresia activa' };
 
   const { data, error } = await supabase
     .from('empresa_invitaciones')
@@ -68,6 +128,7 @@ export async function getEmpresaInvitacionesAction(): Promise<{
 export async function createInvitacionAction(payload: {
   candidate_email: string;
   candidate_name?: string;
+  candidate_id?: string;
   process_id?: string;
   message?: string;
 }): Promise<{ data: EmpresaInvitacion | null; error: string | null }> {
@@ -79,22 +140,23 @@ export async function createInvitacionAction(payload: {
   if (authErr || !user) return { data: null, error: 'No autenticado' };
 
   const membership = await getCallerEmpresaId(supabase, user.id);
-  if (!membership) return { data: null, error: 'Sin membresía activa' };
+  if (!membership) return { data: null, error: 'Sin membresia activa' };
 
-  // Check for duplicate active invitation
+  const normalizedEmail = payload.candidate_email.toLowerCase().trim();
   const { data: existing } = await supabase
     .from('empresa_invitaciones')
     .select('id, status')
     .eq('empresa_id', membership.empresa_id)
-    .eq('candidate_email', payload.candidate_email.toLowerCase().trim())
+    .eq('candidate_email', normalizedEmail)
     .in('status', ['pendiente', 'vista'])
     .maybeSingle();
 
-  if (existing)
+  if (existing) {
     return {
       data: null,
-      error: 'Ya existe una invitación activa para ese email',
+      error: 'Ya existe una invitacion activa para ese email',
     };
+  }
 
   const { data, error } = await supabase
     .from('empresa_invitaciones')
@@ -102,7 +164,8 @@ export async function createInvitacionAction(payload: {
       empresa_id: membership.empresa_id,
       process_id: payload.process_id ?? null,
       invited_by: user.id,
-      candidate_email: payload.candidate_email.toLowerCase().trim(),
+      candidate_id: payload.candidate_id ?? null,
+      candidate_email: normalizedEmail,
       candidate_name: payload.candidate_name?.trim() ?? null,
       message: payload.message?.trim() ?? null,
       status: 'pendiente',
@@ -113,64 +176,61 @@ export async function createInvitacionAction(payload: {
   if (error) return { data: null, error: error.message };
 
   const inv = data as EmpresaInvitacion;
+  return {
+    data: await sendInvitacionEmailIfEnabled(supabase, inv),
+    error: null,
+  };
+}
 
-  // Send email when EMAIL_SENDING_ENABLED=true; track result in DB.
-  if (EMAIL_SENDING_ENABLED && inv.token) {
-    const { data: empresaRow } = await supabase
-      .from('empresas')
-      .select('razon_social, nombre_comercial')
-      .eq('id', inv.empresa_id)
-      .single();
+export async function createInvitacionToCandidateAction(payload: {
+  candidate_id: string;
+  process_id?: string;
+  message?: string;
+}): Promise<{ data: EmpresaInvitacion | null; error: string | null }> {
+  const supabase = await createClient();
+  const {
+    data: { user },
+    error: authErr,
+  } = await supabase.auth.getUser();
+  if (authErr || !user) return { data: null, error: 'No autenticado' };
 
-    const empresaNombre =
-      empresaRow?.nombre_comercial || empresaRow?.razon_social || 'Una empresa';
+  const membership = await getCallerEmpresaId(supabase, user.id);
+  if (!membership) return { data: null, error: 'Sin membresia activa' };
 
-    const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? 'https://aiquaa.com';
-    const link = `${siteUrl}/invitaciones/${inv.token}`;
-    const candidateName = inv.candidate_name ?? inv.candidate_email;
+  const { data: candidate, error: candidateErr } = await supabase
+    .from('profiles')
+    .select(
+      'id, email, display_name, full_name, talent_visible_to_empresas, audience'
+    )
+    .eq('id', payload.candidate_id)
+    .eq('audience', 'candidato')
+    .eq('talent_visible_to_empresas', true)
+    .maybeSingle();
 
-    const subject = `${empresaNombre} te invita a rendir una evaluación técnica QA`;
-    const html = `
-<!DOCTYPE html>
-<html lang="es">
-<head><meta charset="UTF-8" /></head>
-<body style="font-family:sans-serif;background:#f9fafb;padding:24px">
-  <div style="max-width:480px;margin:0 auto;background:#fff;border-radius:12px;padding:32px;border:1px solid #e5e7eb">
-    <h2 style="margin:0 0 8px;font-size:20px;color:#111827">Hola, ${candidateName}</h2>
-    <p style="color:#374151;font-size:14px;line-height:1.6;margin:0 0 16px">
-      <strong>${empresaNombre}</strong> te invita a rendir una evaluación técnica QA en AIQUAA.
-    </p>
-    ${inv.message ? `<blockquote style="border-left:3px solid #6366f1;margin:0 0 16px;padding:8px 16px;color:#4b5563;font-size:13px">${inv.message}</blockquote>` : ''}
-    <a href="${link}" style="display:inline-block;background:#4f46e5;color:#fff;text-decoration:none;font-size:14px;font-weight:600;padding:12px 24px;border-radius:8px;margin-bottom:16px">
-      Ver mi invitación →
-    </a>
-    <p style="color:#9ca3af;font-size:12px;margin:0">
-      O copiá este enlace: ${link}
-    </p>
-    <hr style="border:none;border-top:1px solid #f3f4f6;margin:24px 0" />
-    <p style="color:#9ca3af;font-size:11px;margin:0">
-      AIQUAA — Plataforma de evaluación técnica QA para LATAM
-    </p>
-  </div>
-</body>
-</html>`;
-
-    const { error: emailErr } = await sendEmail(inv.candidate_email, subject, html);
-
-    const { data: updated } = await supabase
-      .from('empresa_invitaciones')
-      .update({
-        email_sent: !emailErr,
-        email_error: emailErr ?? null,
-      })
-      .eq('id', inv.id)
-      .select('*, hiring_processes(position_name, code)')
-      .single();
-
-    if (updated) return { data: updated as EmpresaInvitacion, error: null };
+  if (candidateErr) return { data: null, error: candidateErr.message };
+  if (!candidate?.email) {
+    return { data: null, error: 'Candidato no disponible para invitacion' };
   }
 
-  return { data: inv, error: null };
+  const result = await createInvitacionAction({
+    candidate_id: candidate.id,
+    candidate_email: candidate.email,
+    candidate_name:
+      candidate.display_name?.trim() ||
+      candidate.full_name?.trim() ||
+      undefined,
+    process_id: payload.process_id,
+    message: payload.message,
+  });
+
+  if (result.error === 'Ya existe una invitacion activa para ese email') {
+    return {
+      data: null,
+      error: 'Ya existe una invitacion activa para ese candidato',
+    };
+  }
+
+  return result;
 }
 
 export async function cancelInvitacionAction(invitacionId: string): Promise<{

--- a/apps/frontend/src/actions/profile.ts
+++ b/apps/frontend/src/actions/profile.ts
@@ -12,7 +12,24 @@ export async function updateProfileAction(formData: FormData) {
   const country = (formData.get('country') as string)?.trim();
   const githubProfile = (formData.get('github_profile') as string)?.trim();
   const istqbLevel = (formData.get('istqb_level') as string)?.trim();
-  const openToWork = formData.get('open_to_work') === 'true';
+  const disponibilidadRaw = (formData.get('disponibilidad') as string)?.trim();
+  const disponibilidad = (
+    ['activo', 'pasivo', 'no_disponible'].includes(disponibilidadRaw)
+      ? disponibilidadRaw
+      : 'no_disponible'
+  ) as 'activo' | 'pasivo' | 'no_disponible';
+  const qaSkillsRaw = (formData.get('qa_skills') as string)?.trim();
+  const qaSkills = (() => {
+    try {
+      const parsed = JSON.parse(qaSkillsRaw || '[]');
+      return Array.isArray(parsed)
+        ? parsed.filter((item): item is string => typeof item === 'string')
+        : [];
+    } catch {
+      return [];
+    }
+  })();
+  const openToWork = disponibilidad === 'activo';
   const talentVisibleToEmpresas =
     formData.get('talent_visible_to_empresas') === 'true';
 
@@ -31,6 +48,8 @@ export async function updateProfileAction(formData: FormData) {
       country,
       github_profile: githubProfile,
       istqb_level: istqbLevel,
+      disponibilidad,
+      qa_skills: qaSkills,
       open_to_work: openToWork,
       talent_visible_to_empresas: talentVisibleToEmpresas,
     },
@@ -48,6 +67,8 @@ export async function updateProfileAction(formData: FormData) {
       country: country || null,
       istqb_level: istqbLevel || null,
       github_profile: githubProfile || null,
+      disponibilidad,
+      qa_skills: qaSkills,
       open_to_work: openToWork,
       talent_visible_to_empresas: talentVisibleToEmpresas,
     },

--- a/apps/frontend/src/app/empresa/buscar-candidatos/page.tsx
+++ b/apps/frontend/src/app/empresa/buscar-candidatos/page.tsx
@@ -1,0 +1,699 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import Link from 'next/link';
+import { Search, Send, Star, StarOff, X } from 'lucide-react';
+import { createClient } from '@/lib/supabase/client';
+import { useTheme } from '@/contexts/ThemeContext';
+import { createInvitacionToCandidateAction } from '@/actions/empresa-invitaciones';
+import {
+  AVAILABILITY_LABELS,
+  QA_SKILL_OPTIONS,
+  filterTalentCandidates,
+  type CandidateAvailability,
+  type TalentCandidate,
+} from '@/app/empresa/candidatos/candidateDirectory';
+
+const ISTQB_LEVEL_LABELS: Record<string, string> = {
+  ctfl: 'Foundation Level (CTFL)',
+  ctal_ta: 'Advanced Level - Test Analyst',
+  ctal_tm: 'Advanced Level - Test Manager',
+  ctal_tta: 'Advanced Level - Technical Test Analyst',
+  expert: 'Expert Level',
+  en_proceso: 'En proceso de certificacion',
+};
+
+const EXAM_LABELS: Record<string, string> = {
+  istqb: 'ISTQB CTFL',
+  git: 'Git',
+  'git-practico': 'Git Practica',
+  performance: 'Performance',
+  'api-testing-fundamentals': 'API Testing Fundamentals',
+  'api-banking': 'API Testing Challenge',
+  'database-fundamentals': 'Bases de Datos - Fundamentos',
+  'database-practice': 'Bases de Datos - Practica SQL',
+  'infrastructure-fundamentals': 'Infraestructura - Fundamentos',
+  sin_evaluacion: 'Sin evaluacion visible',
+};
+
+type SourcingRow = {
+  user_id: string;
+  name: string;
+  role: string | null;
+  country: string | null;
+  istqb_level: string | null;
+  github_profile: string | null;
+  qa_skills: string[] | null;
+  disponibilidad: CandidateAvailability;
+  best_score: number | null;
+  best_exam_type: string | null;
+  passed_assessments: number;
+  total_assessments: number;
+  last_activity_at: string;
+  favorite_id: string | null;
+  favorite_created_at: string | null;
+  favorite_notes: string | null;
+};
+
+type HiringProcessOption = {
+  id: string;
+  code: string;
+  position_name: string;
+  status: string;
+};
+
+function mapSourcingRow(row: SourcingRow): TalentCandidate {
+  return {
+    userId: row.user_id,
+    name: row.name,
+    role: row.role,
+    country: row.country,
+    istqbLevel: row.istqb_level,
+    githubProfile: row.github_profile,
+    qaSkills: row.qa_skills ?? [],
+    disponibilidad: row.disponibilidad,
+    visibleToEmpresas: true,
+    bestScore: Number(row.best_score ?? 0),
+    bestExamType: row.best_exam_type ?? 'sin_evaluacion',
+    passedAssessments: Number(row.passed_assessments ?? 0),
+    totalAssessments: Number(row.total_assessments ?? 0),
+    lastActivityAt: row.last_activity_at,
+    favoriteId: row.favorite_id,
+    favoriteCreatedAt: row.favorite_created_at,
+    favoriteNotes: row.favorite_notes,
+  };
+}
+
+export default function BuscarCandidatosPage() {
+  const { isDarkMode } = useTheme();
+  const [candidates, setCandidates] = useState<TalentCandidate[]>([]);
+  const [processes, setProcesses] = useState<HiringProcessOption[]>([]);
+  const [empresaId, setEmpresaId] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [actionMessage, setActionMessage] = useState<string | null>(null);
+  const [search, setSearch] = useState('');
+  const [filterIstqbLevel, setFilterIstqbLevel] = useState('all');
+  const [filterCountry, setFilterCountry] = useState('all');
+  const [filterAvailability, setFilterAvailability] = useState<
+    CandidateAvailability | 'all'
+  >('all');
+  const [selectedSkills, setSelectedSkills] = useState<string[]>([]);
+  const [inviteCandidate, setInviteCandidate] =
+    useState<TalentCandidate | null>(null);
+  const [inviteProcessId, setInviteProcessId] = useState('');
+  const [inviteMessage, setInviteMessage] = useState('');
+  const [inviteSending, setInviteSending] = useState(false);
+
+  const card = isDarkMode
+    ? 'bg-dark-secondary border-slate-700'
+    : 'bg-white border-gray-200';
+  const inputClass = `rounded-lg border px-3 py-2 text-sm outline-none transition-colors focus:ring-2 focus:ring-indigo-500 ${
+    isDarkMode
+      ? 'bg-slate-700 border-slate-600 text-white placeholder-slate-400'
+      : 'bg-white border-gray-300 text-gray-900 placeholder-gray-400'
+  }`;
+
+  const loadDirectory = useCallback(async () => {
+    setLoading(true);
+    const supabase = createClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+
+    if (user?.id) {
+      const { data: profile } = await supabase
+        .from('profiles')
+        .select('empresa_id')
+        .eq('id', user.id)
+        .maybeSingle();
+      setEmpresaId(profile?.empresa_id ?? null);
+    }
+
+    const [{ data: rows, error }, { data: processRows }] = await Promise.all([
+      supabase.rpc('get_empresa_candidate_sourcing'),
+      supabase
+        .from('hiring_processes')
+        .select('id, code, position_name, status')
+        .eq('status', 'active')
+        .order('created_at', { ascending: false }),
+    ]);
+
+    if (error) {
+      setActionMessage(error.message);
+      setCandidates([]);
+    } else {
+      setCandidates(((rows ?? []) as SourcingRow[]).map(mapSourcingRow));
+    }
+    setProcesses((processRows ?? []) as HiringProcessOption[]);
+    setLoading(false);
+  }, []);
+
+  useEffect(() => {
+    void loadDirectory();
+  }, [loadDirectory]);
+
+  const availableCountries = useMemo(
+    () =>
+      [
+        ...new Set(
+          candidates.map((candidate) => candidate.country).filter(Boolean)
+        ),
+      ].sort() as string[],
+    [candidates]
+  );
+
+  const filteredCandidates = useMemo(
+    () =>
+      filterTalentCandidates(candidates, {
+        search,
+        istqbLevel: filterIstqbLevel,
+        country: filterCountry,
+        availability: filterAvailability,
+        skills: selectedSkills,
+      }),
+    [
+      candidates,
+      filterAvailability,
+      filterCountry,
+      filterIstqbLevel,
+      search,
+      selectedSkills,
+    ]
+  );
+
+  const toggleSkill = (skill: string) => {
+    setSelectedSkills((prev) =>
+      prev.includes(skill)
+        ? prev.filter((item) => item !== skill)
+        : [...prev, skill]
+    );
+  };
+
+  const toggleFavorite = async (candidate: TalentCandidate) => {
+    setActionMessage(null);
+    if (!empresaId) {
+      setActionMessage('No se pudo identificar la empresa activa.');
+      return;
+    }
+
+    const supabase = createClient();
+    if (candidate.favoriteId) {
+      const { error } = await supabase
+        .from('empresa_favoritos')
+        .delete()
+        .eq('id', candidate.favoriteId);
+      if (error) {
+        setActionMessage(error.message);
+        return;
+      }
+      setCandidates((prev) =>
+        prev.map((item) =>
+          item.userId === candidate.userId
+            ? {
+                ...item,
+                favoriteId: null,
+                favoriteCreatedAt: null,
+                favoriteNotes: null,
+              }
+            : item
+        )
+      );
+      setActionMessage('Candidato quitado de favoritos.');
+      return;
+    }
+
+    const { data, error } = await supabase
+      .from('empresa_favoritos')
+      .insert({ empresa_id: empresaId, candidate_id: candidate.userId })
+      .select('id, created_at, notes')
+      .single();
+
+    if (error) {
+      setActionMessage(error.message);
+      return;
+    }
+
+    setCandidates((prev) =>
+      prev.map((item) =>
+        item.userId === candidate.userId
+          ? {
+              ...item,
+              favoriteId: data.id,
+              favoriteCreatedAt: data.created_at,
+              favoriteNotes: data.notes,
+            }
+          : item
+      )
+    );
+    setActionMessage('Candidato guardado en favoritos.');
+  };
+
+  const sendInvite = async () => {
+    if (!inviteCandidate) return;
+    setInviteSending(true);
+    const { error } = await createInvitacionToCandidateAction({
+      candidate_id: inviteCandidate.userId,
+      process_id: inviteProcessId || undefined,
+      message: inviteMessage || undefined,
+    });
+    setInviteSending(false);
+    if (error) {
+      setActionMessage(`Error al invitar: ${error}`);
+      return;
+    }
+    setActionMessage(`Invitacion enviada a ${inviteCandidate.name}.`);
+    setInviteCandidate(null);
+    setInviteProcessId('');
+    setInviteMessage('');
+  };
+
+  const clearFilters = () => {
+    setSearch('');
+    setFilterIstqbLevel('all');
+    setFilterCountry('all');
+    setFilterAvailability('all');
+    setSelectedSkills([]);
+  };
+
+  return (
+    <div
+      className={`min-h-screen transition-colors duration-300 ${
+        isDarkMode ? 'bg-dark-bg' : 'bg-gray-50'
+      }`}
+    >
+      <div className="mx-auto max-w-6xl space-y-6 px-4 py-10 sm:px-6 lg:px-8">
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+          <div>
+            <p
+              className={`text-sm font-semibold ${
+                isDarkMode ? 'text-indigo-300' : 'text-indigo-600'
+              }`}
+            >
+              Sourcing B2B
+            </p>
+            <h1
+              className={`mt-1 text-2xl font-bold ${
+                isDarkMode ? 'text-white' : 'text-gray-900'
+              }`}
+            >
+              Buscar candidatos QA
+            </h1>
+            <p
+              className={`mt-2 max-w-2xl text-sm ${
+                isDarkMode ? 'text-slate-400' : 'text-gray-500'
+              }`}
+            >
+              Explora perfiles opt-in, filtra por disponibilidad y skills, y
+              arma tu shortlist sin exponer emails.
+            </p>
+          </div>
+          <Link
+            href="/empresa/candidatos"
+            className={`rounded-lg border px-4 py-2 text-sm font-semibold transition-colors ${
+              isDarkMode
+                ? 'border-slate-600 text-slate-300 hover:bg-slate-700'
+                : 'border-gray-300 text-gray-700 hover:bg-gray-50'
+            }`}
+          >
+            Ver evaluados
+          </Link>
+        </div>
+
+        {actionMessage && (
+          <div
+            className={`rounded-lg border px-4 py-3 text-sm ${
+              isDarkMode
+                ? 'border-indigo-700 bg-indigo-900/30 text-indigo-200'
+                : 'border-indigo-200 bg-indigo-50 text-indigo-800'
+            }`}
+          >
+            {actionMessage}
+          </div>
+        )}
+
+        <section className={`rounded-lg border p-4 ${card}`}>
+          <div className="flex flex-wrap gap-3">
+            <div className="relative min-w-64 flex-1">
+              <Search
+                className={`absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 ${
+                  isDarkMode ? 'text-slate-400' : 'text-gray-400'
+                }`}
+              />
+              <input
+                type="text"
+                value={search}
+                onChange={(event) => setSearch(event.target.value)}
+                placeholder="Buscar por nombre, rol, pais o skill"
+                className={`${inputClass} w-full pl-9`}
+              />
+            </div>
+            <select
+              value={filterAvailability}
+              onChange={(event) =>
+                setFilterAvailability(
+                  event.target.value as CandidateAvailability | 'all'
+                )
+              }
+              className={inputClass}
+            >
+              <option value="all">Toda disponibilidad</option>
+              {Object.entries(AVAILABILITY_LABELS).map(([value, label]) => (
+                <option key={value} value={value}>
+                  {label}
+                </option>
+              ))}
+            </select>
+            <select
+              value={filterIstqbLevel}
+              onChange={(event) => setFilterIstqbLevel(event.target.value)}
+              className={inputClass}
+            >
+              <option value="all">Todos los niveles ISTQB</option>
+              {Object.entries(ISTQB_LEVEL_LABELS).map(([value, label]) => (
+                <option key={value} value={value}>
+                  {label}
+                </option>
+              ))}
+            </select>
+            <select
+              value={filterCountry}
+              onChange={(event) => setFilterCountry(event.target.value)}
+              className={inputClass}
+            >
+              <option value="all">Todos los paises</option>
+              {availableCountries.map((country) => (
+                <option key={country} value={country}>
+                  {country}
+                </option>
+              ))}
+            </select>
+            <button
+              type="button"
+              onClick={clearFilters}
+              className={`inline-flex items-center gap-2 rounded-lg border px-3 py-2 text-sm font-semibold transition-colors ${
+                isDarkMode
+                  ? 'border-slate-600 text-slate-300 hover:bg-slate-700'
+                  : 'border-gray-300 text-gray-700 hover:bg-gray-50'
+              }`}
+            >
+              <X className="h-4 w-4" />
+              Limpiar
+            </button>
+          </div>
+
+          <div className="mt-4 flex flex-wrap gap-2">
+            {QA_SKILL_OPTIONS.map((skill) => {
+              const selected = selectedSkills.includes(skill);
+              return (
+                <button
+                  key={skill}
+                  type="button"
+                  onClick={() => toggleSkill(skill)}
+                  className={`rounded-full border px-3 py-1 text-xs font-semibold transition-colors ${
+                    selected
+                      ? 'border-indigo-600 bg-indigo-600 text-white'
+                      : isDarkMode
+                        ? 'border-slate-600 text-slate-300 hover:bg-slate-700'
+                        : 'border-gray-300 text-gray-700 hover:bg-gray-50'
+                  }`}
+                >
+                  {skill}
+                </button>
+              );
+            })}
+          </div>
+        </section>
+
+        <section className={`rounded-lg border ${card}`}>
+          <div
+            className={`flex items-center justify-between border-b px-5 py-4 ${
+              isDarkMode ? 'border-slate-700' : 'border-gray-100'
+            }`}
+          >
+            <div>
+              <h2
+                className={`text-sm font-semibold ${
+                  isDarkMode ? 'text-white' : 'text-gray-900'
+                }`}
+              >
+                Talento disponible
+              </h2>
+              <p
+                className={`text-xs ${
+                  isDarkMode ? 'text-slate-400' : 'text-gray-500'
+                }`}
+              >
+                {filteredCandidates.length} de {candidates.length} perfiles
+              </p>
+            </div>
+          </div>
+
+          {loading ? (
+            <div className="p-8 text-center text-sm text-gray-500">
+              Cargando candidatos...
+            </div>
+          ) : filteredCandidates.length === 0 ? (
+            <div className="p-8 text-center">
+              <p
+                className={`font-semibold ${
+                  isDarkMode ? 'text-white' : 'text-gray-900'
+                }`}
+              >
+                Sin candidatos para estos filtros
+              </p>
+              <p
+                className={`mt-1 text-sm ${
+                  isDarkMode ? 'text-slate-400' : 'text-gray-500'
+                }`}
+              >
+                Ajusta la busqueda o limpia los filtros para ampliar el pool.
+              </p>
+            </div>
+          ) : (
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className={isDarkMode ? 'bg-slate-800/60' : 'bg-gray-50'}>
+                    {[
+                      'Candidato',
+                      'Disponibilidad',
+                      'Score',
+                      'Skills',
+                      'Acciones',
+                    ].map((header) => (
+                      <th
+                        key={header}
+                        className={`px-5 py-3 text-left text-xs font-semibold uppercase ${
+                          isDarkMode ? 'text-slate-400' : 'text-gray-500'
+                        }`}
+                      >
+                        {header}
+                      </th>
+                    ))}
+                  </tr>
+                </thead>
+                <tbody>
+                  {filteredCandidates.map((candidate) => (
+                    <tr
+                      key={candidate.userId}
+                      className={`border-t ${
+                        isDarkMode ? 'border-slate-700' : 'border-gray-100'
+                      }`}
+                    >
+                      <td className="px-5 py-4">
+                        <Link
+                          href={`/talento/${candidate.userId}`}
+                          className={`font-semibold hover:underline ${
+                            isDarkMode ? 'text-white' : 'text-gray-900'
+                          }`}
+                        >
+                          {candidate.name}
+                        </Link>
+                        <p
+                          className={`mt-1 text-xs ${
+                            isDarkMode ? 'text-slate-400' : 'text-gray-500'
+                          }`}
+                        >
+                          {[candidate.role, candidate.country]
+                            .filter(Boolean)
+                            .join(' - ') || 'Perfil QA'}
+                        </p>
+                        {candidate.istqbLevel && (
+                          <p className="mt-0.5 text-xs text-indigo-500">
+                            {ISTQB_LEVEL_LABELS[candidate.istqbLevel] ??
+                              candidate.istqbLevel}
+                          </p>
+                        )}
+                      </td>
+                      <td className="px-5 py-4">
+                        <span
+                          className={`rounded-full px-2 py-1 text-xs font-semibold ${
+                            candidate.disponibilidad === 'activo'
+                              ? 'bg-emerald-100 text-emerald-700'
+                              : candidate.disponibilidad === 'pasivo'
+                                ? 'bg-amber-100 text-amber-700'
+                                : 'bg-slate-100 text-slate-600'
+                          }`}
+                        >
+                          {AVAILABILITY_LABELS[candidate.disponibilidad]}
+                        </span>
+                      </td>
+                      <td className="px-5 py-4">
+                        <p className="text-lg font-bold text-indigo-500">
+                          {candidate.bestScore}%
+                        </p>
+                        <p
+                          className={`text-xs ${
+                            isDarkMode ? 'text-slate-400' : 'text-gray-500'
+                          }`}
+                        >
+                          {EXAM_LABELS[candidate.bestExamType] ??
+                            candidate.bestExamType}
+                        </p>
+                        <p
+                          className={`mt-1 text-xs ${
+                            isDarkMode ? 'text-slate-500' : 'text-gray-400'
+                          }`}
+                        >
+                          {candidate.passedAssessments}/
+                          {candidate.totalAssessments} aprobados
+                        </p>
+                      </td>
+                      <td className="px-5 py-4">
+                        <div className="flex max-w-xs flex-wrap gap-1.5">
+                          {candidate.qaSkills.length > 0 ? (
+                            candidate.qaSkills.map((skill) => (
+                              <span
+                                key={skill}
+                                className={`rounded-full px-2 py-0.5 text-xs ${
+                                  isDarkMode
+                                    ? 'bg-slate-700 text-slate-300'
+                                    : 'bg-gray-100 text-gray-700'
+                                }`}
+                              >
+                                {skill}
+                              </span>
+                            ))
+                          ) : (
+                            <span
+                              className={`text-xs ${
+                                isDarkMode ? 'text-slate-500' : 'text-gray-400'
+                              }`}
+                            >
+                              Sin skills cargadas
+                            </span>
+                          )}
+                        </div>
+                      </td>
+                      <td className="px-5 py-4">
+                        <div className="flex flex-wrap gap-2">
+                          <button
+                            type="button"
+                            onClick={() => toggleFavorite(candidate)}
+                            className={`inline-flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-xs font-semibold transition-colors ${
+                              candidate.favoriteId
+                                ? isDarkMode
+                                  ? 'bg-amber-900/40 text-amber-200 hover:bg-amber-900/60'
+                                  : 'bg-amber-100 text-amber-700 hover:bg-amber-200'
+                                : 'bg-indigo-600 text-white hover:bg-indigo-700'
+                            }`}
+                          >
+                            {candidate.favoriteId ? (
+                              <StarOff className="h-3.5 w-3.5" />
+                            ) : (
+                              <Star className="h-3.5 w-3.5" />
+                            )}
+                            {candidate.favoriteId ? 'Quitar' : 'Guardar'}
+                          </button>
+                          <button
+                            type="button"
+                            onClick={() => setInviteCandidate(candidate)}
+                            className="inline-flex items-center gap-1.5 rounded-lg bg-emerald-600 px-3 py-1.5 text-xs font-semibold text-white transition-colors hover:bg-emerald-700"
+                          >
+                            <Send className="h-3.5 w-3.5" />
+                            Invitar
+                          </button>
+                        </div>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </section>
+      </div>
+
+      {inviteCandidate && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
+          <div
+            className={`w-full max-w-md space-y-4 rounded-lg border p-6 shadow-xl ${card}`}
+          >
+            <div>
+              <h3
+                className={`text-base font-bold ${
+                  isDarkMode ? 'text-white' : 'text-gray-900'
+                }`}
+              >
+                Invitar a {inviteCandidate.name}
+              </h3>
+              <p
+                className={`mt-1 text-sm ${
+                  isDarkMode ? 'text-slate-400' : 'text-gray-500'
+                }`}
+              >
+                AIQUAA enviara la invitacion por email sin revelar el correo en
+                el directorio.
+              </p>
+            </div>
+            <select
+              value={inviteProcessId}
+              onChange={(event) => setInviteProcessId(event.target.value)}
+              className={`${inputClass} w-full`}
+            >
+              <option value="">Sin proceso especifico</option>
+              {processes.map((process) => (
+                <option key={process.id} value={process.id}>
+                  {process.position_name} ({process.code})
+                </option>
+              ))}
+            </select>
+            <textarea
+              value={inviteMessage}
+              onChange={(event) => setInviteMessage(event.target.value)}
+              rows={3}
+              maxLength={300}
+              placeholder="Mensaje opcional para el candidato"
+              className={`${inputClass} w-full resize-none`}
+            />
+            <div className="flex gap-2">
+              <button
+                type="button"
+                onClick={sendInvite}
+                disabled={inviteSending}
+                className="flex-1 rounded-lg bg-indigo-600 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-indigo-700 disabled:opacity-50"
+              >
+                {inviteSending ? 'Enviando...' : 'Enviar invitacion'}
+              </button>
+              <button
+                type="button"
+                onClick={() => {
+                  setInviteCandidate(null);
+                  setInviteProcessId('');
+                  setInviteMessage('');
+                }}
+                className={`flex-1 rounded-lg border px-4 py-2 text-sm font-semibold transition-colors ${
+                  isDarkMode
+                    ? 'border-slate-600 text-slate-300 hover:bg-slate-700'
+                    : 'border-gray-300 text-gray-700 hover:bg-gray-50'
+                }`}
+              >
+                Cancelar
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/frontend/src/app/empresa/candidatos/__tests__/candidateDirectory.test.ts
+++ b/apps/frontend/src/app/empresa/candidatos/__tests__/candidateDirectory.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import { buildTalentDirectory, buildFavoriteMap } from '../candidateDirectory';
+import {
+  buildFavoriteMap,
+  buildTalentDirectory,
+  filterTalentCandidates,
+} from '../candidateDirectory';
 
 const results = [
   {
@@ -45,6 +49,8 @@ describe('candidate talent directory', () => {
           email: 'ana@example.com',
           role: 'QA Automation',
           country: 'PY',
+          disponibilidad: 'activo',
+          qa_skills: ['Selenium', 'API Testing'],
           open_to_work: true,
           talent_visible_to_empresas: true,
         },
@@ -67,8 +73,10 @@ describe('candidate talent directory', () => {
       bestExamType: 'performance',
       passedAssessments: 2,
       totalAssessments: 2,
-      openToWork: true,
+      disponibilidad: 'activo',
+      qaSkills: ['Selenium', 'API Testing'],
     });
+    expect('email' in directory[0]).toBe(false);
   });
 
   it('attaches favorite state by candidate id', () => {
@@ -97,5 +105,42 @@ describe('candidate talent directory', () => {
     expect(map.get('candidate-1')?.id).toBe('fav-1');
     expect(directory[0].favoriteId).toBe('fav-1');
     expect(directory[0].favoriteNotes).toBe('Buen perfil API');
+  });
+
+  it('filters by availability, country, ISTQB level and skills', () => {
+    const directory = buildTalentDirectory(
+      results,
+      [
+        {
+          id: 'candidate-1',
+          display_name: 'Ana Testing',
+          country: 'PY',
+          istqb_level: 'ctfl',
+          disponibilidad: 'activo',
+          qa_skills: ['Selenium', 'Postman'],
+          talent_visible_to_empresas: true,
+        },
+        {
+          id: 'candidate-2',
+          display_name: 'Bruno Testing',
+          country: 'UY',
+          istqb_level: 'expert',
+          disponibilidad: 'pasivo',
+          qa_skills: ['JMeter'],
+          talent_visible_to_empresas: true,
+        },
+      ],
+      []
+    );
+
+    const filtered = filterTalentCandidates(directory, {
+      availability: 'activo',
+      country: 'PY',
+      istqbLevel: 'ctfl',
+      skills: ['Postman'],
+    });
+
+    expect(filtered).toHaveLength(1);
+    expect(filtered[0].userId).toBe('candidate-1');
   });
 });

--- a/apps/frontend/src/app/empresa/candidatos/candidateDirectory.ts
+++ b/apps/frontend/src/app/empresa/candidatos/candidateDirectory.ts
@@ -1,14 +1,18 @@
 export type CandidateProfile = {
   id: string;
   display_name: string | null;
-  email: string | null;
+  email?: string | null;
   role?: string | null;
   country?: string | null;
   istqb_level?: string | null;
   github_profile?: string | null;
+  qa_skills?: string[] | null;
+  disponibilidad?: CandidateAvailability | null;
   open_to_work?: boolean | null;
   talent_visible_to_empresas?: boolean | null;
 };
+
+export type CandidateAvailability = 'activo' | 'pasivo' | 'no_disponible';
 
 export type CandidateResult = {
   id: string;
@@ -31,12 +35,13 @@ export type FavoriteRow = {
 export type TalentCandidate = {
   userId: string;
   name: string;
-  email: string | null;
+  contactEmail?: string | null;
   role: string | null;
   country: string | null;
   istqbLevel: string | null;
   githubProfile: string | null;
-  openToWork: boolean;
+  qaSkills: string[];
+  disponibilidad: CandidateAvailability;
   visibleToEmpresas: boolean;
   bestScore: number;
   bestExamType: string;
@@ -46,6 +51,34 @@ export type TalentCandidate = {
   favoriteId: string | null;
   favoriteCreatedAt: string | null;
   favoriteNotes: string | null;
+};
+
+export type TalentCandidateFilters = {
+  search?: string;
+  istqbLevel?: string;
+  country?: string;
+  availability?: CandidateAvailability | 'all';
+  skills?: string[];
+};
+
+export const QA_SKILL_OPTIONS = [
+  'Selenium',
+  'Cypress',
+  'Playwright',
+  'Postman',
+  'k6',
+  'JMeter',
+  'SQL',
+  'API Testing',
+  'Exploratory Testing',
+  'Git',
+  'CI/CD',
+];
+
+export const AVAILABILITY_LABELS: Record<CandidateAvailability, string> = {
+  activo: 'Activo',
+  pasivo: 'Pasivo',
+  no_disponible: 'No disponible',
 };
 
 export function getCandidateKey(result: CandidateResult) {
@@ -91,18 +124,15 @@ export function buildTalentDirectory(
 
       return {
         userId,
-        name:
-          profile.display_name ||
-          best.participant_name ||
-          profile.email ||
-          best.participant_email ||
-          'Sin nombre',
-        email: profile.email ?? best.participant_email ?? null,
+        name: profile.display_name || best.participant_name || 'Sin nombre',
         role: profile.role ?? null,
         country: profile.country ?? null,
         istqbLevel: profile.istqb_level ?? null,
         githubProfile: profile.github_profile ?? null,
-        openToWork: Boolean(profile.open_to_work),
+        qaSkills: profile.qa_skills ?? [],
+        disponibilidad:
+          profile.disponibilidad ??
+          (profile.open_to_work ? 'activo' : 'no_disponible'),
         visibleToEmpresas: Boolean(profile.talent_visible_to_empresas),
         bestScore: Number(best.percentage ?? 0),
         bestExamType: best.exam_type,
@@ -122,8 +152,19 @@ export function buildTalentDirectory(
       } satisfies TalentCandidate;
     })
     .sort((a, b) => {
-      if (Number(b.openToWork) !== Number(a.openToWork)) {
-        return Number(b.openToWork) - Number(a.openToWork);
+      const availabilityRank: Record<CandidateAvailability, number> = {
+        activo: 0,
+        pasivo: 1,
+        no_disponible: 2,
+      };
+      if (
+        availabilityRank[a.disponibilidad] !==
+        availabilityRank[b.disponibilidad]
+      ) {
+        return (
+          availabilityRank[a.disponibilidad] -
+          availabilityRank[b.disponibilidad]
+        );
       }
       if (b.bestScore !== a.bestScore) return b.bestScore - a.bestScore;
       return (
@@ -131,4 +172,45 @@ export function buildTalentDirectory(
         new Date(a.lastActivityAt).getTime()
       );
     });
+}
+
+export function filterTalentCandidates(
+  candidates: TalentCandidate[],
+  filters: TalentCandidateFilters
+) {
+  const query = filters.search?.trim().toLowerCase();
+  const skills = filters.skills?.filter(Boolean) ?? [];
+
+  return candidates.filter((candidate) => {
+    const matchesSearch =
+      !query ||
+      candidate.name.toLowerCase().includes(query) ||
+      (candidate.role?.toLowerCase().includes(query) ?? false) ||
+      (candidate.country?.toLowerCase().includes(query) ?? false) ||
+      (candidate.istqbLevel?.toLowerCase().includes(query) ?? false) ||
+      candidate.qaSkills.some((skill) => skill.toLowerCase().includes(query));
+    const matchesLevel =
+      !filters.istqbLevel ||
+      filters.istqbLevel === 'all' ||
+      candidate.istqbLevel === filters.istqbLevel;
+    const matchesCountry =
+      !filters.country ||
+      filters.country === 'all' ||
+      candidate.country === filters.country;
+    const matchesAvailability =
+      !filters.availability ||
+      filters.availability === 'all' ||
+      candidate.disponibilidad === filters.availability;
+    const matchesSkills =
+      skills.length === 0 ||
+      skills.some((skill) => candidate.qaSkills.includes(skill));
+
+    return (
+      matchesSearch &&
+      matchesLevel &&
+      matchesCountry &&
+      matchesAvailability &&
+      matchesSkills
+    );
+  });
 }

--- a/apps/frontend/src/app/empresa/candidatos/page.tsx
+++ b/apps/frontend/src/app/empresa/candidatos/page.tsx
@@ -200,7 +200,7 @@ export default function CandidatosPage() {
         const { data: profiles } = await supabase
           .from('profiles')
           .select(
-            'id, display_name, email, role, country, istqb_level, github_profile, open_to_work, talent_visible_to_empresas'
+            'id, display_name, role, country, istqb_level, github_profile, qa_skills, disponibilidad, talent_visible_to_empresas'
           )
           .in('id', talentUserIds)
           .eq('audience', 'candidato')
@@ -427,12 +427,13 @@ export default function CandidatosPage() {
       return {
         userId,
         name: best.participant_name || best.participant_email || 'Sin nombre',
-        email: best.participant_email,
+        contactEmail: best.participant_email,
         role: null,
         country: null,
         istqbLevel: null,
         githubProfile: null,
-        openToWork: false,
+        qaSkills: [],
+        disponibilidad: 'no_disponible',
         visibleToEmpresas: false,
         bestScore: Number(best.percentage ?? 0),
         bestExamType: best.exam_type,
@@ -462,7 +463,7 @@ export default function CandidatosPage() {
       const matchesSearch =
         !q ||
         candidate.name.toLowerCase().includes(q) ||
-        (candidate.email?.toLowerCase().includes(q) ?? false) ||
+        (candidate.contactEmail?.toLowerCase().includes(q) ?? false) ||
         (candidate.role?.toLowerCase().includes(q) ?? false) ||
         (candidate.country?.toLowerCase().includes(q) ?? false) ||
         (candidate.istqbLevel
@@ -880,7 +881,7 @@ export default function CandidatosPage() {
                             >
                               {candidate.name}
                             </Link>
-                            {candidate.openToWork && (
+                            {candidate.disponibilidad === 'activo' && (
                               <span className="text-xs px-2 py-0.5 rounded-full bg-emerald-100 text-emerald-700">
                                 Disponible
                               </span>
@@ -901,11 +902,11 @@ export default function CandidatosPage() {
                               ? ` · ${ISTQB_LEVEL_LABELS[candidate.istqbLevel] ?? candidate.istqbLevel}`
                               : ''}
                           </p>
-                          {candidate.email && (
+                          {candidate.contactEmail && (
                             <p
                               className={`text-xs mt-0.5 ${isDarkMode ? 'text-slate-500' : 'text-gray-400'}`}
                             >
-                              {candidate.email}
+                              {candidate.contactEmail}
                             </p>
                           )}
                         </div>
@@ -953,18 +954,20 @@ export default function CandidatosPage() {
                         >
                           {isFavorite ? 'Quitar' : 'Guardar'}
                         </button>
-                        {candidate.email && (
+                        {candidate.contactEmail && (
                           <a
-                            href={`mailto:${candidate.email}`}
+                            href={`mailto:${candidate.contactEmail}`}
                             className={`px-3 py-1.5 rounded-lg text-xs font-semibold border transition-colors ${isDarkMode ? 'border-slate-600 text-slate-300 hover:bg-slate-700' : 'border-gray-300 text-gray-700 hover:bg-gray-50'}`}
                           >
                             Contactar
                           </a>
                         )}
-                        {candidate.email && (
+                        {candidate.contactEmail && (
                           <button
                             type="button"
-                            onClick={() => openInviteModal(candidate.email!)}
+                            onClick={() =>
+                              openInviteModal(candidate.contactEmail!)
+                            }
                             className="px-3 py-1.5 rounded-lg text-xs font-semibold bg-emerald-600 text-white hover:bg-emerald-700 transition-colors"
                           >
                             Invitar

--- a/apps/frontend/src/app/empresa/page.tsx
+++ b/apps/frontend/src/app/empresa/page.tsx
@@ -38,10 +38,16 @@ const BASE_LINKS = [
     description: 'Gestioná tus procesos activos y cerrados',
   },
   {
-    href: '/empresa/candidatos',
+    href: '/empresa/buscar-candidatos',
     emoji: '👥',
-    title: 'Candidatos y talento QA',
-    description: 'Revisá evaluados, directorio opt-in y shortlist',
+    title: 'Buscar talento QA',
+    description: 'Explorá el pool opt-in por skills y disponibilidad',
+  },
+  {
+    href: '/empresa/candidatos',
+    emoji: '📊',
+    title: 'Candidatos evaluados',
+    description: 'Revisá resultados, compará perfiles y shortlist',
   },
   {
     href: '/empresa/invitaciones',
@@ -115,7 +121,11 @@ function FunnelWidget({
   const steps = [
     { label: 'Enviadas', value: funnel.total, color: 'text-indigo-500' },
     { label: 'Vistas', value: funnel.vistas, color: 'text-amber-500' },
-    { label: 'Completadas', value: funnel.completadas, color: 'text-emerald-500' },
+    {
+      label: 'Completadas',
+      value: funnel.completadas,
+      color: 'text-emerald-500',
+    },
   ];
   return (
     <div
@@ -324,7 +334,9 @@ export default function EmpresaDashboardPage() {
               <StatCard
                 label="Visitas al perfil"
                 value={stats?.profileViews ?? 0}
-                color={stats?.profileViews ? 'text-purple-500' : 'text-slate-400'}
+                color={
+                  stats?.profileViews ? 'text-purple-500' : 'text-slate-400'
+                }
                 isDarkMode={isDarkMode}
               />
             </>
@@ -431,7 +443,10 @@ export default function EmpresaDashboardPage() {
         {/* Invitaciones funnel */}
         {stats && stats.invitacionesFunnel.total > 0 && (
           <div className="mb-8">
-            <FunnelWidget funnel={stats.invitacionesFunnel} isDarkMode={isDarkMode} />
+            <FunnelWidget
+              funnel={stats.invitacionesFunnel}
+              isDarkMode={isDarkMode}
+            />
           </div>
         )}
 

--- a/apps/frontend/src/app/perfil/page.tsx
+++ b/apps/frontend/src/app/perfil/page.tsx
@@ -22,6 +22,11 @@ import {
   formatExamScore,
   type ExamType,
 } from '@/lib/exams';
+import {
+  AVAILABILITY_LABELS,
+  QA_SKILL_OPTIONS,
+  type CandidateAvailability,
+} from '@/app/empresa/candidatos/candidateDirectory';
 
 const EXAM_PAGE_SIZE = 20;
 
@@ -120,7 +125,8 @@ export default function PerfilPage() {
     country: '',
     github_profile: '',
     istqb_level: '',
-    open_to_work: false,
+    disponibilidad: 'no_disponible' as CandidateAvailability,
+    qa_skills: [] as string[],
     talent_visible_to_empresas: false,
   });
   const [initialized, setInitialized] = useState(false);
@@ -144,7 +150,12 @@ export default function PerfilPage() {
         country: user.user_metadata?.country || '',
         github_profile: user.user_metadata?.github_profile || '',
         istqb_level: user.user_metadata?.istqb_level || '',
-        open_to_work: Boolean(user.user_metadata?.open_to_work),
+        disponibilidad:
+          user.user_metadata?.disponibilidad ||
+          (user.user_metadata?.open_to_work ? 'activo' : 'no_disponible'),
+        qa_skills: Array.isArray(user.user_metadata?.qa_skills)
+          ? user.user_metadata.qa_skills
+          : [],
         talent_visible_to_empresas: Boolean(
           user.user_metadata?.talent_visible_to_empresas
         ),
@@ -278,7 +289,9 @@ export default function PerfilPage() {
     fd.set('country', formData.country);
     fd.set('github_profile', formData.github_profile);
     fd.set('istqb_level', formData.istqb_level);
-    fd.set('open_to_work', String(formData.open_to_work));
+    fd.set('disponibilidad', formData.disponibilidad);
+    fd.set('qa_skills', JSON.stringify(formData.qa_skills));
+    fd.set('open_to_work', String(formData.disponibilidad === 'activo'));
     fd.set(
       'talent_visible_to_empresas',
       String(formData.talent_visible_to_empresas)
@@ -632,24 +645,58 @@ export default function PerfilPage() {
                     Mostrar mi perfil en el directorio de talento para empresas
                   </span>
                 </label>
-                <label className="flex gap-3 items-start text-sm">
-                  <input
-                    type="checkbox"
-                    checked={formData.open_to_work}
+                <div>
+                  <label className={labelClass}>Disponibilidad</label>
+                  <select
+                    value={formData.disponibilidad}
                     onChange={(e) =>
                       setFormData((p) => ({
                         ...p,
-                        open_to_work: e.target.checked,
+                        disponibilidad: e.target.value as CandidateAvailability,
                       }))
                     }
-                    className="mt-1 h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500"
-                  />
-                  <span
-                    className={isDarkMode ? 'text-slate-300' : 'text-gray-700'}
+                    className={inputClass}
                   >
-                    Estoy disponible para ser contactado por oportunidades QA
-                  </span>
-                </label>
+                    {Object.entries(AVAILABILITY_LABELS).map(
+                      ([value, label]) => (
+                        <option key={value} value={value}>
+                          {label}
+                        </option>
+                      )
+                    )}
+                  </select>
+                </div>
+                <div>
+                  <p className={labelClass}>Skills QA</p>
+                  <div className="flex flex-wrap gap-2">
+                    {QA_SKILL_OPTIONS.map((skill) => {
+                      const selected = formData.qa_skills.includes(skill);
+                      return (
+                        <button
+                          key={skill}
+                          type="button"
+                          onClick={() =>
+                            setFormData((p) => ({
+                              ...p,
+                              qa_skills: selected
+                                ? p.qa_skills.filter((item) => item !== skill)
+                                : [...p.qa_skills, skill],
+                            }))
+                          }
+                          className={`rounded-full border px-3 py-1 text-xs font-semibold transition-colors ${
+                            selected
+                              ? 'border-indigo-600 bg-indigo-600 text-white'
+                              : isDarkMode
+                                ? 'border-slate-600 text-slate-300 hover:bg-slate-700'
+                                : 'border-gray-300 text-gray-700 hover:bg-gray-50'
+                          }`}
+                        >
+                          {skill}
+                        </button>
+                      );
+                    })}
+                  </div>
+                </div>
               </div>
               <label className={labelClass}>Tu rol en QA</label>
               <div className="grid grid-cols-2 gap-2">

--- a/apps/frontend/src/app/talento/[id]/page.tsx
+++ b/apps/frontend/src/app/talento/[id]/page.tsx
@@ -43,7 +43,7 @@ export default async function TalentProfilePage({ params }: PageProps) {
   const { data: profile } = await supabase
     .from('profiles')
     .select(
-      'id, display_name, email, role, country, istqb_level, github_profile, open_to_work, talent_visible_to_empresas'
+      'id, display_name, role, country, istqb_level, github_profile, disponibilidad, talent_visible_to_empresas'
     )
     .eq('id', params.id)
     .eq('audience', 'candidato')
@@ -99,7 +99,7 @@ export default async function TalentProfilePage({ params }: PageProps) {
                 Talento QA AIQUAA
               </p>
               <h1 className="mt-1 text-3xl font-bold text-gray-900">
-                {profile.display_name || profile.email || 'Candidato QA'}
+                {profile.display_name || 'Candidato QA'}
               </h1>
               <p className="mt-2 text-sm text-gray-600">
                 {[profile.role, profile.country].filter(Boolean).join(' · ') ||
@@ -112,9 +112,6 @@ export default async function TalentProfilePage({ params }: PageProps) {
                     profile.istqb_level}
                 </p>
               )}
-              {profile.email && (
-                <p className="mt-1 text-sm text-gray-500">{profile.email}</p>
-              )}
               {githubUrl && (
                 <a
                   href={githubUrl}
@@ -126,7 +123,7 @@ export default async function TalentProfilePage({ params }: PageProps) {
                 </a>
               )}
             </div>
-            {profile.open_to_work && (
+            {profile.disponibilidad === 'activo' && (
               <span className="rounded-full bg-emerald-100 px-3 py-1 text-xs font-bold text-emerald-700">
                 Disponible para contacto
               </span>

--- a/apps/frontend/src/components/Header.tsx
+++ b/apps/frontend/src/components/Header.tsx
@@ -23,7 +23,8 @@ const navLinks = [
 const empresaNavLinks = [
   { href: '/empresa', label: 'Panel', emoji: '🏢' },
   { href: '/empresa/procesos', label: 'Mis procesos', emoji: '📂' },
-  { href: '/empresa/candidatos', label: 'Candidatos', emoji: '👥' },
+  { href: '/empresa/buscar-candidatos', label: 'Buscar talento', emoji: '👥' },
+  { href: '/empresa/candidatos', label: 'Evaluados', emoji: '📊' },
   { href: '/empresa/admin/usuarios', label: 'Usuarios', emoji: '👤' },
   { href: '/ranking', label: 'Tops', emoji: '🏆' },
   { href: '/labs', label: 'Herramientas', emoji: '🧪' },

--- a/supabase/migrations/20260702_220000_empresa_candidate_sourcing.sql
+++ b/supabase/migrations/20260702_220000_empresa_candidate_sourcing.sql
@@ -1,0 +1,167 @@
+-- ============================================================
+-- EMP-001: B2B candidate sourcing without exposing candidate email
+-- ============================================================
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'candidate_availability') THEN
+    CREATE TYPE candidate_availability AS ENUM ('activo', 'pasivo', 'no_disponible');
+  END IF;
+END $$;
+
+ALTER TABLE public.profiles
+  ADD COLUMN IF NOT EXISTS disponibilidad candidate_availability NOT NULL DEFAULT 'no_disponible',
+  ADD COLUMN IF NOT EXISTS qa_skills TEXT[] NOT NULL DEFAULT '{}'::TEXT[];
+
+UPDATE public.profiles
+SET disponibilidad = CASE
+  WHEN open_to_work IS TRUE THEN 'activo'::candidate_availability
+  WHEN talent_visible_to_empresas IS TRUE THEN 'pasivo'::candidate_availability
+  ELSE 'no_disponible'::candidate_availability
+END
+WHERE disponibilidad = 'no_disponible'::candidate_availability
+  AND (open_to_work IS TRUE OR talent_visible_to_empresas IS TRUE);
+
+CREATE INDEX IF NOT EXISTS profiles_candidate_sourcing_idx
+  ON public.profiles (audience, talent_visible_to_empresas, disponibilidad, istqb_level, country);
+
+CREATE INDEX IF NOT EXISTS profiles_qa_skills_gin_idx
+  ON public.profiles USING gin (qa_skills);
+
+ALTER TABLE public.empresa_invitaciones
+  ADD COLUMN IF NOT EXISTS candidate_id UUID REFERENCES public.profiles(id) ON DELETE SET NULL;
+
+CREATE INDEX IF NOT EXISTS empresa_invitaciones_candidate_idx
+  ON public.empresa_invitaciones (empresa_id, candidate_id)
+  WHERE candidate_id IS NOT NULL;
+
+CREATE OR REPLACE FUNCTION public.get_empresa_candidate_sourcing()
+RETURNS TABLE (
+  user_id UUID,
+  name TEXT,
+  role TEXT,
+  country TEXT,
+  istqb_level TEXT,
+  github_profile TEXT,
+  qa_skills TEXT[],
+  disponibilidad candidate_availability,
+  best_score NUMERIC,
+  best_exam_type TEXT,
+  passed_assessments BIGINT,
+  total_assessments BIGINT,
+  last_activity_at TIMESTAMPTZ,
+  favorite_id UUID,
+  favorite_created_at TIMESTAMPTZ,
+  favorite_notes TEXT
+)
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = public
+AS $function$
+  WITH caller AS (
+    SELECT p.empresa_id
+    FROM public.profiles p
+    WHERE p.id = auth.uid()
+      AND p.empresa_id IS NOT NULL
+      AND public.is_active_empresa_member(p.empresa_id)
+    LIMIT 1
+  ),
+  visible_profiles AS (
+    SELECT
+      p.id,
+      COALESCE(NULLIF(TRIM(p.display_name), ''), NULLIF(TRIM(p.full_name), ''), 'Candidato QA') AS name,
+      p.role,
+      p.country,
+      p.istqb_level,
+      p.github_profile,
+      COALESCE(p.qa_skills, '{}'::TEXT[]) AS qa_skills,
+      p.disponibilidad
+    FROM public.profiles p
+    WHERE EXISTS (SELECT 1 FROM caller)
+      AND p.audience = 'candidato'
+      AND p.talent_visible_to_empresas IS TRUE
+  ),
+  legacy_results AS (
+    SELECT
+      er.user_id,
+      er.exam_type,
+      er.percentage::NUMERIC AS percentage,
+      er.passed,
+      er.created_at
+    FROM public.exam_results er
+    WHERE er.user_id IS NOT NULL
+      AND er.percentage <= 100
+  ),
+  assessment_results AS (
+    SELECT
+      aa.user_id,
+      a.slug AS exam_type,
+      aa.percentage::NUMERIC AS percentage,
+      aa.passed,
+      COALESCE(aa.submitted_at, aa.created_at) AS created_at
+    FROM public.assessment_attempts aa
+    JOIN public.assessments a ON a.id = aa.assessment_id
+    WHERE aa.user_id IS NOT NULL
+      AND aa.status = 'graded'
+      AND aa.percentage <= 100
+  ),
+  combined_results AS (
+    SELECT * FROM legacy_results
+    UNION ALL
+    SELECT * FROM assessment_results
+  ),
+  ranked_results AS (
+    SELECT
+      cr.*,
+      ROW_NUMBER() OVER (
+        PARTITION BY cr.user_id
+        ORDER BY cr.percentage DESC, cr.created_at DESC
+      ) AS rn
+    FROM combined_results cr
+  ),
+  result_summary AS (
+    SELECT
+      cr.user_id,
+      COUNT(*) AS total_assessments,
+      COUNT(*) FILTER (WHERE cr.passed) AS passed_assessments,
+      MAX(cr.created_at) AS last_activity_at
+    FROM combined_results cr
+    GROUP BY cr.user_id
+  )
+  SELECT
+    vp.id AS user_id,
+    vp.name,
+    vp.role,
+    vp.country,
+    vp.istqb_level,
+    vp.github_profile,
+    vp.qa_skills,
+    vp.disponibilidad,
+    COALESCE(rr.percentage, 0) AS best_score,
+    COALESCE(rr.exam_type, 'sin_evaluacion') AS best_exam_type,
+    COALESCE(rs.passed_assessments, 0) AS passed_assessments,
+    COALESCE(rs.total_assessments, 0) AS total_assessments,
+    COALESCE(rs.last_activity_at, now()) AS last_activity_at,
+    ef.id AS favorite_id,
+    ef.created_at AS favorite_created_at,
+    ef.notes AS favorite_notes
+  FROM visible_profiles vp
+  LEFT JOIN ranked_results rr ON rr.user_id = vp.id AND rr.rn = 1
+  LEFT JOIN result_summary rs ON rs.user_id = vp.id
+  LEFT JOIN caller c ON true
+  LEFT JOIN public.empresa_favoritos ef
+    ON ef.candidate_id = vp.id
+   AND ef.empresa_id = c.empresa_id
+  ORDER BY
+    CASE vp.disponibilidad
+      WHEN 'activo' THEN 0
+      WHEN 'pasivo' THEN 1
+      ELSE 2
+    END,
+    COALESCE(rr.percentage, 0) DESC,
+    COALESCE(rs.last_activity_at, now()) DESC;
+$function$;
+
+REVOKE EXECUTE ON FUNCTION public.get_empresa_candidate_sourcing() FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION public.get_empresa_candidate_sourcing() FROM anon;
+GRANT EXECUTE ON FUNCTION public.get_empresa_candidate_sourcing() TO authenticated;


### PR DESCRIPTION
## Summary
- Fixes #127
- Adds `/empresa/buscar-candidatos` as the focused B2B candidate sourcing page with search, availability, ISTQB, country, and skill filters.
- Adds candidate availability + QA skills to profiles and a secure `get_empresa_candidate_sourcing()` RPC that returns public sourcing data without candidate email.
- Adds candidate-id based invitations, favorites support in sourcing, profile controls for availability/skills, and hides email from public talent profiles.

## Validation
- `pnpm --filter @aiquaa/frontend test -- candidateDirectory`
- `pnpm --filter @aiquaa/frontend test -- empresa-invitaciones`
- `pnpm --filter @aiquaa/frontend type-check`
- `pnpm --filter @aiquaa/frontend lint` (passes with existing warnings)
- Pre-push hook: `pnpm --filter @aiquaa/frontend type-check`
- Browser/dev check: `/empresa/buscar-candidatos` is protected and redirects to login when unauthenticated; no authenticated visual pass was possible locally.

## Notes
- Draft PR because the Supabase migration must be reviewed/applied before #127 is closed.
- Local SQL smoke test was not run because neither `psql` nor the Supabase CLI is available in this workspace PATH.
- The ranking RPCs and public ranking behavior are untouched.