### PR TITLE
fix(eventos): cards de resumen usan el mismo criterio macro que la tabla

### DIFF
--- a/apps/frontend/src/actions/employer.ts
+++ b/apps/frontend/src/actions/employer.ts
@@ -960,12 +960,16 @@ export async function getEventStatsAction(groupId: string): Promise<{
     })
     .sort((a, b) => b.completedCount - a.completedCount || b.avgScore - a.avgScore);
 
-  const totalCandidates = allCandidates.length;
-  const totalPassed = allCandidates.filter((r) => r.passed).length;
+  // Totals reflect the same macro-level criteria as the participants table
+  // (60% of the event's required exams completed), not each person's single
+  // best-scoring exam — otherwise someone who aced 1/10 exams counted as
+  // "aprobado" here while showing "No aprobado (macro)" below.
+  const totalCandidates = participants.length;
+  const totalPassed = participants.filter((p) => p.macroApproved).length;
   const avgScore =
     totalCandidates > 0
       ? Math.round(
-          allCandidates.reduce((sum, r) => sum + r.percentage, 0) /
+          participants.reduce((sum, p) => sum + p.avgScore, 0) /
             totalCandidates
         )
       : null;

--- a/apps/frontend/src/app/empresa/eventos/[id]/page.tsx
+++ b/apps/frontend/src/app/empresa/eventos/[id]/page.tsx
@@ -289,8 +289,6 @@ export default function EventoDetailPage() {
     tasa: e.passRate,
   }));
 
-  const examCount = byExamType.length;
-
   const tooltipStyle = isDarkMode
     ? {
         backgroundColor: '#1e293b',
@@ -374,7 +372,7 @@ export default function EventoDetailPage() {
           />
           <StatCard
             label="Tipos de examen"
-            value={examCount}
+            value={totalExamTypes}
             isDarkMode={isDarkMode}
           />
         </div>


### PR DESCRIPTION
## Summary
Reportado: "Total candidatos 41 / Tasa aprobación 95% (39 aprobados) / Puntaje promedio 92%" no coincidía con el estado real. Causa: esas 4 cards seguían calculándose desde `allCandidates` (el mejor puntaje individual de cada persona, sin importar cuántas pruebas rindió), mientras que la tabla de participantes ya usa el criterio macro (≥60% de pruebas completadas) desde el PR #258. Alguien que rindió 1/10 y la aprobó contaba como "aprobado" arriba pero como "No aprobado (macro)" abajo.

- `totals.candidates/passed/passRate/avgScore` ahora se calculan desde `participants` + `macroApproved`, igual que la tabla
- "Tipos de examen" ahora muestra `totalExamTypes` (el total requerido del evento) en vez de solo los tipos que alguien llegó a rendir

## Test plan
- [ ] Abrir el evento reportado y confirmar que "Tasa aprobación" y "aprobados" coinciden con la cantidad de badges "Aprobado (macro)" en la tabla de abajo
- [ ] Confirmar "Puntaje promedio" refleja el promedio real de los participantes

🤖 Generated with [Claude Code](https://claude.com/claude-code)