### PR TITLE
feat(eventos): marcar no aprobado a nivel macro con <60% de pruebas completadas

### DIFF
--- a/apps/frontend/src/actions/employer.ts
+++ b/apps/frontend/src/actions/employer.ts
@@ -730,6 +730,8 @@ export interface EventParticipant {
   bestScore: number;
   /** completionRate >= MACRO_COMPLETION_THRESHOLD */
   macroApproved: boolean;
+  /** Exam types required by the event this participant hasn't attempted yet. */
+  missingExamTypes: string[];
 }
 
 export interface EventStats {
@@ -742,6 +744,8 @@ export interface EventStats {
   participants: EventParticipant[];
   /** Distinct exam types required across all processes in this event. */
   totalExamTypes: number;
+  /** The exam type slugs behind totalExamTypes, for computing what's missing. */
+  requiredExamTypes: string[];
   totals: {
     candidates: number;
     passed: number;
@@ -789,6 +793,7 @@ export async function getEventStatsAction(groupId: string): Promise<{
         byExamType: [],
         participants: [],
         totalExamTypes: 0,
+        requiredExamTypes: [],
         totals: { candidates: 0, passed: 0, passRate: 0, avgScore: null },
       },
       error: null,
@@ -931,6 +936,10 @@ export async function getEventStatsAction(groupId: string): Promise<{
         totalExamTypes > 0
           ? Math.round((results.length / totalExamTypes) * 100)
           : 0;
+      const doneExamTypes = new Set(results.map((x) => x.examType));
+      const missingExamTypes = Array.from(examTypesInEvent).filter(
+        (examType) => !doneExamTypes.has(examType)
+      );
       return {
         key,
         userId: info.userId,
@@ -946,6 +955,7 @@ export async function getEventStatsAction(groupId: string): Promise<{
             : 0,
         bestScore: scores.length > 0 ? Math.max(...scores) : 0,
         macroApproved: completionRate >= MACRO_COMPLETION_THRESHOLD,
+        missingExamTypes,
       };
     })
     .sort((a, b) => b.completedCount - a.completedCount || b.avgScore - a.avgScore);
@@ -968,6 +978,7 @@ export async function getEventStatsAction(groupId: string): Promise<{
       byExamType,
       participants,
       totalExamTypes,
+      requiredExamTypes: Array.from(examTypesInEvent),
       totals: {
         candidates: totalCandidates,
         passed: totalPassed,

--- a/apps/frontend/src/actions/employer.ts
+++ b/apps/frontend/src/actions/employer.ts
@@ -711,6 +711,11 @@ export interface EventParticipantResult {
   passed: boolean;
 }
 
+/** Below this % of the event's required exams completed, a participant is
+ * marked "no aprobado" at the macro (evento) level regardless of individual
+ * exam scores. */
+const MACRO_COMPLETION_THRESHOLD = 60;
+
 export interface EventParticipant {
   key: string;
   userId: string | null;
@@ -723,6 +728,8 @@ export interface EventParticipant {
   passedCount: number;
   avgScore: number;
   bestScore: number;
+  /** completionRate >= MACRO_COMPLETION_THRESHOLD */
+  macroApproved: boolean;
 }
 
 export interface EventStats {
@@ -920,6 +927,10 @@ export async function getEventStatsAction(groupId: string): Promise<{
         (a, b) => b.percentage - a.percentage
       );
       const scores = results.map((x) => x.percentage);
+      const completionRate =
+        totalExamTypes > 0
+          ? Math.round((results.length / totalExamTypes) * 100)
+          : 0;
       return {
         key,
         userId: info.userId,
@@ -927,16 +938,14 @@ export async function getEventStatsAction(groupId: string): Promise<{
         email: info.email,
         results,
         completedCount: results.length,
-        completionRate:
-          totalExamTypes > 0
-            ? Math.round((results.length / totalExamTypes) * 100)
-            : 0,
+        completionRate,
         passedCount: results.filter((x) => x.passed).length,
         avgScore:
           scores.length > 0
             ? Math.round(scores.reduce((sum, s) => sum + s, 0) / scores.length)
             : 0,
         bestScore: scores.length > 0 ? Math.max(...scores) : 0,
+        macroApproved: completionRate >= MACRO_COMPLETION_THRESHOLD,
       };
     })
     .sort((a, b) => b.completedCount - a.completedCount || b.avgScore - a.avgScore);

--- a/apps/frontend/src/app/empresa/eventos/[id]/page.tsx
+++ b/apps/frontend/src/app/empresa/eventos/[id]/page.tsx
@@ -182,6 +182,7 @@ export default function EventoDetailPage() {
         'Total pruebas del evento',
         '% Completado',
         'Resultados por prueba',
+        'Pruebas faltantes',
         'Promedio',
         'Mejor puntaje',
         'Pruebas aprobadas',
@@ -196,6 +197,11 @@ export default function EventoDetailPage() {
         p.results
           .map((r) => `${EXAM_LABELS[r.examType] ?? r.examType}: ${r.percentage}%${r.passed ? ' (aprobado)' : ''}`)
           .join(' | '),
+        p.missingExamTypes.length === 0
+          ? 'Ninguna'
+          : p.missingExamTypes
+              .map((examType) => EXAM_LABELS[examType] ?? examType)
+              .join(' | '),
         `${p.avgScore}%`,
         `${p.bestScore}%`,
         `${p.passedCount}/${p.completedCount}`,
@@ -616,6 +622,9 @@ export default function EventoDetailPage() {
                       <th className="px-4 py-3 text-left">
                         Resultados por prueba
                       </th>
+                      <th className="px-4 py-3 text-left">
+                        Pruebas faltantes
+                      </th>
                       <th className="px-4 py-3 text-center">Promedio</th>
                       <th className="px-4 py-3 text-center">Estado</th>
                     </tr>
@@ -626,7 +635,7 @@ export default function EventoDetailPage() {
                     {filteredParticipants.length === 0 ? (
                       <tr>
                         <td
-                          colSpan={6}
+                          colSpan={7}
                           className={`px-5 py-8 text-center text-sm ${isDarkMode ? 'text-slate-500' : 'text-gray-400'}`}
                         >
                           Sin resultados para este filtro
@@ -700,6 +709,26 @@ export default function EventoDetailPage() {
                                 </span>
                               ))}
                             </div>
+                          </td>
+                          <td className="px-4 py-3">
+                            {p.missingExamTypes.length === 0 ? (
+                              <span
+                                className={`text-xs ${isDarkMode ? 'text-green-400' : 'text-green-600'}`}
+                              >
+                                ✓ Completo
+                              </span>
+                            ) : (
+                              <div className="flex flex-wrap gap-1.5 max-w-xs">
+                                {p.missingExamTypes.map((examType) => (
+                                  <span
+                                    key={examType}
+                                    className={`text-xs px-1.5 py-0.5 rounded font-medium ${isDarkMode ? 'bg-slate-700 text-slate-400' : 'bg-gray-100 text-gray-500'}`}
+                                  >
+                                    {EXAM_LABELS[examType] ?? examType}
+                                  </span>
+                                ))}
+                              </div>
+                            )}
                           </td>
                           <td className="px-4 py-3 text-center">
                             <span

--- a/apps/frontend/src/app/empresa/eventos/[id]/page.tsx
+++ b/apps/frontend/src/app/empresa/eventos/[id]/page.tsx
@@ -184,7 +184,8 @@ export default function EventoDetailPage() {
         'Resultados por prueba',
         'Promedio',
         'Mejor puntaje',
-        'Aprobados',
+        'Pruebas aprobadas',
+        'Estado (macro)',
       ],
       ...stats.participants.map((p) => [
         p.name,
@@ -198,6 +199,7 @@ export default function EventoDetailPage() {
         `${p.avgScore}%`,
         `${p.bestScore}%`,
         `${p.passedCount}/${p.completedCount}`,
+        p.macroApproved ? 'Aprobado' : 'No aprobado',
       ]),
     ];
     const csv = rows
@@ -271,7 +273,7 @@ export default function EventoDetailPage() {
     completedCount: p.completedCount,
     totalExamTypes,
     avgScore: p.avgScore,
-    anyPassed: p.passedCount > 0,
+    macroApproved: p.macroApproved,
   }));
 
   const examChartData = byExamType.map((e) => ({
@@ -298,8 +300,8 @@ export default function EventoDetailPage() {
       (p.email ?? '').toLowerCase().includes(searchCand.toLowerCase());
     const matchPass =
       filterPassed === 'all' ||
-      (filterPassed === 'passed' && p.passedCount > 0) ||
-      (filterPassed === 'failed' && p.passedCount === 0);
+      (filterPassed === 'passed' && p.macroApproved) ||
+      (filterPassed === 'failed' && !p.macroApproved);
     return matchSearch && matchPass;
   });
 
@@ -453,7 +455,7 @@ export default function EventoDetailPage() {
                         {topChartData.map((entry, i) => (
                           <Cell
                             key={i}
-                            fill={entry.anyPassed ? '#22c55e' : '#ef4444'}
+                            fill={entry.macroApproved ? '#22c55e' : '#ef4444'}
                             fillOpacity={0.85}
                           />
                         ))}
@@ -464,8 +466,8 @@ export default function EventoDetailPage() {
                 <p
                   className={`text-xs mt-2 ${isDarkMode ? 'text-slate-500' : 'text-gray-400'}`}
                 >
-                  Ordenado por pruebas completadas · 🟢 Aprobó al menos una ·
-                  🔴 Ninguna aprobada
+                  Ordenado por pruebas completadas · 🟢 Aprobado (macro, ≥60%
+                  completado) · 🔴 No aprobado (macro)
                 </p>
               </div>
 
@@ -707,19 +709,30 @@ export default function EventoDetailPage() {
                             </span>
                           </td>
                           <td className="px-4 py-3 text-center">
-                            <span
-                              className={`text-xs font-medium px-2 py-0.5 rounded-full ${
-                                p.passedCount > 0
-                                  ? isDarkMode
-                                    ? 'bg-green-900/40 text-green-300'
-                                    : 'bg-green-100 text-green-700'
-                                  : isDarkMode
-                                    ? 'bg-red-900/40 text-red-300'
-                                    : 'bg-red-100 text-red-600'
-                              }`}
-                            >
-                              {p.passedCount}/{p.completedCount} aprobados
-                            </span>
+                            <div className="flex flex-col items-center gap-1">
+                              <span
+                                className={`text-xs font-semibold px-2 py-0.5 rounded-full ${
+                                  p.macroApproved
+                                    ? isDarkMode
+                                      ? 'bg-green-900/40 text-green-300'
+                                      : 'bg-green-100 text-green-700'
+                                    : isDarkMode
+                                      ? 'bg-red-900/40 text-red-300'
+                                      : 'bg-red-100 text-red-600'
+                                }`}
+                                title="Aprobado/no aprobado a nivel macro: requiere haber completado al menos 60% de las pruebas técnicas del evento"
+                              >
+                                {p.macroApproved
+                                  ? 'Aprobado (macro)'
+                                  : 'No aprobado (macro)'}
+                              </span>
+                              <span
+                                className={`text-xs ${isDarkMode ? 'text-slate-500' : 'text-gray-400'}`}
+                              >
+                                {p.passedCount}/{p.completedCount} pruebas
+                                aprobadas
+                              </span>
+                            </div>
                           </td>
                         </tr>
                       ))


### PR DESCRIPTION
## Summary
En un evento con 10 pruebas técnicas, un candidato que solo rindió 1 y la aprobó se veía igual de "aprobado" que uno con 9/10. Se agrega un estado a nivel macro (evento): `macroApproved = completionRate >= 60%`, independiente del resultado individual de cada examen.

- `EventParticipant.macroApproved` (`employer.ts`), umbral configurable vía `MACRO_COMPLETION_THRESHOLD = 60`
- Columna **Estado** ahora muestra badge "Aprobado (macro)" / "No aprobado (macro)" (con el detalle `X/Y pruebas aprobadas` como subtexto)
- Filtro **Aprobados/No aprobados** de la tabla ahora usa este criterio macro
- Color de barras del gráfico "Top 10 participantes" también refleja el estado macro
- Export CSV incluye columna "Estado (macro)"

## Test plan
- [ ] Abrir un evento y confirmar que participantes con <60% de pruebas completadas aparecen como "No aprobado (macro)" aunque hayan aprobado las que rindieron
- [ ] Confirmar que el filtro "Aprobados/No aprobados" refleja el nuevo criterio
- [ ] Exportar CSV y verificar la columna "Estado (macro)"

🤖 Generated with [Claude Code](https://claude.com/claude-code)