### PR TITLE
fix(empresa): source empresa_id from empresa_miembros on process create

### DIFF
--- a/apps/frontend/src/actions/employer.ts
+++ b/apps/frontend/src/actions/employer.ts
@@ -183,11 +183,15 @@ export async function createHiringProcessAction(payload: {
 
   const code = generateCode(payload.company_name);
 
-  // Attach empresa_id so all empresa members can access this process
-  const { data: profile } = await supabase
-    .from('profiles')
+  // Attach empresa_id so all empresa members can access this process.
+  // Sourced from empresa_miembros (same source the dashboard stats use),
+  // not profiles.empresa_id, which can drift out of sync with actual
+  // active membership.
+  const { data: membership } = await supabase
+    .from('empresa_miembros')
     .select('empresa_id')
-    .eq('id', user.id)
+    .eq('user_id', user.id)
+    .eq('status', 'active')
     .single();
 
   const { group_id, ...rest } = payload;
@@ -198,7 +202,7 @@ export async function createHiringProcessAction(payload: {
       code,
       created_by: user.id,
       status: 'active',
-      ...(profile?.empresa_id ? { empresa_id: profile.empresa_id } : {}),
+      ...(membership?.empresa_id ? { empresa_id: membership.empresa_id } : {}),
       ...(group_id ? { group_id } : {}),
     })
     .select()


### PR DESCRIPTION
## Summary
- Follow-up to #267. `createHiringProcessAction` sourced `empresa_id` from `profiles.empresa_id`, which had drifted out of sync with `empresa_miembros` (the active-membership table the dashboard stats query actually uses). This left almost every existing process with `empresa_id NULL`, so once #267 scoped the dashboard query strictly by `empresa_id`, the panel showed all zeros for real companies.
- Switched process creation to read `empresa_id` from `empresa_miembros` (same source as the dashboard) so it can't drift again.
- Also backfilled the 17 affected rows directly in prod (`empresa_id` column only — no candidate/exam/prospect data touched), so `admin@aiquaa.com`'s panel now reflects its actual processes/candidates.

## Test plan
- [x] `pnpm --filter @aiquaa/frontend type-check` passes
- [ ] Confirm `/empresa` panel for `admin@aiquaa.com` shows the expected 17 processes and real candidate counts

🤖 Generated with [Claude Code](https://claude.com/claude-code)