### PR TITLE
fix: resolve process_code case-insensitively

### DIFF
--- a/apps/frontend/src/actions/exams.ts
+++ b/apps/frontend/src/actions/exams.ts
@@ -77,12 +77,16 @@ export async function saveExamResultAction(payload: SaveExamResultPayload) {
 
   const resolvedEmail = payload.participant_email?.trim() || user.email || null;
 
-  const resolvedProcessCode = payload.process_code?.trim() || undefined;
-  if (resolvedProcessCode) {
+  // hiring_processes.code is stored with mixed case; match case-insensitively
+  // and use the canonical stored value so it satisfies exam_results'
+  // FK to hiring_processes(code) regardless of how the candidate typed it.
+  const rawProcessCode = payload.process_code?.trim() || undefined;
+  let resolvedProcessCode: string | undefined;
+  if (rawProcessCode) {
     const { data: process } = await supabase
       .from('hiring_processes')
       .select('code')
-      .eq('code', resolvedProcessCode)
+      .ilike('code', rawProcessCode)
       .maybeSingle();
 
     if (!process) {
@@ -91,6 +95,7 @@ export async function saveExamResultAction(payload: SaveExamResultPayload) {
           'El código de proceso ingresado no existe o ya no está vigente. Verificá el código con la empresa antes de enviar el examen.',
       };
     }
+    resolvedProcessCode = process.code;
   }
 
   const { error } = await supabase.from('exam_results').insert({


### PR DESCRIPTION
## Summary
- `hiring_processes.code` is stored with mixed case (e.g. `testappfinal-CXXU`), but the test-app report page uppercases whatever the candidate types before sending it, and `saveExamResultAction` looked it up with an exact-case `.eq()`. Result: valid codes were rejected as "no existe" (previously: raw FK violation on insert, since there was no pre-validation at all).
- Fixed the lookup to use `.ilike()` and store the canonical DB-cased value, matching the pattern already used in `assignProcessCodeToExamAction` and `app/api/assessments/start/route.ts`.

## Test plan
- [ ] Submit test-app report with an existing process code in a different case than stored (e.g. type `TESTAPPFINAL-CXXU` for stored `testappfinal-CXXU`) — should save successfully.
- [ ] Submit with a nonexistent code — still shows the friendly error.
- [ ] Submit with no code — unaffected.