### PR TITLE
fix: prefer-const lint error breaking Vercel build

### DIFF
--- a/apps/frontend/src/actions/exams.ts
+++ b/apps/frontend/src/actions/exams.ts
@@ -77,7 +77,7 @@ export async function saveExamResultAction(payload: SaveExamResultPayload) {
 
   const resolvedEmail = payload.participant_email?.trim() || user.email || null;
 
-  let resolvedProcessCode = payload.process_code?.trim() || undefined;
+  const resolvedProcessCode = payload.process_code?.trim() || undefined;
   if (resolvedProcessCode) {
     const { data: process } = await supabase
       .from('hiring_processes')


### PR DESCRIPTION
## Summary
- `main` build is currently broken: `resolvedProcessCode` in `apps/frontend/src/actions/exams.ts` was declared with `let` but never reassigned, tripping Next.js's `prefer-const` ESLint rule during `next build`, which fails the whole build.
- Changed to `const`.

## Test plan
- [ ] Vercel build succeeds (lint step passes).