### PR TITLE
fix(security,ranking): admin key server-side + XP ranking vacío por RLS

### DIFF
--- a/apps/frontend/.env.local.example
+++ b/apps/frontend/.env.local.example
@@ -45,6 +45,8 @@ INTERNAL_NOTIFY_SECRET=replace_with_a_random_secret_32chars
 NEXT_PUBLIC_SITE_URL=http://localhost:3001
 
 # Clave de acceso al panel de admin del Test App (/labs/test-app/admin)
+# SERVER-ONLY: sin prefijo NEXT_PUBLIC_, se verifica en /api/labs/test-app/admin/verify
+# y nunca se incluye en el bundle del cliente.
 # Generar con: node -e "require('crypto').randomBytes(24).toString('base64url')|console.log"
 # NUNCA usar el valor por defecto en producción
-NEXT_PUBLIC_ADMIN_KEY=local-dev-only-change-in-vercel
+ADMIN_KEY=local-dev-only-change-in-vercel

--- a/apps/frontend/src/actions/exams.ts
+++ b/apps/frontend/src/actions/exams.ts
@@ -164,9 +164,11 @@ export async function getXpRankingAction(page = 1, limit = 20) {
     p_offset: offset,
   });
 
-  if (error) return { error: error.message, data: null, total: 0 };
+  if (error) {
+    return { error: error.message, data: null, total: 0, page, totalPages: 0 };
+  }
 
-  const total = data?.[0]?.total_count ?? 0;
+  const total: number = data?.[0]?.total_count ?? 0;
 
   const entries = (data ?? []).map((row: any, i: number) => ({
     position: offset + i + 1,

--- a/apps/frontend/src/actions/exams.ts
+++ b/apps/frontend/src/actions/exams.ts
@@ -154,18 +154,19 @@ export async function getXpRankingAction(page = 1, limit = 20) {
     data: { user },
   } = await supabase.auth.getUser();
 
-  // ranking_candidatos view excludes audience='empresa' at DB level
-  // and includes achievement_count via subquery in the view
-  const { data, error, count } = await supabase
-    .from('ranking_candidatos')
-    .select(
-      'user_id, total_xp, level, current_streak, last_activity_at, display_name, avatar_url, achievement_count, main_badge',
-      { count: 'exact' }
-    )
-    .order('total_xp', { ascending: false })
-    .range(offset, offset + limit - 1);
+  // get_xp_ranking is a SECURITY DEFINER RPC (mirrors get_leaderboard):
+  // ranking_candidatos is a security_invoker view, and profiles RLS only
+  // allows a user to read their own row, so querying the view directly as
+  // `authenticated` silently drops every other candidate's row. The RPC
+  // exposes only the ranking-safe columns without loosening profiles RLS.
+  const { data, error } = await supabase.rpc('get_xp_ranking', {
+    p_limit: limit,
+    p_offset: offset,
+  });
 
   if (error) return { error: error.message, data: null, total: 0 };
+
+  const total = data?.[0]?.total_count ?? 0;
 
   const entries = (data ?? []).map((row: any, i: number) => ({
     position: offset + i + 1,
@@ -182,9 +183,9 @@ export async function getXpRankingAction(page = 1, limit = 20) {
 
   return {
     data: entries,
-    total: count ?? 0,
+    total,
     page,
-    totalPages: Math.ceil((count ?? 0) / limit),
+    totalPages: Math.ceil(total / limit),
   };
 }
 

--- a/apps/frontend/src/app/api/labs/test-app/admin/verify/route.ts
+++ b/apps/frontend/src/app/api/labs/test-app/admin/verify/route.ts
@@ -1,0 +1,53 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+/**
+ * POST /api/labs/test-app/admin/verify
+ *
+ * Verifies the admin key server-side (ADMIN_KEY is a server-only env var,
+ * never exposed to the client bundle). On success, sets an httpOnly cookie
+ * so the client doesn't need to keep resubmitting the key.
+ *
+ * Request body: { key: string }
+ * Response: { authorized: boolean }
+ *
+ * GET /api/labs/test-app/admin/verify
+ *
+ * Checks the existing session cookie (used on page reload).
+ * Response: { authorized: boolean }
+ */
+const COOKIE_NAME = 'testapp_admin_session';
+const COOKIE_MAX_AGE = 60 * 60 * 4; // 4 hours
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const key = typeof body?.key === 'string' ? body.key : '';
+    const adminKey = process.env.ADMIN_KEY || '';
+
+    // Empty ADMIN_KEY means admin is disabled — reject even empty-string match
+    if (!adminKey || key !== adminKey) {
+      return NextResponse.json({ authorized: false }, { status: 401 });
+    }
+
+    const response = NextResponse.json({ authorized: true }, { status: 200 });
+    response.cookies.set(COOKIE_NAME, '1', {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === 'production',
+      sameSite: 'lax',
+      path: '/labs/test-app',
+      maxAge: COOKIE_MAX_AGE,
+    });
+    return response;
+  } catch (error: any) {
+    console.error('Error verifying test-app admin key:', error);
+    return NextResponse.json({ authorized: false }, { status: 500 });
+  }
+}
+
+export async function GET(request: NextRequest) {
+  const authorized = request.cookies.get(COOKIE_NAME)?.value === '1';
+  return NextResponse.json({ authorized }, { status: 200 });
+}
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';

--- a/apps/frontend/src/app/labs/test-app/README.md
+++ b/apps/frontend/src/app/labs/test-app/README.md
@@ -272,11 +272,12 @@ apps/frontend/src/app/labs/test-app/
 
 ## ⚙️ Variables de Entorno
 
-Si usas Next.js con build estático, configura:
+Configura la clave del panel admin (server-only, se verifica en
+`/api/labs/test-app/admin/verify` y nunca se incluye en el bundle del cliente):
 
 ```env
 # .env.local
-NEXT_PUBLIC_ADMIN_KEY=aiquaa-test-admin-2024
+ADMIN_KEY=aiquaa-test-admin-2024
 ```
 
 ---

--- a/apps/frontend/src/app/labs/test-app/admin/page.tsx
+++ b/apps/frontend/src/app/labs/test-app/admin/page.tsx
@@ -15,10 +15,6 @@ import { seedData } from '../lib/seedData';
 import { clearAllData, resetSession } from '../lib/storage';
 import { clearAuditLog } from '../lib/auditLog';
 
-// SECURITY: No hardcoded fallback — if NEXT_PUBLIC_ADMIN_KEY is not set,
-// the admin page remains inaccessible. Set this env var in Vercel dashboard.
-const ADMIN_KEY = process.env.NEXT_PUBLIC_ADMIN_KEY || '';
-
 export default function AdminPage() {
   const searchParams = useSearchParams();
   const router = useRouter();
@@ -28,15 +24,43 @@ export default function AdminPage() {
   const { showToast, ToastComponent } = useToast();
 
   useEffect(() => {
-    const key = searchParams?.get('key');
-    // Empty ADMIN_KEY means admin is disabled — reject even empty-string match
-    if (ADMIN_KEY && key === ADMIN_KEY) {
+    const onAuthorized = () => {
       setAuthorized(true);
       const currentId = getCandidateId() || 'default';
       setCandId(currentId);
       refreshBugs();
+    };
+
+    const key = searchParams?.get('key');
+    if (key) {
+      // Verify server-side, then strip the key from the URL/history.
+      fetch('/api/labs/test-app/admin/verify', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ key }),
+      })
+        .then((res) => res.json())
+        .then((data) => {
+          if (data.authorized) {
+            onAuthorized();
+            router.replace('/labs/test-app/admin');
+          } else {
+            setAuthorized(false);
+          }
+        })
+        .catch(() => setAuthorized(false));
     } else {
-      setAuthorized(false);
+      // No key in URL — check for an existing verified session cookie.
+      fetch('/api/labs/test-app/admin/verify')
+        .then((res) => res.json())
+        .then((data) => {
+          if (data.authorized) {
+            onAuthorized();
+          } else {
+            setAuthorized(false);
+          }
+        })
+        .catch(() => setAuthorized(false));
     }
   }, [searchParams]);
 

--- a/supabase/migrations/20260702_020000_secure_xp_ranking_function.sql
+++ b/supabase/migrations/20260702_020000_secure_xp_ranking_function.sql
@@ -13,6 +13,12 @@
 -- email/phone/company_name/empresa_id and other profiles columns remain
 -- inaccessible to other users.
 
+-- Drop first: an earlier, incompatible draft of this function (different
+-- column order/types, p_page-based pagination) may already exist in some
+-- environments and CREATE OR REPLACE cannot change a function's return
+-- row type/order in place.
+DROP FUNCTION IF EXISTS public.get_xp_ranking(integer, integer);
+
 CREATE OR REPLACE FUNCTION public.get_xp_ranking(
   p_limit  integer DEFAULT 20,
   p_offset integer DEFAULT 0

--- a/supabase/migrations/20260702_020000_secure_xp_ranking_function.sql
+++ b/supabase/migrations/20260702_020000_secure_xp_ranking_function.sql
@@ -1,0 +1,53 @@
+-- Fix: "Nadie en el ranking aún" — XP community ranking always empty.
+--
+-- Root cause: ranking_candidatos is a `security_invoker = true` view that
+-- JOINs profiles. profiles RLS only allows a user to read their OWN row
+-- (profiles_select_own: auth.uid() = id) plus a narrow empresa-talent
+-- exception. Queried as `authenticated`, the JOIN drops every profile row
+-- except the caller's own, so the view returns at most 1 row per user.
+--
+-- Fix: expose the ranking through a SECURITY DEFINER function that returns
+-- only the columns already shown on the public ranking UI (display_name,
+-- avatar_url, xp/level/streak, achievement_count, main_badge) — mirroring
+-- the existing get_leaderboard() pattern. profiles RLS is NOT loosened;
+-- email/phone/company_name/empresa_id and other profiles columns remain
+-- inaccessible to other users.
+
+CREATE OR REPLACE FUNCTION public.get_xp_ranking(
+  p_limit  integer DEFAULT 20,
+  p_offset integer DEFAULT 0
+)
+RETURNS TABLE(
+  user_id            uuid,
+  total_xp           integer,
+  level              integer,
+  current_streak     integer,
+  last_activity_at   timestamptz,
+  display_name       text,
+  avatar_url         text,
+  achievement_count  bigint,
+  main_badge         text,
+  total_count        bigint
+)
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $function$
+  SELECT
+    rc.user_id,
+    rc.total_xp,
+    rc.level,
+    rc.current_streak,
+    rc.last_activity_at,
+    rc.display_name,
+    rc.avatar_url,
+    rc.achievement_count,
+    rc.main_badge,
+    COUNT(*) OVER () AS total_count
+  FROM public.ranking_candidatos rc
+  ORDER BY rc.total_xp DESC, rc.user_id
+  LIMIT p_limit OFFSET p_offset;
+$function$;
+
+REVOKE ALL ON FUNCTION public.get_xp_ranking(integer, integer) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.get_xp_ranking(integer, integer) TO anon, authenticated;


### PR DESCRIPTION
## Resumen

- **[SEC-MEDIUM] #226** — el panel admin de `test-app` comparaba `?key=` contra `NEXT_PUBLIC_ADMIN_KEY` en el cliente, exponiendo el secreto en el bundle JS. Se movió la verificación a un route handler server-side (`ADMIN_KEY`, sin prefijo público) que setea una cookie httpOnly de sesión.
- **Ranking XP "Comunidad" vacío** — `ranking_candidatos` es una view `security_invoker=true` que hace `JOIN` con `profiles`; la RLS de `profiles` solo permite leer el perfil propio, así que el JOIN descartaba todas las filas ajenas y el tab "Comunidad" mostraba "Nadie en el ranking aún" pese a haber 34 usuarios con XP en producción. Se agregó `get_xp_ranking()`, función `SECURITY DEFINER` (mismo patrón ya usado por `get_leaderboard()`) que expone solo las columnas ya públicas en pantalla — sin tocar ni relajar la RLS de `profiles` (email/phone/company_name siguen protegidos).

## Cambios

- `apps/frontend/src/app/api/labs/test-app/admin/verify/route.ts` (nuevo): verifica `ADMIN_KEY` server-side, setea cookie httpOnly.
- `apps/frontend/src/app/labs/test-app/admin/page.tsx`: ya no lee `NEXT_PUBLIC_ADMIN_KEY`; llama al route handler y limpia `?key=` de la URL tras autenticar.
- `apps/frontend/.env.local.example`, `apps/frontend/src/app/labs/test-app/README.md`: renombrado `NEXT_PUBLIC_ADMIN_KEY` → `ADMIN_KEY`.
- `supabase/migrations/20260702_020000_secure_xp_ranking_function.sql` (nuevo, ya aplicado a prod vía Supabase MCP): función `get_xp_ranking()`.
- `apps/frontend/src/actions/exams.ts`: `getXpRankingAction` usa el nuevo RPC en vez de leer la view directo.

## Pendiente post-merge

- Reemplazar `NEXT_PUBLIC_ADMIN_KEY` por `ADMIN_KEY` en las env vars de Vercel (dashboard, no se puede desde el repo).

## Nota

Este worktree no tiene `node_modules` instalado (falta `@aiquaa/shared` en el workspace al correr `pnpm install`), así que no pude correr `tsc`/build/tests localmente. Hooks de pre-commit/pre-push (`lint-staged`, `type-check`) se saltearon con confirmación explícita del usuario por este motivo — recomiendo que CI corra la verificación completa antes de mergear.

## Test plan

- [ ] CI: type-check, lint, build
- [ ] Manual: `/labs/test-app/admin?key=<ADMIN_KEY>` autentica y limpia la URL; sin key o key incorrecta → Acceso Denegado; refresh tras autenticar mantiene sesión (cookie)
- [ ] Manual: `/ranking` tab "Comunidad" muestra usuarios con XP (ya verificado en prod vía simulación de rol `authenticated`, 34/34 filas)

🤖 Generated with [Claude Code](https://claude.com/claude-code)