### PR TITLE
feat(eventos): completado y resultados por participante

### DIFF
--- a/apps/frontend/src/actions/employer.ts
+++ b/apps/frontend/src/actions/employer.ts
@@ -670,12 +670,37 @@ export interface EventExamTypeStat {
   passRate: number;
 }
 
+export interface EventParticipantResult {
+  examType: string;
+  processCode: string;
+  percentage: number;
+  passed: boolean;
+}
+
+export interface EventParticipant {
+  key: string;
+  userId: string | null;
+  name: string;
+  email: string | null;
+  /** One entry per distinct exam type attempted (best attempt kept). */
+  results: EventParticipantResult[];
+  completedCount: number;
+  completionRate: number;
+  passedCount: number;
+  avgScore: number;
+  bestScore: number;
+}
+
 export interface EventStats {
   group: ProcessGroup;
   processes: EventProcessStat[];
   /** All candidates sorted by percentage DESC (use .slice(0,10) for chart) */
   allCandidates: EventCandidate[];
   byExamType: EventExamTypeStat[];
+  /** One entry per unique participant, with their per-exam results. */
+  participants: EventParticipant[];
+  /** Distinct exam types required across all processes in this event. */
+  totalExamTypes: number;
   totals: {
     candidates: number;
     passed: number;
@@ -721,6 +746,8 @@ export async function getEventStatsAction(groupId: string): Promise<{
         processes: [],
         allCandidates: [],
         byExamType: [],
+        participants: [],
+        totalExamTypes: 0,
         totals: { candidates: 0, passed: 0, passRate: 0, avgScore: null },
       },
       error: null,
@@ -805,6 +832,81 @@ export async function getEventStatsAction(groupId: string): Promise<{
     })
   );
 
+  // Distinct exam types required across all processes in this event —
+  // the denominator for each participant's "% completado".
+  const examTypesInEvent = new Set(
+    processes.flatMap((p) => p.exam_types ?? [])
+  );
+  const totalExamTypes = examTypesInEvent.size;
+
+  // Per-participant breakdown: every distinct exam type they attempted
+  // (best score kept per type) plus a completion rate against the event's
+  // required exams. Lets recruiters see "3/8 pruebas — 92%, 84%, 65%..."
+  // instead of a single collapsed best-score row.
+  const resultsByCandidate = new Map<string, EventParticipantResult[]>();
+  const infoByCandidate = new Map<
+    string,
+    { userId: string | null; name: string; email: string | null }
+  >();
+  for (const r of allRaw) {
+    const key = candidateKey(r);
+    if (!key) continue;
+    if (!infoByCandidate.has(key)) {
+      infoByCandidate.set(key, {
+        userId: r.userId,
+        name: r.name,
+        email: r.email,
+      });
+    }
+    const list = resultsByCandidate.get(key) ?? [];
+    const existingIdx = list.findIndex((x) => x.examType === r.examType);
+    if (existingIdx === -1) {
+      list.push({
+        examType: r.examType,
+        processCode: r.processCode,
+        percentage: r.percentage,
+        passed: r.passed,
+      });
+    } else if (r.percentage > list[existingIdx].percentage) {
+      list[existingIdx] = {
+        examType: r.examType,
+        processCode: r.processCode,
+        percentage: r.percentage,
+        passed: r.passed,
+      };
+    }
+    resultsByCandidate.set(key, list);
+  }
+
+  const participants: EventParticipant[] = Array.from(
+    infoByCandidate.entries()
+  )
+    .map(([key, info]) => {
+      const results = (resultsByCandidate.get(key) ?? []).sort(
+        (a, b) => b.percentage - a.percentage
+      );
+      const scores = results.map((x) => x.percentage);
+      return {
+        key,
+        userId: info.userId,
+        name: info.name,
+        email: info.email,
+        results,
+        completedCount: results.length,
+        completionRate:
+          totalExamTypes > 0
+            ? Math.round((results.length / totalExamTypes) * 100)
+            : 0,
+        passedCount: results.filter((x) => x.passed).length,
+        avgScore:
+          scores.length > 0
+            ? Math.round(scores.reduce((sum, s) => sum + s, 0) / scores.length)
+            : 0,
+        bestScore: scores.length > 0 ? Math.max(...scores) : 0,
+      };
+    })
+    .sort((a, b) => b.completedCount - a.completedCount || b.avgScore - a.avgScore);
+
   const totalCandidates = allCandidates.length;
   const totalPassed = allCandidates.filter((r) => r.passed).length;
   const avgScore =
@@ -821,6 +923,8 @@ export async function getEventStatsAction(groupId: string): Promise<{
       processes: processStats,
       allCandidates,
       byExamType,
+      participants,
+      totalExamTypes,
       totals: {
         candidates: totalCandidates,
         passed: totalPassed,

--- a/apps/frontend/src/app/empresa/eventos/[id]/page.tsx
+++ b/apps/frontend/src/app/empresa/eventos/[id]/page.tsx
@@ -207,7 +207,15 @@ export default function EventoDetailPage() {
     );
   }
 
-  const { group, processes, allCandidates, byExamType, totals } = stats;
+  const {
+    group,
+    processes,
+    allCandidates,
+    byExamType,
+    participants,
+    totalExamTypes,
+    totals,
+  } = stats;
 
   const top10 = allCandidates.slice(0, 10);
 
@@ -237,15 +245,15 @@ export default function EventoDetailPage() {
       }
     : { backgroundColor: '#fff', border: '1px solid #e2e8f0' };
 
-  const filteredCandidates = allCandidates.filter((c) => {
+  const filteredParticipants = participants.filter((p) => {
     const matchSearch =
       !searchCand ||
-      c.name.toLowerCase().includes(searchCand.toLowerCase()) ||
-      (c.email ?? '').toLowerCase().includes(searchCand.toLowerCase());
+      p.name.toLowerCase().includes(searchCand.toLowerCase()) ||
+      (p.email ?? '').toLowerCase().includes(searchCand.toLowerCase());
     const matchPass =
       filterPassed === 'all' ||
-      (filterPassed === 'passed' && c.passed) ||
-      (filterPassed === 'failed' && !c.passed);
+      (filterPassed === 'passed' && p.passedCount > 0) ||
+      (filterPassed === 'failed' && p.passedCount === 0);
     return matchSearch && matchPass;
   });
 
@@ -485,7 +493,7 @@ export default function EventoDetailPage() {
                   <span
                     className={`font-normal text-xs ml-1 ${isDarkMode ? 'text-slate-500' : 'text-gray-400'}`}
                   >
-                    ({filteredCandidates.length} de {allCandidates.length})
+                    ({filteredParticipants.length} de {participants.length})
                   </span>
                 </p>
                 <div className="flex items-center gap-2 flex-wrap">
@@ -539,16 +547,20 @@ export default function EventoDetailPage() {
                     >
                       <th className="px-4 py-3 text-center w-10">#</th>
                       <th className="px-5 py-3 text-left">Participante</th>
-                      <th className="px-4 py-3 text-left">Examen</th>
-                      <th className="px-4 py-3 text-left">Proceso</th>
-                      <th className="px-4 py-3 text-center">Puntaje</th>
+                      <th className="px-4 py-3 text-center">
+                        % Completado
+                      </th>
+                      <th className="px-4 py-3 text-left">
+                        Resultados por prueba
+                      </th>
+                      <th className="px-4 py-3 text-center">Promedio</th>
                       <th className="px-4 py-3 text-center">Estado</th>
                     </tr>
                   </thead>
                   <tbody
                     className={`divide-y ${isDarkMode ? 'divide-slate-700/50' : 'divide-gray-100'}`}
                   >
-                    {filteredCandidates.length === 0 ? (
+                    {filteredParticipants.length === 0 ? (
                       <tr>
                         <td
                           colSpan={6}
@@ -558,94 +570,98 @@ export default function EventoDetailPage() {
                         </td>
                       </tr>
                     ) : (
-                      filteredCandidates.map((c, i) => {
-                        const globalRank =
-                          allCandidates.findIndex(
-                            (x) =>
-                              x.name === c.name &&
-                              x.processCode === c.processCode
-                          ) + 1;
-                        return (
-                          <tr
-                            key={i}
-                            className={`transition-colors ${
-                              isDarkMode
-                                ? 'hover:bg-slate-800/30'
-                                : 'hover:bg-gray-50'
-                            }`}
+                      filteredParticipants.map((p, i) => (
+                        <tr
+                          key={p.key}
+                          className={`transition-colors ${
+                            isDarkMode
+                              ? 'hover:bg-slate-800/30'
+                              : 'hover:bg-gray-50'
+                          }`}
+                        >
+                          <td
+                            className={`px-4 py-3 text-center text-xs font-mono ${isDarkMode ? 'text-slate-500' : 'text-gray-400'}`}
                           >
-                            <td
-                              className={`px-4 py-3 text-center text-xs font-mono ${isDarkMode ? 'text-slate-500' : 'text-gray-400'}`}
+                            {i === 0 ? '🥇' : i === 1 ? '🥈' : i === 2 ? '🥉' : i + 1}
+                          </td>
+                          <td className="px-5 py-3">
+                            <p
+                              className={`font-medium ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
                             >
-                              {globalRank === 1
-                                ? '🥇'
-                                : globalRank === 2
-                                  ? '🥈'
-                                  : globalRank === 3
-                                    ? '🥉'
-                                    : globalRank}
-                            </td>
-                            <td className="px-5 py-3">
+                              {p.name}
+                            </p>
+                            {p.email && p.email !== p.name && (
                               <p
-                                className={`font-medium ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
+                                className={`text-xs ${isDarkMode ? 'text-slate-500' : 'text-gray-400'}`}
                               >
-                                {c.name}
+                                {p.email}
                               </p>
-                              {c.email && c.email !== c.name && (
-                                <p
-                                  className={`text-xs ${isDarkMode ? 'text-slate-500' : 'text-gray-400'}`}
-                                >
-                                  {c.email}
-                                </p>
-                              )}
-                            </td>
-                            <td
-                              className={`px-4 py-3 text-sm ${isDarkMode ? 'text-slate-300' : 'text-gray-600'}`}
-                            >
-                              {EXAM_LABELS[c.examType] ?? c.examType}
-                            </td>
-                            <td className="px-4 py-3">
-                              <span
-                                className={`font-mono text-xs px-2 py-0.5 rounded ${isDarkMode ? 'bg-slate-700 text-slate-300' : 'bg-gray-100 text-gray-600'}`}
+                            )}
+                          </td>
+                          <td className="px-4 py-3 text-center">
+                            <div className="flex flex-col items-center gap-1">
+                              <div
+                                className={`h-1.5 w-20 rounded-full overflow-hidden ${isDarkMode ? 'bg-slate-700' : 'bg-gray-200'}`}
                               >
-                                {c.processCode}
-                              </span>
-                            </td>
-                            <td className="px-4 py-3 text-center">
-                              <div className="flex items-center justify-center gap-2">
                                 <div
-                                  className={`h-1.5 w-16 rounded-full overflow-hidden ${isDarkMode ? 'bg-slate-700' : 'bg-gray-200'}`}
-                                >
-                                  <div
-                                    className={`h-full rounded-full ${c.passed ? 'bg-green-500' : 'bg-red-500'}`}
-                                    style={{ width: `${c.percentage}%` }}
-                                  />
-                                </div>
-                                <span
-                                  className={`text-xs font-semibold w-10 text-right ${isDarkMode ? 'text-slate-200' : 'text-gray-700'}`}
-                                >
-                                  {c.percentage}%
-                                </span>
+                                  className={`h-full rounded-full ${p.completionRate >= 100 ? 'bg-green-500' : 'bg-indigo-500'}`}
+                                  style={{ width: `${p.completionRate}%` }}
+                                />
                               </div>
-                            </td>
-                            <td className="px-4 py-3 text-center">
                               <span
-                                className={`text-xs font-medium px-2 py-0.5 rounded-full ${
-                                  c.passed
-                                    ? isDarkMode
-                                      ? 'bg-green-900/40 text-green-300'
-                                      : 'bg-green-100 text-green-700'
-                                    : isDarkMode
-                                      ? 'bg-red-900/40 text-red-300'
-                                      : 'bg-red-100 text-red-600'
-                                }`}
+                                className={`text-xs font-semibold ${isDarkMode ? 'text-slate-300' : 'text-gray-600'}`}
                               >
-                                {c.passed ? 'Aprobado' : 'No aprobado'}
+                                {p.completedCount}/{totalExamTypes} ·{' '}
+                                {p.completionRate}%
                               </span>
-                            </td>
-                          </tr>
-                        );
-                      })
+                            </div>
+                          </td>
+                          <td className="px-4 py-3">
+                            <div className="flex flex-wrap gap-1.5 max-w-xs">
+                              {p.results.map((r) => (
+                                <span
+                                  key={r.examType}
+                                  title={r.processCode}
+                                  className={`text-xs px-1.5 py-0.5 rounded font-medium ${
+                                    r.passed
+                                      ? isDarkMode
+                                        ? 'bg-green-900/40 text-green-300'
+                                        : 'bg-green-100 text-green-700'
+                                      : isDarkMode
+                                        ? 'bg-red-900/40 text-red-300'
+                                        : 'bg-red-100 text-red-600'
+                                  }`}
+                                >
+                                  {EXAM_LABELS[r.examType] ?? r.examType}{' '}
+                                  {r.percentage}%
+                                </span>
+                              ))}
+                            </div>
+                          </td>
+                          <td className="px-4 py-3 text-center">
+                            <span
+                              className={`text-sm font-semibold ${isDarkMode ? 'text-slate-200' : 'text-gray-700'}`}
+                            >
+                              {p.avgScore}%
+                            </span>
+                          </td>
+                          <td className="px-4 py-3 text-center">
+                            <span
+                              className={`text-xs font-medium px-2 py-0.5 rounded-full ${
+                                p.passedCount > 0
+                                  ? isDarkMode
+                                    ? 'bg-green-900/40 text-green-300'
+                                    : 'bg-green-100 text-green-700'
+                                  : isDarkMode
+                                    ? 'bg-red-900/40 text-red-300'
+                                    : 'bg-red-100 text-red-600'
+                              }`}
+                            >
+                              {p.passedCount}/{p.completedCount} aprobados
+                            </span>
+                          </td>
+                        </tr>
+                      ))
                     )}
                   </tbody>
                 </table>

--- a/apps/frontend/src/app/empresa/eventos/[id]/page.tsx
+++ b/apps/frontend/src/app/empresa/eventos/[id]/page.tsx
@@ -210,22 +210,24 @@ export default function EventoDetailPage() {
   const {
     group,
     processes,
-    allCandidates,
     byExamType,
     participants,
     totalExamTypes,
     totals,
   } = stats;
 
-  const top10 = allCandidates.slice(0, 10);
+  // participants is already sorted by completedCount desc, then avgScore desc
+  // — ranking priorizes quienes completaron más pruebas técnicas del evento.
+  const top10 = participants.slice(0, 10);
 
-  const topChartData = top10.map((c) => ({
-    name: c.name.length > 22 ? c.name.slice(0, 22) + '…' : c.name,
-    fullName: c.name,
-    puntaje: c.percentage,
-    examType: EXAM_LABELS[c.examType] ?? c.examType,
-    processCode: c.processCode,
-    passed: c.passed,
+  const topChartData = top10.map((p) => ({
+    name: p.name.length > 22 ? p.name.slice(0, 22) + '…' : p.name,
+    fullName: p.name,
+    puntaje: p.completionRate,
+    completedCount: p.completedCount,
+    totalExamTypes,
+    avgScore: p.avgScore,
+    anyPassed: p.passedCount > 0,
   }));
 
   const examChartData = byExamType.map((e) => ({
@@ -346,7 +348,9 @@ export default function EventoDetailPage() {
             <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
               {/* Top 10 participants */}
               <div className={`${cardClass} p-5`}>
-                <p className={headingClass}>Top 10 participantes</p>
+                <p className={headingClass}>
+                  Top 10 participantes — más pruebas completadas
+                </p>
                 {topChartData.length === 0 ? (
                   <p
                     className={`text-sm ${isDarkMode ? 'text-slate-500' : 'text-gray-400'}`}
@@ -385,11 +389,16 @@ export default function EventoDetailPage() {
                       />
                       <Tooltip
                         contentStyle={tooltipStyle}
-                        formatter={(value: number) => [`${value}%`, 'Puntaje']}
+                        formatter={(_value: number, _name: string, item: any) => {
+                          const d = item?.payload;
+                          return [
+                            `${d?.completedCount ?? 0}/${d?.totalExamTypes ?? 0} pruebas · promedio ${d?.avgScore ?? 0}%`,
+                            'Completado',
+                          ];
+                        }}
                         labelFormatter={(_, payload) => {
                           const d = payload?.[0]?.payload;
-                          if (!d) return '';
-                          return `${d.fullName} — ${d.examType} (${d.processCode})`;
+                          return d?.fullName ?? '';
                         }}
                       />
                       <Bar
@@ -400,7 +409,7 @@ export default function EventoDetailPage() {
                         {topChartData.map((entry, i) => (
                           <Cell
                             key={i}
-                            fill={entry.passed ? '#22c55e' : '#ef4444'}
+                            fill={entry.anyPassed ? '#22c55e' : '#ef4444'}
                             fillOpacity={0.85}
                           />
                         ))}
@@ -411,7 +420,8 @@ export default function EventoDetailPage() {
                 <p
                   className={`text-xs mt-2 ${isDarkMode ? 'text-slate-500' : 'text-gray-400'}`}
                 >
-                  🟢 Aprobado · 🔴 No aprobado
+                  Ordenado por pruebas completadas · 🟢 Aprobó al menos una ·
+                  🔴 Ninguna aprobada
                 </p>
               </div>
 


### PR DESCRIPTION
## Summary
- El PR #254 se mergeó antes de que llegara a subir este último commit, así que la feature de "% completado + resultados por prueba por participante" nunca llegó a main. Este PR la reintroduce (cherry-pick limpio del mismo commit).
- La tabla "Todos los participantes" en `/empresa/eventos/[id]` agrupaba cada resultado de examen como una fila separada, colapsando a un solo candidato con el mejor puntaje. Ahora agrupa por candidato (`user_id`, con fallback a email/nombre) y muestra:
  - **% Completado**: `X/Y pruebas` sobre el total de exámenes distintos requeridos en el evento
  - **Resultados por prueba**: un badge por examen rendido con su puntaje (verde/rojo según aprobado)
  - **Promedio** y **Estado** (`X/Y aprobados`) por participante

## Test plan
- [ ] Abrir un evento con varios procesos/candidatos que rindieron múltiples pruebas y confirmar que cada persona aparece en una sola fila
- [ ] Verificar que "% Completado" y los badges de resultados sean correctos
- [ ] Confirmar que el filtro de búsqueda y "Aprobados/No aprobados" siguen funcionando

🤖 Generated with [Claude Code](https://claude.com/claude-code)