### PR TITLE
fix: stabilize assessment and candidate display flows

### DIFF
--- a/apps/frontend/src/app/assessments/_shared/components/AssessmentSectionScreen.tsx
+++ b/apps/frontend/src/app/assessments/_shared/components/AssessmentSectionScreen.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useRef, useState, useTransition } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useParams, useRouter, useSearchParams } from 'next/navigation';
 import { useTheme } from '@/contexts/ThemeContext';
 import {
@@ -46,7 +46,7 @@ export default function AssessmentSectionScreen({
   const [savingMessage, setSavingMessage] = useState('Autosave activo');
   const [error, setError] = useState('');
   const [submitError, setSubmitError] = useState('');
-  const [isPending, startTransition] = useTransition();
+  const [isSubmitting, setIsSubmitting] = useState(false);
   const saveTimers = useRef<Record<string, number>>({});
 
   useEffect(() => {
@@ -56,6 +56,7 @@ export default function AssessmentSectionScreen({
     }
 
     let cancelled = false;
+    const timers = saveTimers.current;
 
     async function loadSection() {
       if (!attemptId) return;
@@ -91,9 +92,7 @@ export default function AssessmentSectionScreen({
 
     return () => {
       cancelled = true;
-      Object.values(saveTimers.current).forEach((timer) =>
-        window.clearTimeout(timer)
-      );
+      Object.values(timers).forEach((timer) => window.clearTimeout(timer));
     };
   }, [attemptId, basePath, router, sectionSlug]);
 
@@ -146,30 +145,33 @@ export default function AssessmentSectionScreen({
     if (!attemptId || !payload) return;
 
     setSubmitError('');
-    startTransition(async () => {
-      try {
-        const { nextSectionSlug } = await submitAssessmentSectionAction({
-          attemptId,
-          sectionSlug: payload.section.slug,
-        });
+    setIsSubmitting(true);
 
-        if (nextSectionSlug) {
-          router.push(
-            `${basePath}/section/${nextSectionSlug}?attempt=${attemptId}`
-          );
-          return;
-        }
+    try {
+      const { nextSectionSlug } = await submitAssessmentSectionAction({
+        attemptId,
+        sectionSlug: payload.section.slug,
+      });
 
-        await finalizeAssessmentAttemptAction(attemptId);
-        router.replace(`${basePath}/result?attempt=${attemptId}`);
-      } catch (submitSectionError) {
-        setSubmitError(
-          submitSectionError instanceof Error
-            ? submitSectionError.message
-            : 'No se pudo enviar la sección.'
+      if (nextSectionSlug) {
+        setIsSubmitting(false);
+        router.push(
+          `${basePath}/section/${nextSectionSlug}?attempt=${attemptId}`
         );
+        return;
       }
-    });
+
+      await finalizeAssessmentAttemptAction(attemptId);
+      setIsSubmitting(false);
+      router.replace(`${basePath}/result?attempt=${attemptId}`);
+    } catch (submitSectionError) {
+      setIsSubmitting(false);
+      setSubmitError(
+        submitSectionError instanceof Error
+          ? submitSectionError.message
+          : 'No se pudo enviar la sección.'
+      );
+    }
   }
 
   if (loading || !payload) {
@@ -451,7 +453,7 @@ export default function AssessmentSectionScreen({
                 ? 'Finalizar assessment'
                 : 'Enviar nivel y continuar'
             }
-            isSubmitting={isPending}
+            isSubmitting={isSubmitting}
             onSubmit={() => void handleSubmitSection()}
           />
         </div>

--- a/apps/frontend/src/app/assessments/infrastructure-fundamentals/start/page.tsx
+++ b/apps/frontend/src/app/assessments/infrastructure-fundamentals/start/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState, useTransition } from 'react';
+import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { useTheme } from '@/contexts/ThemeContext';
 import { startAssessmentAttemptAction } from '@/actions/assessments';
@@ -12,7 +12,7 @@ export default function StartInfrastructureFundamentalsPage() {
   const { isDarkMode } = useTheme();
   const [processCode, setProcessCode] = useState('');
   const [error, setError] = useState('');
-  const [isPending, startTransition] = useTransition();
+  const [isStarting, setIsStarting] = useState(false);
 
   // Pre-fill desde ?code= (links de invitaciones/procesos de empresa)
   useEffect(() => {
@@ -20,38 +20,42 @@ export default function StartInfrastructureFundamentalsPage() {
     if (codeParam) setProcessCode(codeParam);
   }, []);
 
-  function handleStart() {
+  async function handleStart() {
     setError('');
-    startTransition(async () => {
-      try {
-        const result = await startAssessmentAttemptAction({
-          slug: INFRASTRUCTURE_FUNDAMENTALS_SLUG,
-          processCode,
-        });
+    setIsStarting(true);
 
-        if ('error' in result) {
-          setError(result.error);
-          return;
-        }
+    try {
+      const result = await startAssessmentAttemptAction({
+        slug: INFRASTRUCTURE_FUNDAMENTALS_SLUG,
+        processCode,
+      });
 
-        const { attempt, sectionSlug } = result;
-
-        if (!sectionSlug) {
-          setError('No se encontró la primera sección del assessment.');
-          return;
-        }
-
-        router.push(
-          `/assessments/infrastructure-fundamentals/section/${sectionSlug}?attempt=${attempt.id}`
-        );
-      } catch (startError) {
-        setError(
-          startError instanceof Error
-            ? startError.message
-            : 'No se pudo iniciar el assessment.'
-        );
+      if ('error' in result) {
+        setIsStarting(false);
+        setError(result.error);
+        return;
       }
-    });
+
+      const { attempt, sectionSlug } = result;
+
+      if (!sectionSlug) {
+        setIsStarting(false);
+        setError('No se encontró la primera sección del assessment.');
+        return;
+      }
+
+      setIsStarting(false);
+      router.push(
+        `/assessments/infrastructure-fundamentals/section/${sectionSlug}?attempt=${attempt.id}`
+      );
+    } catch (startError) {
+      setIsStarting(false);
+      setError(
+        startError instanceof Error
+          ? startError.message
+          : 'No se pudo iniciar el assessment.'
+      );
+    }
   }
 
   return (
@@ -112,10 +116,10 @@ export default function StartInfrastructureFundamentalsPage() {
           <button
             type="button"
             onClick={handleStart}
-            disabled={isPending}
+            disabled={isStarting}
             className="inline-flex items-center justify-center rounded-2xl bg-cyan-400 px-5 py-3 text-sm font-semibold text-slate-950 transition hover:bg-cyan-300 disabled:cursor-not-allowed disabled:opacity-60"
           >
-            {isPending ? 'Preparando intento...' : 'Iniciar o reanudar'}
+            {isStarting ? 'Preparando intento...' : 'Iniciar o reanudar'}
           </button>
           <button
             type="button"

--- a/apps/frontend/src/app/empresa/procesos/[id]/page.tsx
+++ b/apps/frontend/src/app/empresa/procesos/[id]/page.tsx
@@ -32,13 +32,18 @@ type ExamResult = {
   id: string;
   participant_name: string | null;
   participant_email: string | null;
+  user_id?: string | null;
   exam_type: string;
   score: number;
   percentage: number;
   passed: boolean;
   time_spent: number;
   created_at: string;
+  profiles?: { display_name: string | null; email: string | null }[] | null;
 };
+
+// eslint-disable-next-line no-unused-vars
+type OnProspectAdded = (prospect: Prospect) => void;
 
 const STATUS_LABELS: Record<
   string,
@@ -75,6 +80,10 @@ function getEffectiveStatus(process: HiringProcess): string {
     return 'expired';
   }
   return process.status;
+}
+
+function getResultDisplayName(result: ExamResult) {
+  return result.participant_name || result.participant_email || '—';
 }
 
 const PROSPECT_STATUS_CONFIG: Record<
@@ -134,7 +143,7 @@ function AddProspectModal({
   processId: string;
   isDarkMode: boolean;
   onClose: () => void;
-  onAdded: (_p: Prospect) => void;
+  onAdded: OnProspectAdded;
 }) {
   const [name, setName] = useState('');
   const [email, setEmail] = useState('');
@@ -401,7 +410,7 @@ export default function ProcesoDetailPage() {
         supabase
           .from('exam_results')
           .select(
-            'id, participant_name, participant_email, exam_type, score, percentage, passed, time_spent, created_at'
+            'id, user_id, participant_name, participant_email, exam_type, score, percentage, passed, time_spent, created_at, profiles(display_name, email)'
           )
           .eq('process_code', proc.code)
           .order('percentage', { ascending: false }),
@@ -435,9 +444,22 @@ export default function ProcesoDetailPage() {
         });
       }
 
+      const examResults = ((res ?? []) as ExamResult[]).map((r) => ({
+        ...r,
+        participant_name:
+          r.profiles?.[0]?.display_name ??
+          r.participant_name ??
+          r.participant_email,
+        participant_email:
+          r.profiles?.[0]?.email ?? r.participant_email ?? null,
+      }));
+
       const mappedAttempts: ExamResult[] = attemptRows.map((r: any) => ({
         id: r.id,
-        participant_name: profileMap[r.user_id]?.display_name ?? null,
+        participant_name:
+          profileMap[r.user_id]?.display_name ??
+          profileMap[r.user_id]?.email ??
+          null,
         participant_email: profileMap[r.user_id]?.email ?? null,
         exam_type: r.assessments?.slug ?? 'unknown',
         score: r.total_score ?? 0,
@@ -454,7 +476,7 @@ export default function ProcesoDetailPage() {
         created_at: r.created_at,
       }));
 
-      setResults([...(res ?? []), ...mappedAttempts]);
+      setResults([...examResults, ...mappedAttempts]);
       setProspects(prsp ?? []);
       setLoading(false);
     };
@@ -844,7 +866,7 @@ export default function ProcesoDetailPage() {
                           <p
                             className={`text-sm font-medium truncate ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
                           >
-                            {r.participant_name || '—'}
+                            {getResultDisplayName(r)}
                           </p>
                           <p
                             className={`text-xs truncate ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}
@@ -932,7 +954,7 @@ export default function ProcesoDetailPage() {
                             <div
                               className={`font-medium ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
                             >
-                              {r.participant_name || '—'}
+                              {getResultDisplayName(r)}
                             </div>
                             {r.participant_email && (
                               <div

--- a/supabase/migrations/20260702_235000_fix_ranking_regression.sql
+++ b/supabase/migrations/20260702_235000_fix_ranking_regression.sql
@@ -12,10 +12,12 @@
 
 -- ── a) user_xp: allow authenticated users to read their own row ──────────────
 
+DROP POLICY IF EXISTS "user_xp_select_own" ON public.user_xp;
 CREATE POLICY "user_xp_select_own" ON public.user_xp
   FOR SELECT TO authenticated
   USING (auth.uid() = user_id);
 
+DROP POLICY IF EXISTS "user_xp_select_service_role" ON public.user_xp;
 CREATE POLICY "user_xp_select_service_role" ON public.user_xp
   FOR SELECT TO service_role
   USING (true);


### PR DESCRIPTION
Reemplacé el submit asíncrono para evitar que los assessments queden en Procesando..., corregí el inicio de infraestructura y mostré nombres de candidatos con fallback a email. Verificación: eslint sobre archivos tocados y typecheck pre-push.