### PR TITLE
fix: validate process_code before exam_results insert

### DIFF
--- a/apps/frontend/src/actions/exams.ts
+++ b/apps/frontend/src/actions/exams.ts
@@ -77,9 +77,26 @@ export async function saveExamResultAction(payload: SaveExamResultPayload) {
 
   const resolvedEmail = payload.participant_email?.trim() || user.email || null;
 
+  let resolvedProcessCode = payload.process_code?.trim() || undefined;
+  if (resolvedProcessCode) {
+    const { data: process } = await supabase
+      .from('hiring_processes')
+      .select('code')
+      .eq('code', resolvedProcessCode)
+      .maybeSingle();
+
+    if (!process) {
+      return {
+        error:
+          'El código de proceso ingresado no existe o ya no está vigente. Verificá el código con la empresa antes de enviar el examen.',
+      };
+    }
+  }
+
   const { error } = await supabase.from('exam_results').insert({
     user_id: user.id,
     ...payload,
+    process_code: resolvedProcessCode,
     participant_name: resolvedName,
     participant_email: resolvedEmail,
   });
@@ -87,12 +104,12 @@ export async function saveExamResultAction(payload: SaveExamResultPayload) {
   if (error) return { error: error.message };
 
   // Mark empresa_invitacion as completada when exam is submitted with a process code
-  if (payload.process_code && resolvedEmail) {
+  if (resolvedProcessCode && resolvedEmail) {
     try {
       const { data: process } = await supabase
         .from('hiring_processes')
         .select('id')
-        .eq('code', payload.process_code)
+        .eq('code', resolvedProcessCode)
         .maybeSingle();
 
       if (process?.id) {


### PR DESCRIPTION
## Summary
- Candidates submitting the test-app report at `/labs/test-app/report` could type any hiring process code into a free-text field; a wrong, typo'd, or expired code hit the `exam_results_process_code_fkey` constraint on insert and surfaced a raw Postgres FK error instead of an actionable message.
- `saveExamResultAction` now looks up the code in `hiring_processes` before inserting into `exam_results`. If it doesn't exist, it returns a friendly Spanish error asking the candidate to verify the code with the company, instead of attempting (and failing) the insert.

## Test plan
- [ ] Submit the test-app report with a valid process code — exam saves and invitation is marked `completada`.
- [ ] Submit with an invalid/typo'd process code — see friendly error, no unhandled exception.
- [ ] Submit with no process code — exam saves as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)