### PR TITLE
fix: test-app exam integration for hiring process + bug report nav

### DIFF
--- a/apps/frontend/src/app/labs/test-app/components/TestAppLayout.tsx
+++ b/apps/frontend/src/app/labs/test-app/components/TestAppLayout.tsx
@@ -15,7 +15,10 @@ interface TestAppLayoutProps {
   requireAuth?: boolean;
 }
 
-export default function TestAppLayout({ children, requireAuth = false }: TestAppLayoutProps) {
+export default function TestAppLayout({
+  children,
+  requireAuth = false,
+}: TestAppLayoutProps) {
   const [user, setUser] = useState<User | null>(null);
   const [loading, setLoading] = useState(true);
   const [activeBugCount, setActiveBugCount] = useState(0);
@@ -71,7 +74,10 @@ export default function TestAppLayout({ children, requireAuth = false }: TestApp
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4">
           <div className="flex justify-between items-center">
             <div>
-              <Link href="/labs/test-app" className="text-2xl font-bold text-amber-600">
+              <Link
+                href="/labs/test-app"
+                className="text-2xl font-bold text-amber-600"
+              >
                 AIQUAA Test App
               </Link>
               <div className="flex items-center gap-2 mt-1">
@@ -128,6 +134,16 @@ export default function TestAppLayout({ children, requireAuth = false }: TestApp
                     Soporte
                   </Link>
                   <Link
+                    href="/labs/test-app/report"
+                    className={`text-sm font-semibold px-3 py-1.5 rounded-lg transition-colors ${
+                      isActive('/labs/test-app/report')
+                        ? 'bg-amber-600 text-white'
+                        : 'bg-red-50 text-red-700 hover:bg-red-100 border border-red-200'
+                    }`}
+                  >
+                    🐛 Reportar Bugs
+                  </Link>
+                  <Link
                     href="/labs/test-app/profile"
                     className={`text-sm font-medium ${
                       isActive('/labs/test-app/profile')
@@ -176,7 +192,16 @@ export default function TestAppLayout({ children, requireAuth = false }: TestApp
           <div className="flex justify-between items-center text-sm text-gray-600">
             <p>AIQUAA Test App — Solo para evaluación</p>
             <div className="flex space-x-4">
-              <Link href="/labs/test-app/evidence" className="hover:text-amber-600">
+              <Link
+                href="/labs/test-app/report"
+                className="hover:text-amber-600 font-semibold"
+              >
+                🐛 Reportar Bugs
+              </Link>
+              <Link
+                href="/labs/test-app/evidence"
+                className="hover:text-amber-600"
+              >
                 Evidencias
               </Link>
             </div>

--- a/apps/frontend/src/app/labs/test-app/report/page.tsx
+++ b/apps/frontend/src/app/labs/test-app/report/page.tsx
@@ -3,7 +3,6 @@
 export const dynamic = 'force-dynamic';
 
 import { useState, useEffect } from 'react';
-import { useRouter } from 'next/navigation';
 import { useTheme } from '@/contexts/ThemeContext';
 import { useSupabaseAuth } from '@/contexts/SupabaseAuthContext';
 import { getExamUserDefaults } from '@/lib/exam-user-defaults';
@@ -33,11 +32,13 @@ import { saveExamResultAction } from '@/actions/exams';
 export default function TechnicalReportPage() {
   const { isDarkMode } = useTheme();
   const { user, isLoading } = useSupabaseAuth();
-  const router = useRouter();
 
   useEffect(() => {
-    if (!isLoading && !user) router.push('/login');
-  }, [user, isLoading, router]);
+    if (!isLoading && !user) {
+      // Don't redirect — allow test-app-only users to fill the report form.
+      // Saving to DB will require Supabase auth, but PDF/JSON export works offline.
+    }
+  }, [user, isLoading]);
 
   // Candidate Info — pre-filled from session, github editable
   const [candidateInfo, setCandidateInfo] = useState<CandidateInfo>({
@@ -469,7 +470,7 @@ export default function TechnicalReportPage() {
     }
   };
 
-  if (isLoading || !user) {
+  if (isLoading) {
     return (
       <div
         className={`min-h-screen ${isDarkMode ? 'bg-slate-900' : 'bg-gray-50'} flex items-center justify-center`}
@@ -1185,25 +1186,41 @@ export default function TechnicalReportPage() {
           </div>
 
           <div className="flex flex-wrap gap-4">
-            <button
-              onClick={handleSaveToDb}
-              disabled={isSaving || savedOk}
-              className={`px-6 py-3 rounded-lg font-medium transition-colors ${
-                savedOk
-                  ? isDarkMode
-                    ? 'bg-green-900/50 text-green-300 cursor-not-allowed'
-                    : 'bg-green-100 text-green-700 cursor-not-allowed'
-                  : isSaving
-                    ? 'bg-indigo-400 text-white cursor-wait'
-                    : 'bg-indigo-600 hover:bg-indigo-700 text-white'
-              }`}
-            >
-              {isSaving
-                ? 'Guardando...'
-                : savedOk
-                  ? '✓ Guardado'
-                  : '💾 Guardar resultado'}
-            </button>
+            {!user ? (
+              <div className="flex items-center gap-3">
+                <a
+                  href="/login"
+                  className="px-6 py-3 rounded-lg font-medium bg-indigo-600 hover:bg-indigo-700 text-white transition-colors"
+                >
+                  🔑 Iniciar sesión para guardar
+                </a>
+                <span
+                  className={`text-xs ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}
+                >
+                  (Podés generar PDF y JSON sin sesión)
+                </span>
+              </div>
+            ) : (
+              <button
+                onClick={handleSaveToDb}
+                disabled={isSaving || savedOk}
+                className={`px-6 py-3 rounded-lg font-medium transition-colors ${
+                  savedOk
+                    ? isDarkMode
+                      ? 'bg-green-900/50 text-green-300 cursor-not-allowed'
+                      : 'bg-green-100 text-green-700 cursor-not-allowed'
+                    : isSaving
+                      ? 'bg-indigo-400 text-white cursor-wait'
+                      : 'bg-indigo-600 hover:bg-indigo-700 text-white'
+                }`}
+              >
+                {isSaving
+                  ? 'Guardando...'
+                  : savedOk
+                    ? '✓ Guardado'
+                    : '💾 Guardar resultado'}
+              </button>
+            )}
             <button
               onClick={handleGeneratePDF}
               className="px-6 py-3 bg-red-600 hover:bg-red-700 text-white rounded-lg font-medium transition-colors"


### PR DESCRIPTION
## Summary

Fixes the test-app exam integration end-to-end so candidates can actually take the exam and employers can see results.

### Changes

1. **Added 	est-app to process creation** — employers can now select 'Test App — Bug Hunt' when creating a hiring process (pps/frontend/src/app/empresa/procesos/nuevo/page.tsx)

2. **Added 	est-app labels in empresa views** — process detail and candidatos pages show 'Test App — Bug Hunt' instead of generic fallback (pps/frontend/src/app/empresa/candidatos/page.tsx, pps/frontend/src/app/empresa/procesos/[id]/page.tsx)

3. **Added 'Reportar Bugs' nav link** — prominent red button in test-app header and footer so candidates know where to report bugs (pps/frontend/src/app/labs/test-app/components/TestAppLayout.tsx)

4. **Fixed report page auth gate** — removed redirect to /login for unauthenticated users; candidates can now fill and export PDF/JSON without Supabase auth; save-to-DB still requires login (pps/frontend/src/app/labs/test-app/report/page.tsx)