### PR TITLE
feat(eventos): reporte macro por evento con exámenes, candidatos y export CSV

### DIFF
--- a/apps/frontend/src/actions/employer.ts
+++ b/apps/frontend/src/actions/employer.ts
@@ -646,6 +646,7 @@ export interface EventProcessStat {
   position_name: string;
   status: 'draft' | 'active' | 'closed';
   expires_at: string | null;
+  examCount: number;
   candidateCount: number;
   passedCount: number;
   passRate: number;
@@ -653,6 +654,7 @@ export interface EventProcessStat {
 }
 
 export interface EventCandidate {
+  userId: string | null;
   name: string;
   email: string | null;
   examType: string;
@@ -704,7 +706,7 @@ export async function getEventStatsAction(groupId: string): Promise<{
 
   const { data: procs, error: procsError } = await supabase
     .from('hiring_processes')
-    .select('id, code, position_name, status, expires_at')
+    .select('id, code, position_name, status, expires_at, exam_types')
     .eq('group_id', groupId)
     .order('created_at', { ascending: true });
 
@@ -731,6 +733,7 @@ export async function getEventStatsAction(groupId: string): Promise<{
   if (resultsError) return { error: resultsError, data: null };
 
   const allRaw: EventCandidate[] = rawResults.map((row) => ({
+    userId: row.user_id ?? null,
     name: row.participant_name || row.participant_email || 'Sin nombre',
     email: row.participant_email ?? null,
     examType: row.exam_type,
@@ -739,10 +742,18 @@ export async function getEventStatsAction(groupId: string): Promise<{
     passed: row.passed ?? false,
   }));
 
-  // Per-process stats (across both sources)
+  const candidateKey = (r: EventCandidate) =>
+    r.userId || (r.email || r.name || '').toLowerCase().trim();
+
+  // Per-process stats (across both sources). candidateCount counts unique
+  // people, not exam attempts — a candidate who rendered 8 exams in this
+  // process still counts once.
   const processStats: EventProcessStat[] = processes.map((p) => {
     const rows = allRaw.filter((r) => r.processCode === p.code);
-    const passed = rows.filter((r) => r.passed).length;
+    const uniqueCandidates = new Set(rows.map(candidateKey));
+    const passedCandidates = new Set(
+      rows.filter((r) => r.passed).map(candidateKey)
+    );
     const scores = rows.map((r) => r.percentage);
     return {
       id: p.id,
@@ -750,9 +761,13 @@ export async function getEventStatsAction(groupId: string): Promise<{
       position_name: p.position_name,
       status: p.status,
       expires_at: p.expires_at,
-      candidateCount: rows.length,
-      passedCount: passed,
-      passRate: rows.length > 0 ? Math.round((passed / rows.length) * 100) : 0,
+      examCount: p.exam_types?.length ?? 0,
+      candidateCount: uniqueCandidates.size,
+      passedCount: passedCandidates.size,
+      passRate:
+        uniqueCandidates.size > 0
+          ? Math.round((passedCandidates.size / uniqueCandidates.size) * 100)
+          : 0,
       topScore: scores.length > 0 ? Math.max(...scores) : null,
     };
   });

--- a/apps/frontend/src/app/empresa/eventos/[id]/page.tsx
+++ b/apps/frontend/src/app/empresa/eventos/[id]/page.tsx
@@ -132,6 +132,46 @@ export default function EventoDetailPage() {
     });
   }, [groupId]);
 
+  const exportProcessesCSV = () => {
+    if (!stats) return;
+    const rows = [
+      [
+        'Proceso',
+        'Código',
+        'Pruebas técnicas',
+        'Candidatos',
+        'Aprobados',
+        'Tasa aprobación',
+        'Top score',
+        'Estado',
+      ],
+      ...stats.processes.map((p) => [
+        p.position_name,
+        p.code,
+        String(p.examCount),
+        String(p.candidateCount),
+        String(p.passedCount),
+        p.candidateCount > 0 ? `${p.passRate}%` : '',
+        p.topScore !== null ? `${p.topScore}%` : '',
+        STATUS_BADGE[getEffectiveStatus(p)]?.text ?? p.status,
+      ]),
+    ];
+    const csv = rows
+      .map((row) =>
+        row.map((cell) => `"${String(cell).replace(/"/g, '""')}"`).join(',')
+      )
+      .join('\n');
+    const blob = new Blob(['﻿' + csv], {
+      type: 'text/csv;charset=utf-8;',
+    });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `evento-${stats.group.name.toLowerCase().replace(/\s+/g, '-')}-procesos-${new Date().toISOString().slice(0, 10)}.csv`;
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
   const cardClass = `rounded-xl border ${
     isDarkMode
       ? 'bg-dark-secondary border-slate-700'
@@ -615,13 +655,20 @@ export default function EventoDetailPage() {
             {/* Processes table */}
             <div className={`${cardClass} overflow-hidden`}>
               <div
-                className={`px-5 py-4 border-b ${isDarkMode ? 'border-slate-700' : 'border-gray-100'}`}
+                className={`px-5 py-4 border-b flex items-center justify-between gap-4 ${isDarkMode ? 'border-slate-700' : 'border-gray-100'}`}
               >
                 <p
                   className={`text-sm font-semibold ${isDarkMode ? 'text-slate-300' : 'text-gray-700'}`}
                 >
                   Procesos del evento
                 </p>
+                <button
+                  type="button"
+                  onClick={exportProcessesCSV}
+                  className={`px-3 py-1.5 rounded-lg text-xs font-medium border transition-colors ${isDarkMode ? 'border-slate-600 text-slate-300 hover:bg-slate-700' : 'border-gray-300 text-gray-700 hover:bg-gray-50'}`}
+                >
+                  📥 Exportar CSV
+                </button>
               </div>
               <div className="overflow-x-auto">
                 <table className="w-full text-sm">
@@ -635,6 +682,9 @@ export default function EventoDetailPage() {
                     >
                       <th className="px-5 py-3 text-left">Proceso</th>
                       <th className="px-4 py-3 text-left">Código</th>
+                      <th className="px-4 py-3 text-center">
+                        Pruebas técnicas
+                      </th>
                       <th className="px-4 py-3 text-center">Candidatos</th>
                       <th className="px-4 py-3 text-center">Aprobados</th>
                       <th className="px-4 py-3 text-center">Tasa</th>
@@ -675,6 +725,11 @@ export default function EventoDetailPage() {
                             >
                               {p.code}
                             </span>
+                          </td>
+                          <td
+                            className={`px-4 py-3 text-center ${isDarkMode ? 'text-slate-300' : 'text-gray-700'}`}
+                          >
+                            {p.examCount}
                           </td>
                           <td
                             className={`px-4 py-3 text-center ${isDarkMode ? 'text-slate-300' : 'text-gray-700'}`}


### PR DESCRIPTION
## Summary
- La vista de "evento" (`/empresa/eventos/[id]`) agrupa varios procesos de contratación y ya mostraba candidatos/aprobados/tasa por proceso, pero faltaba la cantidad de pruebas técnicas de cada proceso y no había forma de exportar el resumen.
- Se agrega columna **"Pruebas técnicas"** a la tabla "Procesos del evento" (viene de `hiring_processes.exam_types`).
- Se agrega botón **"📥 Exportar CSV"** que descarga esa tabla resumen: Proceso, Código, Pruebas técnicas, Candidatos, Aprobados, Tasa aprobación, Top score, Estado.
- De paso se corrige `candidateCount`/`passedCount`: antes contaban filas de resultado de examen (un candidato con 8 exámenes sumaba 8), ahora deduplican por candidato (`user_id`, con fallback a email/nombre) — mismo patrón de bug que se corrigió en el detalle de proceso individual (PR #253).

## Test plan
- [ ] Abrir un evento con varios procesos en `/empresa/eventos/[id]` y confirmar que la columna "Pruebas técnicas" muestra el número correcto por proceso
- [ ] Confirmar que "Candidatos" ya no infla el conteo cuando un mismo candidato rindió varios exámenes en el mismo proceso
- [ ] Click en "Exportar CSV" y verificar que el archivo descargado tiene las columnas esperadas y abre bien en Excel/Sheets

🤖 Generated with [Claude Code](https://claude.com/claude-code)