### PR TITLE
fix: employer views were dropping candidates without opt-in talent visibility

### DIFF
--- a/apps/frontend/src/app/empresa/candidatos/page.tsx
+++ b/apps/frontend/src/app/empresa/candidatos/page.tsx
@@ -47,7 +47,6 @@ type ExamResult = {
   process_code: string | null;
   section_scores: SectionScore[] | null;
   learning_objectives: unknown | null;
-  profiles?: { display_name: string | null }[] | null;
 };
 
 type ViewMode = 'evaluados' | 'talento' | 'favoritos';
@@ -227,7 +226,7 @@ export default function CandidatosPage() {
           supabase
             .from('exam_results')
             .select(
-              'id, participant_name, participant_email, user_id, exam_type, score, percentage, passed, time_spent, created_at, process_code, section_scores, learning_objectives, profiles(display_name)'
+              'id, participant_name, participant_email, user_id, exam_type, score, percentage, passed, time_spent, created_at, process_code, section_scores, learning_objectives'
             )
             .in('process_code', processCodes),
           supabase
@@ -244,14 +243,7 @@ export default function CandidatosPage() {
             .eq('status', 'graded'),
         ]);
 
-        // Use current profile name when available; fall back to the snapshot stored at exam time
-        const examResults = ((examResultsRes.data ?? []) as ExamResult[]).map(
-          (r) => ({
-            ...r,
-            participant_name:
-              r.profiles?.[0]?.display_name ?? r.participant_name,
-          })
-        );
+        const examResults = (examResultsRes.data ?? []) as ExamResult[];
 
         const attemptRows = assessmentAttemptsRes.data ?? [];
         const userIds = [

--- a/apps/frontend/src/app/empresa/procesos/[id]/page.tsx
+++ b/apps/frontend/src/app/empresa/procesos/[id]/page.tsx
@@ -39,7 +39,6 @@ type ExamResult = {
   passed: boolean;
   time_spent: number;
   created_at: string;
-  profiles?: { display_name: string | null; email: string | null }[] | null;
 };
 
 // eslint-disable-next-line no-unused-vars
@@ -410,7 +409,7 @@ export default function ProcesoDetailPage() {
         supabase
           .from('exam_results')
           .select(
-            'id, user_id, participant_name, participant_email, exam_type, score, percentage, passed, time_spent, created_at, profiles(display_name, email)'
+            'id, user_id, participant_name, participant_email, exam_type, score, percentage, passed, time_spent, created_at'
           )
           .eq('process_code', proc.code)
           .order('percentage', { ascending: false }),
@@ -446,12 +445,8 @@ export default function ProcesoDetailPage() {
 
       const examResults = ((res ?? []) as ExamResult[]).map((r) => ({
         ...r,
-        participant_name:
-          r.profiles?.[0]?.display_name ??
-          r.participant_name ??
-          r.participant_email,
-        participant_email:
-          r.profiles?.[0]?.email ?? r.participant_email ?? null,
+        participant_name: r.participant_name ?? r.participant_email,
+        participant_email: r.participant_email ?? null,
       }));
 
       const mappedAttempts: ExamResult[] = attemptRows.map((r: any) => ({


### PR DESCRIPTION
## Summary
- `apps/frontend/src/app/empresa/procesos/[id]/page.tsx` and `apps/frontend/src/app/empresa/candidatos/page.tsx` both queried `exam_results` with an embedded `profiles(display_name, email)`.
- `exam_results.user_id` is `NOT NULL`, so PostgREST embeds the relationship as an inner join.
- `profiles` RLS only allows reading your own profile, or a candidate's profile when `talent_visible_to_empresas = true`. Almost no candidate opts into that flag.
- Result: **every exam result belonging to a candidate who didn't opt in was silently dropped** from the employer's process detail page and the "Evaluados"/talent page — even though the employer legitimately owns the hiring process those results belong to. This is what was causing "no puedo ver ninguna prueba entregada" for `testappfinal-CXXU` (15 real submissions, all invisible).
- Fix: drop the `profiles(...)` embed in both places and rely on `participant_name`/`participant_email`, which `exam_results` already stores at submission time (same pattern already used for `assessment_attempts` in the same files).

## Test plan
- [ ] As an employer, open a process detail page (`/empresa/procesos/[id]`) for a process with submitted candidates who have not enabled "visible to empresas" — confirm they now show up.
- [ ] Check "Evaluados" / talent search page under `/empresa/candidatos` — confirm the same candidates appear there too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)