### PR TITLE
feat: preview evidence link as image in bug review

### DIFF
--- a/apps/frontend/src/app/empresa/evaluar/[resultId]/page.tsx
+++ b/apps/frontend/src/app/empresa/evaluar/[resultId]/page.tsx
@@ -33,6 +33,49 @@ const REVIEW_STATUS_LABELS: Record<string, { text: string; color: string }> = {
 
 const EXAM_LABEL = '🧪 Test App — Bug Hunt';
 
+const IMAGE_URL_PATTERN = /^https?:\/\/\S+\.(png|jpe?g|gif|webp|avif|svg)(\?\S*)?$/i;
+
+function isImageUrl(value: string): boolean {
+  return IMAGE_URL_PATTERN.test(value.trim());
+}
+
+function EvidencePreview({
+  evidence,
+  isDarkMode,
+}: {
+  evidence: string;
+  isDarkMode: boolean;
+}) {
+  const [imageFailed, setImageFailed] = useState(false);
+  const trimmed = evidence.trim();
+
+  if (!imageFailed && isImageUrl(trimmed)) {
+    return (
+      <a
+        href={trimmed}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="mt-2 block w-fit max-w-xs rounded-lg overflow-hidden border border-slate-600/40"
+      >
+        <img
+          src={trimmed}
+          alt="Evidencia"
+          className="max-h-48 w-auto object-contain"
+          onError={() => setImageFailed(true)}
+        />
+      </a>
+    );
+  }
+
+  return (
+    <p
+      className={`text-sm mt-1 break-all ${isDarkMode ? 'text-slate-300' : 'text-gray-700'}`}
+    >
+      {trimmed}
+    </p>
+  );
+}
+
 export default function EvaluarPage() {
   const { isDarkMode } = useTheme();
   const { user, isLoading: authLoading } = useSupabaseAuth();
@@ -449,11 +492,10 @@ export default function EvaluarPage() {
                         {bug.evidence && (
                           <div>
                             <p className={labelClass}>Evidencia</p>
-                            <p
-                              className={`text-sm mt-1 ${isDarkMode ? 'text-slate-300' : 'text-gray-700'}`}
-                            >
-                              {bug.evidence}
-                            </p>
+                            <EvidencePreview
+                              evidence={bug.evidence}
+                              isDarkMode={isDarkMode}
+                            />
                           </div>
                         )}
 


### PR DESCRIPTION
## Summary
- In `/empresa/evaluar/[resultId]` (Test App — Bug Hunt review), the "Evidencia" field is free text and often a URL to a screenshot, but was rendered as plain text with no way to view it without leaving the page.
- Added `EvidencePreview`: if the text looks like an image URL (`https://...png/jpg/gif/webp/avif/svg`), render it as a clickable thumbnail (opens full-size in a new tab); otherwise fall back to plain text. If the image fails to load, falls back to plain text too.
- Matches the preview UX already in place for uploaded evidence images (`bug.images`) on the same page.

## Test plan
- [ ] Open a Test App Bug Hunt result review with a bug whose "Evidencia" field is an image URL — confirm it shows as a thumbnail and opens full-size on click.
- [ ] Confirm a bug with a plain-text (non-image) "Evidencia" still renders as text.
- [ ] Confirm a broken/unreachable image URL falls back to plain text instead of a broken image icon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)