### PR TITLE
fix: preserve evidence images in test-app exam submission

### DIFF
--- a/apps/frontend/src/actions/exam-review.ts
+++ b/apps/frontend/src/actions/exam-review.ts
@@ -13,6 +13,15 @@ type ReviewData = {
   adjustedScore: number | null;
 };
 
+type BugImageEvidence = {
+  id: string;
+  fileName: string;
+  base64Data: string;
+  mimeType: string;
+  size: number;
+  uploadedAt: string;
+};
+
 export type ExamDetail = {
   id: string;
   participant_name: string | null;
@@ -40,6 +49,7 @@ export type ExamDetail = {
       severity: 'Critical' | 'High' | 'Medium' | 'Low';
       category: string;
       evidence: string;
+      images?: BugImageEvidence[];
       foundAt: string;
     }>;
     exploredSections: string[];

--- a/apps/frontend/src/app/empresa/evaluar/[resultId]/page.tsx
+++ b/apps/frontend/src/app/empresa/evaluar/[resultId]/page.tsx
@@ -457,6 +457,36 @@ export default function EvaluarPage() {
                           </div>
                         )}
 
+                        {bug.images && bug.images.length > 0 && (
+                          <div>
+                            <p className={labelClass}>
+                              Imágenes evidencia ({bug.images.length})
+                            </p>
+                            <div className="grid grid-cols-2 sm:grid-cols-3 gap-3 mt-2">
+                              {bug.images.map((image) => (
+                                <a
+                                  key={image.id}
+                                  href={image.base64Data}
+                                  target="_blank"
+                                  rel="noopener noreferrer"
+                                  className="block rounded-lg overflow-hidden border border-slate-600/40"
+                                >
+                                  <img
+                                    src={image.base64Data}
+                                    alt={image.fileName}
+                                    className="w-full h-32 object-cover"
+                                  />
+                                  <p
+                                    className={`text-xs px-1.5 py-1 truncate ${isDarkMode ? 'bg-slate-800 text-slate-400' : 'bg-gray-100 text-gray-600'}`}
+                                  >
+                                    {image.fileName}
+                                  </p>
+                                </a>
+                              ))}
+                            </div>
+                          </div>
+                        )}
+
                         <div>
                           <label
                             className={`block text-sm font-medium mb-1 ${isDarkMode ? 'text-slate-300' : 'text-gray-700'}`}

--- a/apps/frontend/src/app/labs/test-app/report/page.tsx
+++ b/apps/frontend/src/app/labs/test-app/report/page.tsx
@@ -385,7 +385,6 @@ export default function TechnicalReportPage() {
       user?.email ||
       '';
     const participantEmail = candidateInfo.email || user?.email || '';
-    const bugsWithoutImages = bugs.map(({ images: _images, ...rest }) => rest);
     const { error } = await saveExamResultAction({
       exam_type: 'test-app',
       exam_mode: 'exam',
@@ -403,7 +402,7 @@ export default function TechnicalReportPage() {
       github_profile: candidateInfo.githubProfile || undefined,
       process_code: processCode.trim().toUpperCase() || undefined,
       metadata: {
-        bugs: bugsWithoutImages,
+        bugs,
         exploredSections: testSession.exploredSections,
         bugCount: bugs.length,
         severityCounts: {


### PR DESCRIPTION
## Summary
- Bug evidence images (already base64-encoded client-side) were stripped before saving exam results, so evaluators never saw them in the correction screen.
- Images now flow through `metadata.bugs[].images` and render as clickable thumbnails on the `/empresa/evaluar/[resultId]` review page.

## Test plan
- [ ] `pnpm install` && `pnpm dev:front`
- [ ] Complete a `/labs/test-app` exam, attach an image to a bug, submit
- [ ] As evaluator, open `/empresa/candidatos` → "evaluados" tab → "Revisar" and confirm the image preview appears in `/empresa/evaluar/[resultId]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)