### PR TITLE
fix(test-app): medir duración real de Bug Hunt y puntuar calidad por bug

### DIFF
--- a/apps/frontend/src/actions/exam-review.ts
+++ b/apps/frontend/src/actions/exam-review.ts
@@ -5,6 +5,7 @@ import { createClient } from '@/lib/supabase/server';
 type BugReviewItem = {
   approved: boolean;
   evaluatorNotes: string;
+  qualityScore: number; // 1-5, calidad del reporte de este bug (no solo aprobado/rechazado)
 };
 
 type ReviewData = {

--- a/apps/frontend/src/app/empresa/evaluar/[resultId]/page.tsx
+++ b/apps/frontend/src/app/empresa/evaluar/[resultId]/page.tsx
@@ -15,8 +15,16 @@ type Severity = 'Critical' | 'High' | 'Medium' | 'Low';
 
 type BugReviewMap = Record<
   string,
-  { approved: boolean; evaluatorNotes: string }
+  { approved: boolean; evaluatorNotes: string; qualityScore: number }
 >;
+
+const QUALITY_LABELS: Record<number, string> = {
+  1: 'Muy pobre',
+  2: 'Pobre',
+  3: 'Aceptable',
+  4: 'Buena',
+  5: 'Excelente',
+};
 
 const SEVERITY_COLORS: Record<Severity, { bg: string; text: string }> = {
   Critical: { bg: 'bg-red-100', text: 'text-red-800' },
@@ -127,6 +135,7 @@ export default function EvaluarPage() {
         initialReviews[bug.id] = {
           approved: saved?.approved ?? true,
           evaluatorNotes: saved?.evaluatorNotes ?? '',
+          qualityScore: saved?.qualityScore ?? 3,
         };
       });
       setBugReviews(initialReviews);
@@ -147,7 +156,28 @@ export default function EvaluarPage() {
     (r) => !r.approved
   ).length;
 
-  const effectiveScore = adjustedScore != null ? adjustedScore : autoScore;
+  // Calidad no es solo aprobado/rechazado: cada bug aprobado pesa según su
+  // qualityScore (1-5). Un bug aprobado pero mal documentado (pasos vagos,
+  // sin evidencia) ya no vale lo mismo que uno bien reportado.
+  const qualityRatio =
+    bugs.length > 0
+      ? Object.values(bugReviews).reduce(
+          (sum, r) => sum + (r.approved ? r.qualityScore : 0),
+          0
+        ) /
+        (5 * bugs.length)
+      : 0;
+  const approvedQualityScores = bugs
+    .map((bug) => bugReviews[bug.id])
+    .filter((r) => r?.approved);
+  const avgQuality =
+    approvedQualityScores.length > 0
+      ? approvedQualityScores.reduce((sum, r) => sum + r.qualityScore, 0) /
+        approvedQualityScores.length
+      : 0;
+  const computedScore = Math.round(autoScore * qualityRatio);
+
+  const effectiveScore = adjustedScore != null ? adjustedScore : computedScore;
   const maxPoints = exam?.total_questions ?? 30;
   const effectivePercentage = maxPoints
     ? Math.round((effectiveScore / maxPoints) * 100)
@@ -155,7 +185,11 @@ export default function EvaluarPage() {
 
   const updateBugReview = (
     bugId: string,
-    updates: Partial<{ approved: boolean; evaluatorNotes: string }>
+    updates: Partial<{
+      approved: boolean;
+      evaluatorNotes: string;
+      qualityScore: number;
+    }>
   ) => {
     setBugReviews((prev) => ({
       ...prev,
@@ -321,7 +355,7 @@ export default function EvaluarPage() {
               puntaje antes de finalizar la revisión.
             </div>
           )}
-          <div className="grid grid-cols-2 md:grid-cols-5 gap-4">
+          <div className="grid grid-cols-2 md:grid-cols-6 gap-4">
             <div
               className={`text-center p-3 rounded-lg ${isDarkMode ? 'bg-slate-700' : 'bg-gray-100'}`}
             >
@@ -349,6 +383,16 @@ export default function EvaluarPage() {
               </p>
             </div>
             <div
+              className={`text-center p-3 rounded-lg ${isDarkMode ? 'bg-slate-700' : 'bg-gray-100'}`}
+            >
+              <p className={labelClass}>Calidad prom.</p>
+              <p
+                className={`text-xl font-bold ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
+              >
+                {avgQuality > 0 ? avgQuality.toFixed(1) : '—'}/5
+              </p>
+            </div>
+            <div
               className={`text-center p-3 rounded-lg ${isDarkMode ? 'bg-amber-900/30' : 'bg-amber-100'}`}
             >
               <p className={labelClass}>Efectivo</p>
@@ -371,6 +415,13 @@ export default function EvaluarPage() {
               </p>
             </div>
           </div>
+          <p
+            className={`text-xs mt-3 ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}
+          >
+            &quot;Efectivo&quot; = Auto × calidad promedio ponderada por bug
+            (bugs rechazados cuentan como calidad 0). Ajustá manualmente abajo
+            si no estás de acuerdo.
+          </p>
         </div>
 
         {/* Bugs List */}
@@ -439,7 +490,7 @@ export default function EvaluarPage() {
                         </div>
                       </div>
 
-                      <div className="flex items-center gap-3 shrink-0">
+                      <div className="flex items-center gap-3 shrink-0 flex-wrap justify-end">
                         <label
                           className={`flex items-center gap-1.5 text-sm cursor-pointer select-none ${
                             review?.approved
@@ -461,6 +512,33 @@ export default function EvaluarPage() {
                           />
                           Aprobado
                         </label>
+                        {review?.approved && (
+                          <div
+                            className="flex items-center gap-1"
+                            onClick={(e) => e.stopPropagation()}
+                            title={QUALITY_LABELS[review?.qualityScore ?? 3]}
+                          >
+                            {[1, 2, 3, 4, 5].map((n) => (
+                              <button
+                                key={n}
+                                type="button"
+                                onClick={() =>
+                                  updateBugReview(bug.id, { qualityScore: n })
+                                }
+                                aria-label={`Calidad ${n}/5`}
+                                className={`text-lg leading-none transition-colors ${
+                                  n <= (review?.qualityScore ?? 3)
+                                    ? 'text-amber-400'
+                                    : isDarkMode
+                                      ? 'text-slate-600'
+                                      : 'text-gray-300'
+                                }`}
+                              >
+                                ★
+                              </button>
+                            ))}
+                          </div>
+                        )}
                         <button
                           onClick={() =>
                             setExpandedBugId(isExpanded ? null : bug.id)
@@ -631,7 +709,7 @@ export default function EvaluarPage() {
                     const v = e.target.value;
                     setAdjustedScore(v === '' ? null : parseInt(v, 10));
                   }}
-                  placeholder={`Auto: ${autoScore}`}
+                  placeholder={`Sugerido: ${computedScore}`}
                   className={inputClass}
                 />
               </div>

--- a/apps/frontend/src/app/labs/test-app/components/TestAppLayout.tsx
+++ b/apps/frontend/src/app/labs/test-app/components/TestAppLayout.tsx
@@ -3,7 +3,11 @@
 import { useEffect, useState } from 'react';
 import Link from 'next/link';
 import { usePathname, useRouter } from 'next/navigation';
-import { getCurrentUser, setCurrentUser } from '../lib/storage';
+import {
+  getCurrentUser,
+  setCurrentUser,
+  ensureSessionStartedAt,
+} from '../lib/storage';
 import { initializeApp, needsInitialization } from '../lib/seedData';
 import { logLogout } from '../lib/auditLog';
 import { getCandidateId } from '../lib/prng';
@@ -26,6 +30,10 @@ export default function TestAppLayout({
   const router = useRouter();
 
   useEffect(() => {
+    // Mark real session start (only once per browser tab session) so
+    // exam duration can be measured instead of self-reported.
+    ensureSessionStartedAt();
+
     // Initialize app if needed
     if (needsInitialization()) {
       initializeApp();

--- a/apps/frontend/src/app/labs/test-app/lib/storage.ts
+++ b/apps/frontend/src/app/labs/test-app/lib/storage.ts
@@ -16,6 +16,7 @@ const KEYS = {
   TICKETS: 'test-app:tickets',
   CURRENT_USER: 'test-app:current-user',
   SESSION: 'test-app:session',
+  SESSION_STARTED_AT: 'test-app:session-started-at',
 } as const;
 
 // Generic storage helpers
@@ -115,7 +116,11 @@ export function saveCart(items: CartItem[]): void {
   saveToStorage(KEYS.CART, allCarts);
 }
 
-export function addToCart(productId: string, quantity: number, price: number): void {
+export function addToCart(
+  productId: string,
+  quantity: number,
+  price: number
+): void {
   const cart = getCart();
   const existingIndex = cart.findIndex((item) => item.productId === productId);
 
@@ -191,6 +196,22 @@ export function getUserTickets(userId: string): SupportTicket[] {
   return tickets.filter((t) => t.userId === userId);
 }
 
+// Real session start (sessionStorage, not editable by candidate).
+// Used to compute actual elapsed time instead of the self-reported
+// "duración" field, which anyone could type any value into.
+export function ensureSessionStartedAt(): void {
+  if (typeof window === 'undefined') return;
+  if (!sessionStorage.getItem(KEYS.SESSION_STARTED_AT)) {
+    sessionStorage.setItem(KEYS.SESSION_STARTED_AT, new Date().toISOString());
+  }
+}
+
+export function getSessionStartedAt(): Date | null {
+  if (typeof window === 'undefined') return null;
+  const raw = sessionStorage.getItem(KEYS.SESSION_STARTED_AT);
+  return raw ? new Date(raw) : null;
+}
+
 // Candidate Session
 export function getCandidateSession(): CandidateSession | null {
   return getFromStorage<CandidateSession>(KEYS.SESSION);
@@ -213,7 +234,13 @@ export function clearAllData(): void {
 export function resetSession(): void {
   if (typeof window === 'undefined') return;
 
-  [KEYS.CART, KEYS.ORDERS, KEYS.TICKETS, KEYS.CURRENT_USER, KEYS.SESSION].forEach((key) => {
+  [
+    KEYS.CART,
+    KEYS.ORDERS,
+    KEYS.TICKETS,
+    KEYS.CURRENT_USER,
+    KEYS.SESSION,
+  ].forEach((key) => {
     localStorage.removeItem(key);
   });
 }

--- a/apps/frontend/src/app/labs/test-app/report/page.tsx
+++ b/apps/frontend/src/app/labs/test-app/report/page.tsx
@@ -6,7 +6,7 @@ import { useState, useEffect } from 'react';
 import { useTheme } from '@/contexts/ThemeContext';
 import { useSupabaseAuth } from '@/contexts/SupabaseAuthContext';
 import { getExamUserDefaults } from '@/lib/exam-user-defaults';
-import { getCurrentUser } from '../lib/storage';
+import { getCurrentUser, getSessionStartedAt } from '../lib/storage';
 import { getCandidateId, setCandidateId } from '../lib/prng';
 import type {
   BugReport,
@@ -68,6 +68,35 @@ export default function TechnicalReportPage() {
     duration: 30,
     exploredSections: [],
   });
+
+  // Real elapsed time since the candidate's session actually started
+  // (sessionStorage timestamp set on first page load, not editable).
+  // Replaces the old self-reported "duración" field, which every
+  // candidate could set to whatever they wanted.
+  const [realElapsedMinutes, setRealElapsedMinutes] = useState(0);
+  useEffect(() => {
+    const updateElapsed = () => {
+      const start = getSessionStartedAt();
+      if (start) {
+        setRealElapsedMinutes(
+          Math.max(0, Math.round((Date.now() - start.getTime()) / 60000))
+        );
+      }
+    };
+    updateElapsed();
+    const interval = setInterval(updateElapsed, 30000);
+    return () => clearInterval(interval);
+  }, []);
+
+  // Keep testSession.duration (used by PDF/JSON export) in sync with the
+  // real measured time instead of the old manually-typed value.
+  useEffect(() => {
+    setTestSession((prev) =>
+      prev.duration === realElapsedMinutes
+        ? prev
+        : { ...prev, duration: realElapsedMinutes }
+    );
+  }, [realElapsedMinutes]);
 
   // Bugs
   const [bugs, setBugs] = useState<BugReport[]>([]);
@@ -385,6 +414,10 @@ export default function TechnicalReportPage() {
       user?.email ||
       '';
     const participantEmail = candidateInfo.email || user?.email || '';
+    const sessionStart = getSessionStartedAt();
+    const timeSpentSeconds = sessionStart
+      ? Math.max(60, Math.round((Date.now() - sessionStart.getTime()) / 1000))
+      : testSession.duration * 60; // fallback if session start was never recorded
     const { error } = await saveExamResultAction({
       exam_type: 'test-app',
       exam_mode: 'exam',
@@ -398,7 +431,7 @@ export default function TechnicalReportPage() {
       passing_score: Math.round(score.maxPoints * 0.6),
       passed: score.percentage >= 60,
       percentage: score.percentage,
-      time_spent: testSession.duration * 60,
+      time_spent: timeSpentSeconds,
       github_profile: candidateInfo.githubProfile || undefined,
       process_code: processCode.trim().toUpperCase() || undefined,
       metadata: {
@@ -630,23 +663,19 @@ export default function TechnicalReportPage() {
               <label
                 className={`block text-sm font-medium mb-2 ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
               >
-                Duración (minutos)
+                Duración real (minutos, automático)
               </label>
               <input
                 type="number"
-                value={testSession.duration}
-                onChange={(e) =>
-                  setTestSession((prev) => ({
-                    ...prev,
-                    duration: parseInt(e.target.value) || 0,
-                  }))
-                }
-                className={`w-full px-4 py-2 rounded-lg border ${
+                value={realElapsedMinutes}
+                readOnly
+                disabled
+                title="Calculado automáticamente desde que se abrió la prueba. No editable."
+                className={`w-full px-4 py-2 rounded-lg border cursor-not-allowed ${
                   isDarkMode
-                    ? 'bg-slate-700 border-slate-600 text-white'
-                    : 'bg-white border-gray-300 text-gray-900'
-                } focus:outline-none focus:ring-2 focus:ring-amber-500`}
-                placeholder="30"
+                    ? 'bg-slate-800 border-slate-600 text-slate-400'
+                    : 'bg-gray-100 border-gray-300 text-gray-500'
+                }`}
               />
             </div>
             <div>


### PR DESCRIPTION
## Summary
- `time_spent` en Test App — Bug Hunt era self-reported (campo "duración" editable por el candidato, default 30 min), por eso todos los resultados mostraban 30m 0s sin importar el tiempo real. Ahora se mide con un timestamp de sesión no editable (`sessionStorage`).
- La revisión manual solo marcaba bugs como aprobado/rechazado sin efecto real en el puntaje final salvo override manual. Se agregó un rating de calidad 1-5 por bug que pondera el "puntaje efectivo".
- Backfill en producción (Supabase) de los 17 resultados de `testappfinal-CXXU`: `time_spent` recalculado con el rango primer→último bug reportado (`foundAt`), marcado en `metadata.time_spent_estimated`.

## Test plan
- [x] `tsc --noEmit` sin errores en los archivos tocados (pre-push hook OK)
- [x] `eslint` sin errores (solo warnings pre-existentes de `<img>`)
- [ ] Probar en navegador: completar Bug Hunt y confirmar que "Duración real" refleja tiempo transcurrido, no editable
- [ ] Probar pantalla de revisión (`/empresa/evaluar/[resultId]`): calificar bugs con estrellas y verificar que el puntaje efectivo cambia

🤖 Generated with [Claude Code](https://claude.com/claude-code)