### PR TITLE
fix(empresa): resolver 'Sin nombre' cuando exam_results no tiene participant_name

### DIFF
--- a/apps/frontend/src/actions/employer.ts
+++ b/apps/frontend/src/actions/employer.ts
@@ -447,11 +447,45 @@ async function fetchEmpresaResultsForProcessCodes(
     return { data: [], error: assessmentAttemptsRes.error };
   }
 
+  const examResults = (examResultsRes.data ?? []) as EmpresaResultRow[];
+
+  // Some exam_results rows have user_id set but never got participant_name/
+  // participant_email filled in at submission time (e.g. OAuth sign-ins).
+  // Unlike assessment_attempts, these never fall back to the profile — backfill
+  // them here so they don't show up as "Sin nombre" despite having an account.
+  const missingNameUserIds = [
+    ...new Set(
+      examResults
+        .filter((r) => !r.participant_name && !r.participant_email && r.user_id)
+        .map((r) => r.user_id as string)
+    ),
+  ];
+
+  if (missingNameUserIds.length > 0) {
+    const { data: profiles } = await supabase
+      .from('profiles')
+      .select('id, display_name, email')
+      .in('id', missingNameUserIds);
+
+    const profileMap: Record<
+      string,
+      { display_name: string | null; email: string | null }
+    > = {};
+    (profiles ?? []).forEach((p: any) => {
+      profileMap[p.id] = p;
+    });
+
+    for (const r of examResults) {
+      if (r.participant_name || r.participant_email || !r.user_id) continue;
+      const profile = profileMap[r.user_id];
+      if (!profile) continue;
+      r.participant_name = profile.display_name || profile.email;
+      r.participant_email = profile.email ?? null;
+    }
+  }
+
   return {
-    data: [
-      ...((examResultsRes.data ?? []) as EmpresaResultRow[]),
-      ...assessmentAttemptsRes.data,
-    ],
+    data: [...examResults, ...assessmentAttemptsRes.data],
     error: null,
   };
 }

--- a/apps/frontend/src/app/empresa/procesos/[id]/page.tsx
+++ b/apps/frontend/src/app/empresa/procesos/[id]/page.tsx
@@ -425,10 +425,19 @@ export default function ProcesoDetailPage() {
         getProspectsForProcessAction(proc.id),
       ]);
 
-      // profiles has no FK from assessment_attempts — fetch separately
+      // profiles has no FK from assessment_attempts — fetch separately.
+      // Some exam_results rows also have user_id but never got
+      // participant_name/email filled in at submission time (e.g. OAuth
+      // sign-ins), so include those in the same profile lookup.
       const attemptRows = assessmentRes.data ?? [];
+      const examResultsRaw = (res ?? []) as ExamResult[];
       const userIds = [
-        ...new Set(attemptRows.map((r: any) => r.user_id).filter(Boolean)),
+        ...new Set([
+          ...attemptRows.map((r: any) => r.user_id).filter(Boolean),
+          ...examResultsRaw
+            .filter((r) => !r.participant_name && !r.participant_email && r.user_id)
+            .map((r) => r.user_id as string),
+        ]),
       ];
       const profileMap: Record<
         string,
@@ -444,10 +453,17 @@ export default function ProcesoDetailPage() {
         });
       }
 
-      const examResults = ((res ?? []) as ExamResult[]).map((r) => ({
+      const examResults = examResultsRaw.map((r) => ({
         ...r,
-        participant_name: r.participant_name ?? r.participant_email,
-        participant_email: r.participant_email ?? null,
+        participant_name:
+          r.participant_name ??
+          r.participant_email ??
+          (r.user_id ? profileMap[r.user_id]?.display_name : null) ??
+          (r.user_id ? profileMap[r.user_id]?.email : null),
+        participant_email:
+          r.participant_email ??
+          (r.user_id ? profileMap[r.user_id]?.email : null) ??
+          null,
       }));
 
       const mappedAttempts: ExamResult[] = attemptRows.map((r: any) => ({


### PR DESCRIPTION
## Summary
Causa raíz de los "Sin nombre" en la tabla de participantes del evento (y "—" en el detalle de proceso): hay filas de `exam_results` con `user_id` poblado pero `participant_name`/`participant_email` NULL (quedaron sin completar al momento de rendir, ej. login por OAuth). A diferencia de `assessment_attempts`, estas filas nunca hacían fallback al perfil del usuario — se verificó con SQL directo en prod que esos candidatos sí tienen `display_name`/`email` en `profiles`, solo que la fila de resultado no los tenía copiados.

- `fetchEmpresaResultsForProcessCodes` (`employer.ts`): antes de mezclar con `assessment_attempts`, busca el perfil para las filas de `exam_results` que no tienen nombre ni email, y completa `participant_name`/`participant_email` desde ahí. Esto arregla el dashboard de empresa, las stats de evento y `getProcessCandidatesAction` de una sola vez.
- `procesos/[id]/page.tsx`: mismo backfill para su query inline de `exam_results` (usada en la tabla "Postulantes" del detalle de proceso).

## Test plan
- [ ] Abrir el evento del screenshot y confirmar que ya no aparece "Sin nombre" para candidatos con perfil válido
- [ ] Abrir `/empresa/procesos/[id]` de un proceso con candidatos afectados y confirmar que el nombre aparece en vez de "—"
- [ ] Confirmar que candidatos genuinamente sin perfil (sin cuenta) siguen mostrando el fallback esperado

🤖 Generated with [Claude Code](https://claude.com/claude-code)