### PR TITLE
fix: add missing UPDATE RLS policy on exam_results

### DIFF
--- a/supabase/migrations/20260703_000000_add_exam_results_update_policy.sql
+++ b/supabase/migrations/20260703_000000_add_exam_results_update_policy.sql
@@ -1,0 +1,12 @@
+-- exam_results nunca tuvo policy de UPDATE (solo INSERT/SELECT), por lo que
+-- assignProcessCodeToExamAction actualizaba 0 filas en silencio: el candidato
+-- veía "código asignado correctamente" pero al recargar el process_code
+-- seguía en null. La app ya valida ownership y que process_code sea null
+-- antes de llamar al update (ver assignProcessCodeToExamAction), así que acá
+-- solo habilitamos que el dueño de la fila pueda actualizarla.
+
+CREATE POLICY "Users update own results"
+  ON public.exam_results
+  FOR UPDATE
+  USING (auth.uid() = user_id)
+  WITH CHECK (auth.uid() = user_id);


### PR DESCRIPTION
## Summary
- `exam_results` only had INSERT/SELECT RLS policies — no UPDATE policy existed at all.
- `assignProcessCodeToExamAction` (used by the "Asignar código" button in `/perfil`) calls `.update({ process_code })`, which RLS silently blocked (0 rows affected, no error surfaced).
- The UI showed "código asignado correctamente" from the optimistic local state update, but nothing was persisted — on reload the process code was gone.
- Added a migration granting owners (`auth.uid() = user_id`) UPDATE access on their own `exam_results` rows. Already applied directly to the production Supabase project (`cbkctkpyxwbufvbwxogp`) so the fix is live now; this PR just versions the migration in the repo.

## Test plan
- [x] Verified in Supabase that the policy now exists (`pg_policies` shows `Users update own results` with `cmd = UPDATE`).
- [ ] In `/perfil`, use "Asignar código" on a practice exam, reload the page, confirm the process code persists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)