### PR TITLE
feat(perfil): mostrar progreso del candidato en el evento

### DIFF
--- a/apps/frontend/src/actions/candidate-events.ts
+++ b/apps/frontend/src/actions/candidate-events.ts
@@ -1,0 +1,188 @@
+'use server';
+
+import { createClient } from '@/lib/supabase/server';
+
+const ASSESSMENT_SLUGS = [
+  'database-fundamentals',
+  'database-practice',
+  'infrastructure-fundamentals',
+];
+
+export interface MyEventResult {
+  examType: string;
+  processCode: string;
+  percentage: number;
+  passed: boolean;
+}
+
+export interface MyEventProgress {
+  groupId: string;
+  eventName: string;
+  totalExamTypes: number;
+  completedCount: number;
+  completionRate: number;
+  results: MyEventResult[];
+  missingExamTypes: string[];
+}
+
+function getAttemptProcessCode(metadata: unknown) {
+  if (!metadata || typeof metadata !== 'object' || Array.isArray(metadata)) {
+    return '';
+  }
+  const value = (metadata as Record<string, unknown>).processCode;
+  return typeof value === 'string' ? value : '';
+}
+
+/**
+ * Returns, for every "evento" (hiring_process_group) the current candidate has
+ * rendered at least one exam in, their completion % against the union of exam
+ * types required by that event's processes, plus which ones are still missing.
+ */
+export async function getMyEventProgressAction(): Promise<{
+  data: MyEventProgress[] | null;
+  error: string | null;
+}> {
+  const supabase = createClient();
+  const {
+    data: { user },
+    error: userError,
+  } = await supabase.auth.getUser();
+  if (userError || !user) return { error: 'No autenticado', data: null };
+
+  const [{ data: examResults, error: examResultsError }, assessmentRes] =
+    await Promise.all([
+      supabase
+        .from('exam_results')
+        .select('exam_type, process_code, percentage, passed')
+        .eq('user_id', user.id)
+        .not('process_code', 'is', null),
+      supabase
+        .from('assessment_attempts')
+        .select(
+          'percentage, passed, metadata, assessments!inner(slug)'
+        )
+        .eq('user_id', user.id)
+        .eq('status', 'graded')
+        .in('assessments.slug', ASSESSMENT_SLUGS),
+    ]);
+
+  if (examResultsError) return { error: examResultsError.message, data: null };
+  if (assessmentRes.error) return { error: assessmentRes.error.message, data: null };
+
+  type MyResultRow = {
+    examType: string;
+    processCode: string;
+    percentage: number;
+    passed: boolean;
+  };
+
+  const myResults: MyResultRow[] = [
+    ...(examResults ?? []).map((r: any) => ({
+      examType: r.exam_type,
+      processCode: r.process_code as string,
+      percentage: Number(r.percentage ?? 0),
+      passed: Boolean(r.passed),
+    })),
+    ...(assessmentRes.data ?? [])
+      .map((r: any) => ({
+        examType: (r.assessments as any)?.slug ?? 'unknown',
+        processCode: getAttemptProcessCode(r.metadata),
+        percentage: Number(r.percentage ?? 0),
+        passed: Boolean(r.passed),
+      }))
+      .filter((r) => r.processCode),
+  ];
+
+  if (myResults.length === 0) return { data: [], error: null };
+
+  const processCodes = [...new Set(myResults.map((r) => r.processCode))];
+
+  const { data: myProcesses, error: procError } = await supabase
+    .from('hiring_processes')
+    .select('code, group_id, exam_types')
+    .in('code', processCodes)
+    .not('group_id', 'is', null);
+
+  if (procError) return { error: procError.message, data: null };
+
+  const processRows = myProcesses ?? [];
+  const groupIds = [...new Set(processRows.map((p) => p.group_id as string))];
+  if (groupIds.length === 0) return { data: [], error: null };
+
+  const { data: groups, error: groupsError } = await supabase
+    .from('hiring_process_groups')
+    .select('id, name')
+    .in('id', groupIds);
+
+  if (groupsError) return { error: groupsError.message, data: null };
+
+  const groupNameById = new Map(
+    (groups ?? []).map((g: any) => [g.id, g.name as string])
+  );
+
+  // For every event, union the exam_types of all its processes the candidate
+  // has visibility into (required set), then intersect with their own results
+  // limited to that event's processes.
+  const examTypesByGroup = new Map<string, Set<string>>();
+  const processCodesByGroup = new Map<string, Set<string>>();
+  for (const p of processRows) {
+    const gid = p.group_id as string;
+    const types = examTypesByGroup.get(gid) ?? new Set<string>();
+    (p.exam_types ?? []).forEach((t: string) => types.add(t));
+    examTypesByGroup.set(gid, types);
+
+    const codes = processCodesByGroup.get(gid) ?? new Set<string>();
+    codes.add(p.code);
+    processCodesByGroup.set(gid, codes);
+  }
+
+  const progress: MyEventProgress[] = Array.from(examTypesByGroup.entries())
+    .filter(([groupId]) => groupNameById.has(groupId))
+    .map(([groupId, requiredTypes]) => {
+      const myCodes = processCodesByGroup.get(groupId) ?? new Set<string>();
+      const resultsInGroup = myResults.filter((r) =>
+        myCodes.has(r.processCode)
+      );
+
+      // Best attempt per distinct exam type
+      const bestByType = new Map<string, MyResultRow>();
+      for (const r of resultsInGroup) {
+        const existing = bestByType.get(r.examType);
+        if (!existing || r.percentage > existing.percentage) {
+          bestByType.set(r.examType, r);
+        }
+      }
+
+      const results: MyEventResult[] = Array.from(bestByType.values())
+        .map((r) => ({
+          examType: r.examType,
+          processCode: r.processCode,
+          percentage: r.percentage,
+          passed: r.passed,
+        }))
+        .sort((a, b) => b.percentage - a.percentage);
+
+      const missingExamTypes = Array.from(requiredTypes).filter(
+        (t) => !bestByType.has(t)
+      );
+
+      const totalExamTypes = requiredTypes.size;
+      const completedCount = results.length;
+
+      return {
+        groupId,
+        eventName: groupNameById.get(groupId) ?? 'Evento',
+        totalExamTypes,
+        completedCount,
+        completionRate:
+          totalExamTypes > 0
+            ? Math.round((completedCount / totalExamTypes) * 100)
+            : 0,
+        results,
+        missingExamTypes,
+      };
+    })
+    .sort((a, b) => b.completionRate - a.completionRate);
+
+  return { data: progress, error: null };
+}

--- a/apps/frontend/src/app/perfil/page.tsx
+++ b/apps/frontend/src/app/perfil/page.tsx
@@ -15,6 +15,10 @@ import {
   getMyXpProfileAction,
   assignProcessCodeToExamAction,
 } from '@/actions/exams';
+import {
+  getMyEventProgressAction,
+  type MyEventProgress,
+} from '@/actions/candidate-events';
 import Avatar from '@/components/ui/Avatar';
 import { xpForLevel, PY_TIMEZONE } from '@/lib/xp';
 import {
@@ -129,6 +133,8 @@ export default function PerfilPage() {
   >([]);
   const [rankingAchievementsLoading, setRankingAchievementsLoading] =
     useState(true);
+  const [eventProgress, setEventProgress] = useState<MyEventProgress[]>([]);
+  const [eventProgressLoading, setEventProgressLoading] = useState(true);
 
   const [formData, setFormData] = useState({
     full_name: '',
@@ -251,6 +257,14 @@ export default function PerfilPage() {
         setRankingAchievements((data as RankingAchievementRow[]) || []);
       })
       .finally(() => setRankingAchievementsLoading(false));
+  }, [user]);
+
+  useEffect(() => {
+    if (!user) return;
+    setEventProgressLoading(true);
+    getMyEventProgressAction()
+      .then(({ data }) => setEventProgress(data ?? []))
+      .finally(() => setEventProgressLoading(false));
   }, [user]);
 
   const handleFileSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -1096,6 +1110,109 @@ export default function PerfilPage() {
                 ))}
               </div>
             )}
+          </div>
+        )}
+
+        {/* Event progress */}
+        {!eventProgressLoading && eventProgress.length > 0 && (
+          <div className={`${card} rounded-xl p-6 space-y-5`}>
+            <h2
+              className={`text-base font-semibold ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
+            >
+              🗂️ Mi progreso en eventos
+            </h2>
+            {eventProgress.map((ev) => (
+              <div
+                key={ev.groupId}
+                className={`rounded-xl border p-4 ${isDarkMode ? 'border-slate-700 bg-slate-800/40' : 'border-gray-200 bg-gray-50'}`}
+              >
+                <div className="flex items-center justify-between gap-3 flex-wrap mb-2">
+                  <p
+                    className={`font-semibold text-sm ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
+                  >
+                    {ev.eventName}
+                  </p>
+                  <span
+                    className={`text-xs font-semibold px-2 py-0.5 rounded-full ${
+                      ev.completionRate >= 100
+                        ? isDarkMode
+                          ? 'bg-green-900/40 text-green-300'
+                          : 'bg-green-100 text-green-700'
+                        : isDarkMode
+                          ? 'bg-indigo-900/40 text-indigo-300'
+                          : 'bg-indigo-100 text-indigo-700'
+                    }`}
+                  >
+                    {ev.completedCount}/{ev.totalExamTypes} pruebas ·{' '}
+                    {ev.completionRate}%
+                  </span>
+                </div>
+                <div
+                  className={`h-2 rounded-full overflow-hidden mb-3 ${isDarkMode ? 'bg-slate-700' : 'bg-gray-200'}`}
+                >
+                  <div
+                    className={`h-full rounded-full ${ev.completionRate >= 100 ? 'bg-green-500' : 'bg-indigo-500'}`}
+                    style={{ width: `${ev.completionRate}%` }}
+                  />
+                </div>
+
+                {ev.results.length > 0 && (
+                  <div className="mb-3">
+                    <p
+                      className={`text-xs font-semibold uppercase tracking-wide mb-1.5 ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}
+                    >
+                      Ya entregaste
+                    </p>
+                    <div className="flex flex-wrap gap-1.5">
+                      {ev.results.map((r) => (
+                        <span
+                          key={r.examType}
+                          className={`text-xs px-2 py-0.5 rounded font-medium ${
+                            r.passed
+                              ? isDarkMode
+                                ? 'bg-green-900/40 text-green-300'
+                                : 'bg-green-100 text-green-700'
+                              : isDarkMode
+                                ? 'bg-red-900/40 text-red-300'
+                                : 'bg-red-100 text-red-600'
+                          }`}
+                        >
+                          {EXAM_META[r.examType as ExamType]?.label ??
+                            r.examType}{' '}
+                          {r.percentage}%
+                        </span>
+                      ))}
+                    </div>
+                  </div>
+                )}
+
+                {ev.missingExamTypes.length === 0 ? (
+                  <p
+                    className={`text-xs font-medium ${isDarkMode ? 'text-green-400' : 'text-green-600'}`}
+                  >
+                    ✓ Completaste todas las pruebas de este evento
+                  </p>
+                ) : (
+                  <div>
+                    <p
+                      className={`text-xs font-semibold uppercase tracking-wide mb-1.5 ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}
+                    >
+                      Te falta rendir
+                    </p>
+                    <div className="flex flex-wrap gap-1.5">
+                      {ev.missingExamTypes.map((examType) => (
+                        <span
+                          key={examType}
+                          className={`text-xs px-2 py-0.5 rounded font-medium ${isDarkMode ? 'bg-slate-700 text-slate-300' : 'bg-gray-200 text-gray-600'}`}
+                        >
+                          {EXAM_META[examType as ExamType]?.label ?? examType}
+                        </span>
+                      ))}
+                    </div>
+                  </div>
+                )}
+              </div>
+            ))}
           </div>
         )}
 

--- a/supabase/migrations/20260703_050000_candidate_read_own_event_groups.sql
+++ b/supabase/migrations/20260703_050000_candidate_read_own_event_groups.sql
@@ -1,0 +1,33 @@
+-- Let a candidate read the name/description of a hiring_process_group (evento)
+-- they've actually participated in, so their profile can show event progress
+-- (% completado, pruebas faltantes) — mirrors the "Postulantes"/"Eventos"
+-- macro report already built for empresa users.
+--
+-- hiring_process_groups previously only allowed empresa members to read (own
+-- empresa_id). This mirrors the pattern already used for
+-- profiles_select_empresa_process_candidates: grant read access scoped to
+-- rows the candidate is provably connected to via their own exam_results /
+-- assessment_attempts, not a blanket read.
+
+DROP POLICY IF EXISTS "candidates_select_own_event_groups" ON public.hiring_process_groups;
+
+CREATE POLICY "candidates_select_own_event_groups" ON public.hiring_process_groups
+  FOR SELECT
+  TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.hiring_processes hp
+      WHERE hp.group_id = hiring_process_groups.id
+        AND (
+          EXISTS (
+            SELECT 1 FROM public.exam_results er
+            WHERE er.process_code = hp.code AND er.user_id = auth.uid()
+          )
+          OR EXISTS (
+            SELECT 1 FROM public.assessment_attempts aa
+            WHERE aa.metadata->>'processCode' = hp.code AND aa.user_id = auth.uid()
+          )
+        )
+    )
+  );


### PR DESCRIPTION
## Summary
Hasta ahora solo la empresa podía ver el avance de un candidato en un "evento" (proceso multi-prueba). Se agrega en `/perfil` una sección **"🗂️ Mi progreso en eventos"**: por cada evento en el que el candidato participó, muestra % completado (barra + `X/Y pruebas`), badges de las pruebas ya entregadas con su puntaje, y badges de las pruebas que le faltan.

- `getMyEventProgressAction` (`apps/frontend/src/actions/candidate-events.ts`): junta los `exam_results` + `assessment_attempts` propios del candidato, agrupados por `hiring_process_groups`. Usa únicamente lecturas que el candidato ya tenía permitidas por RLS (sus propios resultados, procesos con `status='active'`).
- Nueva policy `candidates_select_own_event_groups` en `hiring_process_groups`: antes solo los miembros de la empresa podían leer el nombre del evento. Se agrega lectura acotada a candidatos que están provablemente ligados a ese grupo vía sus propios resultados (mismo patrón que `profiles_select_empresa_process_candidates`). Ya aplicada en prod.
- Sección insertada en `perfil/page.tsx`, arriba del historial de exámenes.

## Test plan
- [ ] Loguearse como candidato que rindió pruebas de un proceso que pertenece a un evento y confirmar que aparece la sección con % correcto, entregadas y faltantes
- [ ] Confirmar que un candidato sin pruebas de eventos no ve la sección (no rompe el perfil)
- [ ] Confirmar que no se filtra info de otros candidatos ni de procesos ajenos

🤖 Generated with [Claude Code](https://claude.com/claude-code)