### PR TITLE
fix: sync process_code display in exam history

### DIFF
--- a/apps/frontend/src/actions/exams.ts
+++ b/apps/frontend/src/actions/exams.ts
@@ -253,7 +253,7 @@ export async function assignProcessCodeToExamAction(
   // Validate the process code exists and is active
   const { data: process, error: procError } = await supabase
     .from('hiring_processes')
-    .select('code, company_name, position_name, status, expires_at')
+    .select('id, code, company_name, position_name, status, expires_at')
     .ilike('code', processCode.trim())
     .eq('status', 'active')
     .single();
@@ -302,6 +302,7 @@ export async function assignProcessCodeToExamAction(
           completed_at: new Date().toISOString(),
         })
         .eq('candidate_email', resolvedEmail)
+        .eq('process_id', process.id)
         .in('status', ['pendiente', 'vista']);
     } catch {
       // Non-critical
@@ -310,6 +311,7 @@ export async function assignProcessCodeToExamAction(
 
   return {
     success: true,
+    process_code: process.code,
     process: {
       company_name: process.company_name,
       position_name: process.position_name,

--- a/apps/frontend/src/app/perfil/page.tsx
+++ b/apps/frontend/src/app/perfil/page.tsx
@@ -224,9 +224,11 @@ export default function PerfilPage() {
           : 'Código asignado correctamente',
       });
       // Update the local state so the badge changes immediately
+      // (usa el código normalizado que devolvió el servidor, no el texto tipeado)
+      const confirmedCode = result.process_code ?? code;
       setExamResults((prev) =>
         prev.map((r) =>
-          r.id === examResultId ? { ...r, process_code: code } : r
+          r.id === examResultId ? { ...r, process_code: confirmedCode } : r
         )
       );
       setAssigningTo(null);
@@ -1338,7 +1340,9 @@ export default function PerfilPage() {
                                 : 'bg-gray-200 text-gray-600'
                           }`}
                         >
-                          {r.process_code ? `📋 Oficial` : `✏️ Práctica`}
+                          {r.process_code
+                            ? `📋 Oficial · ${r.process_code}`
+                            : `✏️ Práctica`}
                         </span>
 
                         {/* Assign code button (only for practice exams) */}


### PR DESCRIPTION
## Summary
- Show the linked hiring-process code next to the "Oficial" badge in the exam history on the profile page.
- Fix `assignProcessCodeToExamAction` to return the normalized `process_code` from `hiring_processes`, and use it in the profile's local state instead of the raw text the user typed (avoids case/format mismatch vs. what's actually stored in `exam_results`).
- Scope the `empresa_invitaciones` completion update in `assignProcessCodeToExamAction` to `process_id`, matching `saveExamResultAction`'s behavior — previously it could mark the wrong invitation as completed when the same email had invitations across multiple hiring processes.

## Test plan
- [ ] In `/perfil`, complete a practice exam, use "Asignar código" with a valid process code, confirm the badge shows "📋 Oficial · <CODE>" matching the process's actual code casing.
- [ ] Verify `exam_results.process_code` in Supabase matches what's displayed.
- [ ] With a candidate email that has invitations to two different hiring processes, confirm only the invitation for the matching process is marked `completada`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)