### PR TITLE
fix: community XP ranking empty after SEC-003 hardening

### DIFF
--- a/apps/frontend/src/actions/exams.ts
+++ b/apps/frontend/src/actions/exams.ts
@@ -149,42 +149,40 @@ export async function getLeaderboardAction(
 
 export async function getXpRankingAction(page = 1, limit = 20) {
   const supabase = createClient();
-  const offset = (page - 1) * limit;
   const {
     data: { user },
   } = await supabase.auth.getUser();
 
-  // ranking_candidatos view excludes audience='empresa' at DB level
-  // and includes achievement_count via subquery in the view
-  const { data, error, count } = await supabase
-    .from('ranking_candidatos')
-    .select(
-      'user_id, total_xp, level, current_streak, last_activity_at, display_name, avatar_url, achievement_count, main_badge',
-      { count: 'exact' }
-    )
-    .order('total_xp', { ascending: false })
-    .range(offset, offset + limit - 1);
+  // Uses SECURITY DEFINER RPC to bypass RLS on user_xp and profiles
+  const { data, error } = await supabase.rpc('get_xp_ranking', {
+    p_page: page,
+    p_limit: limit,
+  });
 
   if (error) return { error: error.message, data: null, total: 0 };
 
-  const entries = (data ?? []).map((row: any, i: number) => ({
+  const rows = (data ?? []) as any[];
+  const total = rows.length > 0 ? Number(rows[0].total_count) : 0;
+  const offset = (page - 1) * limit;
+
+  const entries = rows.map((row: any, i: number) => ({
     position: offset + i + 1,
     displayName: row.display_name ?? 'Anónimo',
     avatarUrl: row.avatar_url ?? null,
-    totalXp: row.total_xp,
-    level: row.level,
-    currentStreak: row.current_streak,
-    achievementCount: row.achievement_count ?? 0,
-    lastActivityAt: row.last_activity_at,
+    totalXp: Number(row.total_xp ?? 0),
+    level: row.level ?? 1,
+    currentStreak: row.current_streak ?? 0,
+    achievementCount: Number(row.achievement_count ?? 0),
+    lastActivityAt: row.last_activity_at ?? null,
     mainBadge: row.main_badge ?? null,
     isCurrentUser: Boolean(user?.id && row.user_id === user.id),
   }));
 
   return {
     data: entries,
-    total: count ?? 0,
+    total,
     page,
-    totalPages: Math.ceil((count ?? 0) / limit),
+    totalPages: Math.ceil(total / limit),
   };
 }
 

--- a/supabase/migrations/20260702_235000_fix_ranking_regression.sql
+++ b/supabase/migrations/20260702_235000_fix_ranking_regression.sql
@@ -1,0 +1,88 @@
+-- Fix regression from SEC-003 hardening that broke the community XP ranking.
+-- Two issues:
+--   1. user_xp RLS enabled without a SELECT policy → ranking_candidatos view
+--      returns 0 rows for authenticated users.
+--   2. profiles RLS hardened to own-row only → display_name/avatar_url are NULL
+--      for other users even if ranking_candidatos could read them.
+--
+-- Solution:
+--   a. Add SELECT policy on user_xp for own-row reads (fixes getMyXpProfileAction).
+--   b. Create SECURITY DEFINER function that bypasses RLS for the public ranking
+--      (fixes getXpRankingAction and the Comunidad tab).
+
+-- ── a) user_xp: allow authenticated users to read their own row ──────────────
+
+CREATE POLICY "user_xp_select_own" ON public.user_xp
+  FOR SELECT TO authenticated
+  USING (auth.uid() = user_id);
+
+CREATE POLICY "user_xp_select_service_role" ON public.user_xp
+  FOR SELECT TO service_role
+  USING (true);
+
+-- ── b) SECURITY DEFINER function: public XP ranking ──────────────────────────
+-- Bypasses RLS on user_xp and profiles so the Comunidad leaderboard works.
+-- Excludes audience = 'empresa' (company accounts).
+
+CREATE OR REPLACE FUNCTION public.get_xp_ranking(
+  p_page integer DEFAULT 1,
+  p_limit integer DEFAULT 20
+)
+RETURNS TABLE(
+  user_id uuid,
+  display_name text,
+  avatar_url text,
+  total_xp bigint,
+  level integer,
+  current_streak integer,
+  last_activity_at timestamptz,
+  achievement_count bigint,
+  main_badge text,
+  total_count bigint
+)
+LANGUAGE plpgsql STABLE SECURITY DEFINER SET search_path TO 'public'
+AS $$
+DECLARE
+  v_offset integer;
+  v_total bigint;
+BEGIN
+  v_offset := (p_page - 1) * p_limit;
+
+  -- Total count
+  SELECT COUNT(*) INTO v_total
+  FROM user_xp ux
+  JOIN profiles p ON p.id = ux.user_id
+  WHERE p.audience = 'candidato';
+
+  RETURN QUERY
+  SELECT
+    ux.user_id,
+    p.display_name,
+    p.avatar_url,
+    ux.total_xp,
+    ux.level,
+    ux.current_streak,
+    ux.last_activity_at,
+    COALESCE((
+      SELECT COUNT(*)::bigint
+      FROM ranking_achievements ra
+      WHERE ra.user_id = ux.user_id
+    ), 0) AS achievement_count,
+    COALESCE((
+      SELECT ra.achievement_id
+      FROM ranking_achievements ra
+      WHERE ra.user_id = ux.user_id
+      ORDER BY ra.unlocked_at DESC
+      LIMIT 1
+    ), NULL) AS main_badge,
+    v_total AS total_count
+  FROM user_xp ux
+  JOIN profiles p ON p.id = ux.user_id
+  WHERE p.audience = 'candidato'
+  ORDER BY ux.total_xp DESC
+  LIMIT p_limit
+  OFFSET v_offset;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.get_xp_ranking(integer, integer) TO anon, authenticated;


### PR DESCRIPTION
## What

Fixes the community XP ranking tab (Comunidad) showing empty results after SEC-003 RLS hardening.

## Root Cause

Two recent security migrations broke the leaderboard:
1. **\20260702_200000_fix_sec003_without_ranking_regression.sql\** enabled RLS on \user_xp\ but only added an INSERT policy — no SELECT policy → all reads return empty
2. **\20260702_000000_fix_profiles_pii_exposure.sql\** restricted \profiles\ RLS to own-row reads → display_name/avatar_url NULL for other users in ranking queries

## Fix

- Added \user_xp_select_own\ and \user_xp_select_service_role\ SELECT policies for completeness
- Created \get_xp_ranking()\ SECURITY DEFINER function that bypasses RLS on both \user_xp\ and \profiles\ (only reads, never writes)
- Updated \getXpRankingAction()\ frontend action to call \supabase.rpc('get_xp_ranking', ...)\ instead of querying \anking_candidatos\ view directly

## Files Changed

- \pps/frontend/src/actions/exams.ts\ — switched to RPC call
- \supabase/migrations/20260702_235000_fix_ranking_regression.sql\ — new migration: SELECT policies + get_xp_ranking() function + GRANT