### PR TITLE
feat(empresa): constructor de pruebas técnicas propias

### DIFF
--- a/apps/frontend/src/actions/empresa-pruebas-candidato.ts
+++ b/apps/frontend/src/actions/empresa-pruebas-candidato.ts
@@ -1,0 +1,243 @@
+'use server';
+
+// Candidate-facing actions for empresa_pruebas — no session, validated by
+// invitation token, using the service-role client (bypasses RLS). Candidates
+// never touch empresa_intentos/empresa_preguntas directly.
+
+import { createAdminClient } from '@/lib/supabase/admin';
+import {
+  scoreEmpresaIntento,
+  type EmpresaPregunta as ScoringPregunta,
+} from '@/actions/lib/empresa-scoring';
+import type { EmpresaPruebaQuestionType } from '@/actions/empresa-pruebas';
+
+const SUBMIT_GRACE_MS = 2 * 60 * 1000; // 2 min soft margin over duration_minutes
+
+interface InvitacionRow {
+  id: string;
+  prueba_id: string;
+  token: string;
+  candidate_email: string | null;
+  candidate_name: string | null;
+  expires_at: string | null;
+  max_attempts: number;
+  status: 'active' | 'revoked';
+}
+
+interface PruebaRow {
+  id: string;
+  title: string;
+  description: string | null;
+  level: string | null;
+  duration_minutes: number | null;
+  is_active: boolean;
+}
+
+interface PreguntaRow {
+  id: string;
+  position: number;
+  question_type: EmpresaPruebaQuestionType;
+  prompt: string;
+  options: unknown;
+  correct_answer: unknown;
+  expected_keywords: string[] | null;
+  points: number;
+}
+
+export interface PublicPregunta {
+  id: string;
+  position: number;
+  question_type: EmpresaPruebaQuestionType;
+  prompt: string;
+  options: unknown;
+}
+
+async function resolveInvitacion(
+  adminClient: ReturnType<typeof createAdminClient>,
+  token: string
+): Promise<
+  { invitacion: InvitacionRow; prueba: PruebaRow } | { error: string }
+> {
+  const { data: invitacion, error: invErr } = await adminClient
+    .from('empresa_prueba_invitaciones')
+    .select(
+      'id, prueba_id, token, candidate_email, candidate_name, expires_at, max_attempts, status'
+    )
+    .eq('token', token)
+    .maybeSingle();
+
+  if (invErr || !invitacion) return { error: 'not_found' };
+  if (invitacion.status !== 'active') return { error: 'revoked' };
+  if (
+    invitacion.expires_at &&
+    new Date(invitacion.expires_at).getTime() < Date.now()
+  )
+    return { error: 'expired' };
+
+  const { data: prueba, error: pruebaErr } = await adminClient
+    .from('empresa_pruebas')
+    .select('id, title, description, level, duration_minutes, is_active')
+    .eq('id', invitacion.prueba_id)
+    .maybeSingle();
+
+  if (pruebaErr || !prueba || !prueba.is_active) return { error: 'not_found' };
+
+  return {
+    invitacion: invitacion as InvitacionRow,
+    prueba: prueba as PruebaRow,
+  };
+}
+
+function stripAnswerKey(row: PreguntaRow): PublicPregunta {
+  return {
+    id: row.id,
+    position: row.position,
+    question_type: row.question_type,
+    prompt: row.prompt,
+    options: row.question_type === 'multiple_choice' ? row.options : undefined,
+  };
+}
+
+export async function getPruebaByTokenAction(token: string): Promise<{
+  data: {
+    prueba: PruebaRow;
+    preguntas: PublicPregunta[];
+    candidate_name: string | null;
+    candidate_email: string | null;
+  } | null;
+  error: string | null;
+}> {
+  const adminClient = createAdminClient();
+  const resolved = await resolveInvitacion(adminClient, token);
+  if ('error' in resolved) return { data: null, error: resolved.error };
+  const { invitacion, prueba } = resolved;
+
+  const { count } = await adminClient
+    .from('empresa_intentos')
+    .select('id', { count: 'exact', head: true })
+    .eq('invitacion_id', invitacion.id)
+    .not('submitted_at', 'is', null);
+
+  if ((count ?? 0) >= invitacion.max_attempts)
+    return { data: null, error: 'no_attempts_left' };
+
+  const { data: preguntas, error: preguntasErr } = await adminClient
+    .from('empresa_preguntas')
+    .select(
+      'id, position, question_type, prompt, options, correct_answer, expected_keywords, points'
+    )
+    .eq('prueba_id', prueba.id)
+    .order('position', { ascending: true });
+
+  if (preguntasErr) return { data: null, error: preguntasErr.message };
+
+  return {
+    data: {
+      prueba,
+      preguntas: (preguntas as PreguntaRow[]).map(stripAnswerKey),
+      candidate_name: invitacion.candidate_name,
+      candidate_email: invitacion.candidate_email,
+    },
+    error: null,
+  };
+}
+
+export async function startIntentoAction(
+  token: string,
+  candidateInfo: { candidate_name?: string; candidate_email?: string }
+): Promise<{ data: { intentoId: string } | null; error: string | null }> {
+  const adminClient = createAdminClient();
+  const resolved = await resolveInvitacion(adminClient, token);
+  if ('error' in resolved) return { data: null, error: resolved.error };
+  const { invitacion, prueba } = resolved;
+
+  const { count } = await adminClient
+    .from('empresa_intentos')
+    .select('id', { count: 'exact', head: true })
+    .eq('invitacion_id', invitacion.id)
+    .not('submitted_at', 'is', null);
+
+  if ((count ?? 0) >= invitacion.max_attempts)
+    return { data: null, error: 'no_attempts_left' };
+
+  const { data, error } = await adminClient
+    .from('empresa_intentos')
+    .insert({
+      prueba_id: prueba.id,
+      invitacion_id: invitacion.id,
+      candidate_name:
+        invitacion.candidate_name ??
+        candidateInfo.candidate_name?.trim() ??
+        null,
+      candidate_email:
+        invitacion.candidate_email ??
+        candidateInfo.candidate_email?.toLowerCase().trim() ??
+        null,
+      started_at: new Date().toISOString(),
+    })
+    .select('id')
+    .single();
+
+  if (error) return { data: null, error: error.message };
+  return { data: { intentoId: data.id as string }, error: null };
+}
+
+export async function submitIntentoAction(
+  token: string,
+  intentoId: string,
+  answers: Record<string, unknown>
+): Promise<{ error: string | null }> {
+  const adminClient = createAdminClient();
+  const resolved = await resolveInvitacion(adminClient, token);
+  if ('error' in resolved) return { error: resolved.error };
+  const { invitacion, prueba } = resolved;
+
+  const { data: intento, error: intentoErr } = await adminClient
+    .from('empresa_intentos')
+    .select('id, invitacion_id, started_at, submitted_at')
+    .eq('id', intentoId)
+    .eq('invitacion_id', invitacion.id)
+    .maybeSingle();
+
+  if (intentoErr || !intento) return { error: 'not_found' };
+  if (intento.submitted_at) return { error: null }; // idempotent: already scored
+
+  if (prueba.duration_minutes && intento.started_at) {
+    const deadline =
+      new Date(intento.started_at).getTime() +
+      prueba.duration_minutes * 60 * 1000 +
+      SUBMIT_GRACE_MS;
+    if (Date.now() > deadline) return { error: 'time_expired' };
+  }
+
+  const { data: preguntas, error: preguntasErr } = await adminClient
+    .from('empresa_preguntas')
+    .select('id, question_type, correct_answer, expected_keywords, points')
+    .eq('prueba_id', prueba.id);
+
+  if (preguntasErr) return { error: preguntasErr.message };
+
+  const scoringPreguntas: ScoringPregunta[] = (preguntas ?? []).map((row) => ({
+    id: row.id,
+    question_type: row.question_type,
+    correct_answer: row.correct_answer,
+    expected_keywords: row.expected_keywords,
+    points: row.points,
+  }));
+
+  const summary = scoreEmpresaIntento(scoringPreguntas, answers);
+
+  const { error: updateErr } = await adminClient
+    .from('empresa_intentos')
+    .update({
+      submitted_at: new Date().toISOString(),
+      answers,
+      score: summary.score,
+      max_score: summary.maxScore,
+      breakdown: summary.breakdown,
+    })
+    .eq('id', intentoId);
+
+  if (updateErr) return { error: updateErr.message };
+  return { error: null };
+}

--- a/apps/frontend/src/actions/empresa-pruebas.ts
+++ b/apps/frontend/src/actions/empresa-pruebas.ts
@@ -1,0 +1,595 @@
+'use server';
+
+import { randomBytes } from 'crypto';
+import { createClient } from '@/lib/supabase/server';
+
+export type EmpresaPruebaQuestionType =
+  | 'multiple_choice'
+  | 'true_false'
+  | 'short_text';
+
+export interface EmpresaPrueba {
+  id: string;
+  empresa_id: string;
+  created_by: string | null;
+  title: string;
+  category: string;
+  description: string | null;
+  level: string | null;
+  duration_minutes: number | null;
+  is_active: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface EmpresaPreguntaRow {
+  id: string;
+  prueba_id: string;
+  position: number;
+  question_type: EmpresaPruebaQuestionType;
+  prompt: string;
+  options: unknown;
+  correct_answer: unknown;
+  expected_keywords: string[] | null;
+  points: number;
+}
+
+export interface EmpresaPruebaInvitacion {
+  id: string;
+  prueba_id: string;
+  token: string;
+  candidate_email: string | null;
+  candidate_name: string | null;
+  expires_at: string | null;
+  max_attempts: number;
+  status: 'active' | 'revoked';
+  created_by: string | null;
+  created_at: string;
+}
+
+export interface EmpresaIntentoSummary {
+  id: string;
+  prueba_id: string;
+  invitacion_id: string;
+  candidate_name: string | null;
+  candidate_email: string | null;
+  started_at: string | null;
+  submitted_at: string | null;
+  score: number | null;
+  max_score: number | null;
+  breakdown: unknown;
+  answers: unknown;
+}
+
+type SupabaseServerClient = Awaited<ReturnType<typeof createClient>>;
+
+/**
+ * Local copy of the getCallerMembership() pattern from empresa-admin.ts —
+ * duplicated deliberately instead of importing, to keep this feature isolated.
+ */
+async function getCallerEmpresaMembership(
+  supabase: SupabaseServerClient,
+  callerId: string
+) {
+  const { data, error } = await supabase
+    .from('empresa_miembros')
+    .select('id, empresa_id, role, status')
+    .eq('user_id', callerId)
+    .eq('status', 'active')
+    .single();
+  if (error || !data) return null;
+  return data;
+}
+
+type MembershipContext =
+  | {
+      ok: true;
+      user: { id: string };
+      membership: {
+        id: string;
+        empresa_id: string;
+        role: string;
+        status: string;
+      };
+    }
+  | { ok: false; error: string };
+
+async function requireAuthenticatedMember(
+  supabase: SupabaseServerClient
+): Promise<MembershipContext> {
+  const {
+    data: { user },
+    error: authErr,
+  } = await supabase.auth.getUser();
+  if (authErr || !user) return { ok: false, error: 'No autenticado' };
+
+  const membership = await getCallerEmpresaMembership(supabase, user.id);
+  if (!membership) return { ok: false, error: 'Sin membresia activa' };
+
+  return { ok: true, user, membership };
+}
+
+function isAdminRole(role: string) {
+  return role === 'owner' || role === 'admin';
+}
+
+/** Fetches a prueba scoped to the caller's empresa — null if missing or cross-tenant. */
+async function getPruebaForEmpresa(
+  supabase: SupabaseServerClient,
+  pruebaId: string,
+  empresaId: string
+) {
+  const { data, error } = await supabase
+    .from('empresa_pruebas')
+    .select('id, empresa_id')
+    .eq('id', pruebaId)
+    .eq('empresa_id', empresaId)
+    .single();
+  if (error || !data) return null;
+  return data;
+}
+
+// ── pruebas ───────────────────────────────────────────────────────────
+
+export async function listPruebasAction(): Promise<{
+  data: EmpresaPrueba[] | null;
+  error: string | null;
+}> {
+  const supabase = await createClient();
+  const ctx = await requireAuthenticatedMember(supabase);
+  if (!ctx.ok) return { data: null, error: ctx.error };
+
+  const { data, error } = await supabase
+    .from('empresa_pruebas')
+    .select('*')
+    .eq('empresa_id', ctx.membership.empresa_id)
+    .order('created_at', { ascending: false });
+
+  if (error) return { data: null, error: error.message };
+  return { data: data as EmpresaPrueba[], error: null };
+}
+
+export async function getPruebaAction(pruebaId: string): Promise<{
+  data: EmpresaPrueba | null;
+  error: string | null;
+}> {
+  const supabase = await createClient();
+  const ctx = await requireAuthenticatedMember(supabase);
+  if (!ctx.ok) return { data: null, error: ctx.error };
+
+  const { data, error } = await supabase
+    .from('empresa_pruebas')
+    .select('*')
+    .eq('id', pruebaId)
+    .eq('empresa_id', ctx.membership.empresa_id)
+    .single();
+
+  if (error) return { data: null, error: 'Prueba no encontrada' };
+  return { data: data as EmpresaPrueba, error: null };
+}
+
+export async function createPruebaAction(payload: {
+  title: string;
+  category: string;
+  description?: string;
+  level?: string;
+  duration_minutes?: number;
+}): Promise<{ data: EmpresaPrueba | null; error: string | null }> {
+  const supabase = await createClient();
+  const ctx = await requireAuthenticatedMember(supabase);
+  if (!ctx.ok) return { data: null, error: ctx.error };
+  if (!isAdminRole(ctx.membership.role))
+    return { data: null, error: 'Sin permisos suficientes' };
+
+  const title = payload.title.trim();
+  const category = payload.category.trim();
+  if (!title) return { data: null, error: 'El titulo es requerido' };
+  if (!category) return { data: null, error: 'La categoria es requerida' };
+
+  const { data, error } = await supabase
+    .from('empresa_pruebas')
+    .insert({
+      empresa_id: ctx.membership.empresa_id,
+      created_by: ctx.user.id,
+      title,
+      category,
+      description: payload.description?.trim() || null,
+      level: payload.level?.trim() || null,
+      duration_minutes: payload.duration_minutes ?? null,
+    })
+    .select('*')
+    .single();
+
+  if (error) return { data: null, error: error.message };
+  return { data: data as EmpresaPrueba, error: null };
+}
+
+export async function updatePruebaAction(
+  pruebaId: string,
+  payload: {
+    title?: string;
+    category?: string;
+    description?: string;
+    level?: string;
+    duration_minutes?: number;
+  }
+): Promise<{ error: string | null }> {
+  const supabase = await createClient();
+  const ctx = await requireAuthenticatedMember(supabase);
+  if (!ctx.ok) return { error: ctx.error };
+  if (!isAdminRole(ctx.membership.role))
+    return { error: 'Sin permisos suficientes' };
+
+  const update: Record<string, unknown> = {};
+  if (payload.title !== undefined) update.title = payload.title.trim();
+  if (payload.category !== undefined) update.category = payload.category.trim();
+  if (payload.description !== undefined)
+    update.description = payload.description.trim() || null;
+  if (payload.level !== undefined) update.level = payload.level.trim() || null;
+  if (payload.duration_minutes !== undefined)
+    update.duration_minutes = payload.duration_minutes;
+
+  const { error } = await supabase
+    .from('empresa_pruebas')
+    .update(update)
+    .eq('id', pruebaId)
+    .eq('empresa_id', ctx.membership.empresa_id);
+
+  if (error) return { error: error.message };
+  return { error: null };
+}
+
+export async function togglePruebaActivaAction(
+  pruebaId: string,
+  isActive: boolean
+): Promise<{ error: string | null }> {
+  const supabase = await createClient();
+  const ctx = await requireAuthenticatedMember(supabase);
+  if (!ctx.ok) return { error: ctx.error };
+  if (!isAdminRole(ctx.membership.role))
+    return { error: 'Sin permisos suficientes' };
+
+  const { error } = await supabase
+    .from('empresa_pruebas')
+    .update({ is_active: isActive })
+    .eq('id', pruebaId)
+    .eq('empresa_id', ctx.membership.empresa_id);
+
+  if (error) return { error: error.message };
+  return { error: null };
+}
+
+export async function deletePruebaAction(
+  pruebaId: string
+): Promise<{ error: string | null }> {
+  const supabase = await createClient();
+  const ctx = await requireAuthenticatedMember(supabase);
+  if (!ctx.ok) return { error: ctx.error };
+  if (!isAdminRole(ctx.membership.role))
+    return { error: 'Sin permisos suficientes' };
+
+  const { error } = await supabase
+    .from('empresa_pruebas')
+    .delete()
+    .eq('id', pruebaId)
+    .eq('empresa_id', ctx.membership.empresa_id);
+
+  if (error) return { error: error.message };
+  return { error: null };
+}
+
+export async function listCategoriasAction(): Promise<{
+  data: string[];
+  error: string | null;
+}> {
+  const supabase = await createClient();
+  const ctx = await requireAuthenticatedMember(supabase);
+  if (!ctx.ok) return { data: [], error: ctx.error };
+
+  const { data, error } = await supabase
+    .from('empresa_pruebas')
+    .select('category')
+    .eq('empresa_id', ctx.membership.empresa_id);
+
+  if (error) return { data: [], error: error.message };
+
+  const seen = new Map<string, string>();
+  for (const row of data as { category: string }[]) {
+    const key = row.category.trim().toLowerCase();
+    if (key && !seen.has(key)) seen.set(key, row.category.trim());
+  }
+
+  return { data: Array.from(seen.values()).sort(), error: null };
+}
+
+// ── preguntas ─────────────────────────────────────────────────────────
+
+function validatePreguntaShape(payload: {
+  question_type: EmpresaPruebaQuestionType;
+  options?: unknown;
+  correct_answer: unknown;
+  expected_keywords?: string[];
+}): string | null {
+  if (payload.question_type === 'multiple_choice') {
+    if (!Array.isArray(payload.options) || payload.options.length < 2)
+      return 'multiple_choice requiere al menos 2 opciones';
+    if (
+      !payload.correct_answer ||
+      typeof (payload.correct_answer as { value?: unknown }).value !== 'string'
+    )
+      return 'multiple_choice requiere correct_answer.value (string)';
+  }
+  if (payload.question_type === 'true_false') {
+    if (
+      !payload.correct_answer ||
+      typeof (payload.correct_answer as { value?: unknown }).value !== 'boolean'
+    )
+      return 'true_false requiere correct_answer.value (boolean)';
+  }
+  if (payload.question_type === 'short_text') {
+    if (!payload.expected_keywords || payload.expected_keywords.length === 0)
+      return 'short_text requiere al menos 1 expected_keyword';
+  }
+  return null;
+}
+
+export async function upsertPreguntaAction(payload: {
+  id?: string;
+  prueba_id: string;
+  position: number;
+  question_type: EmpresaPruebaQuestionType;
+  prompt: string;
+  options?: unknown;
+  correct_answer: unknown;
+  expected_keywords?: string[];
+  points?: number;
+}): Promise<{ data: EmpresaPreguntaRow | null; error: string | null }> {
+  const supabase = await createClient();
+  const ctx = await requireAuthenticatedMember(supabase);
+  if (!ctx.ok) return { data: null, error: ctx.error };
+  if (!isAdminRole(ctx.membership.role))
+    return { data: null, error: 'Sin permisos suficientes' };
+
+  const prueba = await getPruebaForEmpresa(
+    supabase,
+    payload.prueba_id,
+    ctx.membership.empresa_id
+  );
+  if (!prueba) return { data: null, error: 'Prueba no encontrada' };
+
+  if (!payload.prompt.trim())
+    return { data: null, error: 'El enunciado es requerido' };
+
+  const shapeError = validatePreguntaShape(payload);
+  if (shapeError) return { data: null, error: shapeError };
+
+  const row = {
+    prueba_id: payload.prueba_id,
+    position: payload.position,
+    question_type: payload.question_type,
+    prompt: payload.prompt.trim(),
+    options:
+      payload.question_type === 'multiple_choice' ? payload.options : null,
+    correct_answer: payload.correct_answer,
+    expected_keywords:
+      payload.question_type === 'short_text' ? payload.expected_keywords : null,
+    points: payload.points ?? 1,
+  };
+
+  const query = payload.id
+    ? supabase
+        .from('empresa_preguntas')
+        .update(row)
+        .eq('id', payload.id)
+        .eq('prueba_id', payload.prueba_id)
+    : supabase.from('empresa_preguntas').insert(row);
+
+  const { data, error } = await query.select('*').single();
+
+  if (error) return { data: null, error: error.message };
+  return { data: data as EmpresaPreguntaRow, error: null };
+}
+
+export async function deletePreguntaAction(
+  preguntaId: string,
+  pruebaId: string
+): Promise<{ error: string | null }> {
+  const supabase = await createClient();
+  const ctx = await requireAuthenticatedMember(supabase);
+  if (!ctx.ok) return { error: ctx.error };
+  if (!isAdminRole(ctx.membership.role))
+    return { error: 'Sin permisos suficientes' };
+
+  const prueba = await getPruebaForEmpresa(
+    supabase,
+    pruebaId,
+    ctx.membership.empresa_id
+  );
+  if (!prueba) return { error: 'Prueba no encontrada' };
+
+  const { error } = await supabase
+    .from('empresa_preguntas')
+    .delete()
+    .eq('id', preguntaId)
+    .eq('prueba_id', pruebaId);
+
+  if (error) return { error: error.message };
+  return { error: null };
+}
+
+export async function reorderPreguntasAction(
+  pruebaId: string,
+  orderedIds: string[]
+): Promise<{ error: string | null }> {
+  const supabase = await createClient();
+  const ctx = await requireAuthenticatedMember(supabase);
+  if (!ctx.ok) return { error: ctx.error };
+  if (!isAdminRole(ctx.membership.role))
+    return { error: 'Sin permisos suficientes' };
+
+  const prueba = await getPruebaForEmpresa(
+    supabase,
+    pruebaId,
+    ctx.membership.empresa_id
+  );
+  if (!prueba) return { error: 'Prueba no encontrada' };
+
+  for (let index = 0; index < orderedIds.length; index += 1) {
+    const { error } = await supabase
+      .from('empresa_preguntas')
+      .update({ position: index })
+      .eq('id', orderedIds[index])
+      .eq('prueba_id', pruebaId);
+    if (error) return { error: error.message };
+  }
+
+  return { error: null };
+}
+
+export async function listPreguntasAction(pruebaId: string): Promise<{
+  data: EmpresaPreguntaRow[] | null;
+  error: string | null;
+}> {
+  const supabase = await createClient();
+  const ctx = await requireAuthenticatedMember(supabase);
+  if (!ctx.ok) return { data: null, error: ctx.error };
+
+  const prueba = await getPruebaForEmpresa(
+    supabase,
+    pruebaId,
+    ctx.membership.empresa_id
+  );
+  if (!prueba) return { data: null, error: 'Prueba no encontrada' };
+
+  const { data, error } = await supabase
+    .from('empresa_preguntas')
+    .select('*')
+    .eq('prueba_id', pruebaId)
+    .order('position', { ascending: true });
+
+  if (error) return { data: null, error: error.message };
+  return { data: data as EmpresaPreguntaRow[], error: null };
+}
+
+// ── invitaciones ──────────────────────────────────────────────────────
+
+function generateInvitacionToken() {
+  return randomBytes(32).toString('base64url');
+}
+
+export async function createPruebaInvitacionAction(payload: {
+  prueba_id: string;
+  candidate_email?: string;
+  candidate_name?: string;
+  expires_at?: string;
+  max_attempts?: number;
+}): Promise<{ data: EmpresaPruebaInvitacion | null; error: string | null }> {
+  const supabase = await createClient();
+  const ctx = await requireAuthenticatedMember(supabase);
+  if (!ctx.ok) return { data: null, error: ctx.error };
+  if (!isAdminRole(ctx.membership.role))
+    return { data: null, error: 'Sin permisos suficientes' };
+
+  const prueba = await getPruebaForEmpresa(
+    supabase,
+    payload.prueba_id,
+    ctx.membership.empresa_id
+  );
+  if (!prueba) return { data: null, error: 'Prueba no encontrada' };
+
+  const { data, error } = await supabase
+    .from('empresa_prueba_invitaciones')
+    .insert({
+      prueba_id: payload.prueba_id,
+      token: generateInvitacionToken(),
+      candidate_email: payload.candidate_email?.toLowerCase().trim() || null,
+      candidate_name: payload.candidate_name?.trim() || null,
+      expires_at: payload.expires_at ?? null,
+      max_attempts: payload.max_attempts ?? 1,
+      created_by: ctx.user.id,
+    })
+    .select('*')
+    .single();
+
+  if (error) return { data: null, error: error.message };
+  return { data: data as EmpresaPruebaInvitacion, error: null };
+}
+
+export async function revokePruebaInvitacionAction(
+  invitacionId: string,
+  pruebaId: string
+): Promise<{ error: string | null }> {
+  const supabase = await createClient();
+  const ctx = await requireAuthenticatedMember(supabase);
+  if (!ctx.ok) return { error: ctx.error };
+  if (!isAdminRole(ctx.membership.role))
+    return { error: 'Sin permisos suficientes' };
+
+  const prueba = await getPruebaForEmpresa(
+    supabase,
+    pruebaId,
+    ctx.membership.empresa_id
+  );
+  if (!prueba) return { error: 'Prueba no encontrada' };
+
+  const { error } = await supabase
+    .from('empresa_prueba_invitaciones')
+    .update({ status: 'revoked' })
+    .eq('id', invitacionId)
+    .eq('prueba_id', pruebaId);
+
+  if (error) return { error: error.message };
+  return { error: null };
+}
+
+export async function listPruebaInvitacionesAction(pruebaId: string): Promise<{
+  data: EmpresaPruebaInvitacion[] | null;
+  error: string | null;
+}> {
+  const supabase = await createClient();
+  const ctx = await requireAuthenticatedMember(supabase);
+  if (!ctx.ok) return { data: null, error: ctx.error };
+
+  const prueba = await getPruebaForEmpresa(
+    supabase,
+    pruebaId,
+    ctx.membership.empresa_id
+  );
+  if (!prueba) return { data: null, error: 'Prueba no encontrada' };
+
+  const { data, error } = await supabase
+    .from('empresa_prueba_invitaciones')
+    .select('*')
+    .eq('prueba_id', pruebaId)
+    .order('created_at', { ascending: false });
+
+  if (error) return { data: null, error: error.message };
+  return { data: data as EmpresaPruebaInvitacion[], error: null };
+}
+
+// ── resultados ────────────────────────────────────────────────────────
+
+export async function listIntentosAction(pruebaId: string): Promise<{
+  data: EmpresaIntentoSummary[] | null;
+  error: string | null;
+}> {
+  const supabase = await createClient();
+  const ctx = await requireAuthenticatedMember(supabase);
+  if (!ctx.ok) return { data: null, error: ctx.error };
+
+  const prueba = await getPruebaForEmpresa(
+    supabase,
+    pruebaId,
+    ctx.membership.empresa_id
+  );
+  if (!prueba) return { data: null, error: 'Prueba no encontrada' };
+
+  const { data, error } = await supabase
+    .from('empresa_intentos')
+    .select('*')
+    .eq('prueba_id', pruebaId)
+    .order('submitted_at', { ascending: false, nullsFirst: false });
+
+  if (error) return { data: null, error: error.message };
+  return { data: data as EmpresaIntentoSummary[], error: null };
+}

--- a/apps/frontend/src/actions/lib/__tests__/empresa-scoring.test.ts
+++ b/apps/frontend/src/actions/lib/__tests__/empresa-scoring.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it } from 'vitest';
+import {
+  scoreEmpresaPregunta,
+  scoreEmpresaIntento,
+  type EmpresaPregunta,
+} from '../empresa-scoring';
+
+function mc(overrides: Partial<EmpresaPregunta> = {}): EmpresaPregunta {
+  return {
+    id: 'q1',
+    question_type: 'multiple_choice',
+    correct_answer: { value: 'B' },
+    points: 10,
+    ...overrides,
+  };
+}
+
+function tf(overrides: Partial<EmpresaPregunta> = {}): EmpresaPregunta {
+  return {
+    id: 'q2',
+    question_type: 'true_false',
+    correct_answer: { value: true },
+    points: 5,
+    ...overrides,
+  };
+}
+
+function shortText(overrides: Partial<EmpresaPregunta> = {}): EmpresaPregunta {
+  return {
+    id: 'q3',
+    question_type: 'short_text',
+    correct_answer: {},
+    expected_keywords: ['regresion', 'smoke test', 'automatizacion'],
+    points: 9,
+    ...overrides,
+  };
+}
+
+describe('scoreEmpresaPregunta — multiple_choice', () => {
+  it('awards full points on exact match', () => {
+    const result = scoreEmpresaPregunta(mc(), { value: 'B' });
+    expect(result).toMatchObject({
+      score: 10,
+      isCorrect: true,
+      autoScored: false,
+    });
+  });
+
+  it('is case/whitespace insensitive', () => {
+    const result = scoreEmpresaPregunta(mc(), { value: '  b  ' });
+    expect(result.isCorrect).toBe(true);
+  });
+
+  it('awards zero on wrong answer', () => {
+    const result = scoreEmpresaPregunta(mc(), { value: 'A' });
+    expect(result).toMatchObject({ score: 0, isCorrect: false });
+  });
+
+  it('awards zero on empty answer', () => {
+    const result = scoreEmpresaPregunta(mc(), { value: '' });
+    expect(result.isCorrect).toBe(false);
+  });
+});
+
+describe('scoreEmpresaPregunta — true_false', () => {
+  it('awards full points on match', () => {
+    const result = scoreEmpresaPregunta(tf(), { value: true });
+    expect(result).toMatchObject({
+      score: 5,
+      isCorrect: true,
+      autoScored: false,
+    });
+  });
+
+  it('awards zero on mismatch', () => {
+    const result = scoreEmpresaPregunta(tf(), { value: false });
+    expect(result).toMatchObject({ score: 0, isCorrect: false });
+  });
+});
+
+describe('scoreEmpresaPregunta — short_text', () => {
+  it('awards full points when all keywords match, flagged auto_scored', () => {
+    const result = scoreEmpresaPregunta(
+      shortText(),
+      'Hicimos una regresion completa con smoke test antes de la automatizacion'
+    );
+    expect(result).toMatchObject({
+      score: 9,
+      isCorrect: true,
+      autoScored: true,
+    });
+  });
+
+  it('awards proportional score on partial keyword match', () => {
+    const result = scoreEmpresaPregunta(shortText(), 'Solo hicimos smoke test');
+    expect(result.score).toBe(3); // 1/3 keywords * 9 points
+    expect(result.autoScored).toBe(true);
+  });
+
+  it('is below the 0.6 ratio threshold when isCorrect should be false', () => {
+    const result = scoreEmpresaPregunta(shortText(), 'Solo hicimos smoke test');
+    expect(result.isCorrect).toBe(false);
+  });
+
+  it('awards zero on empty answer', () => {
+    const result = scoreEmpresaPregunta(shortText(), '');
+    expect(result).toMatchObject({
+      score: 0,
+      isCorrect: false,
+      autoScored: true,
+    });
+  });
+
+  it('awards zero when no expected_keywords are configured', () => {
+    const result = scoreEmpresaPregunta(
+      shortText({ expected_keywords: [] }),
+      'cualquier respuesta'
+    );
+    expect(result.score).toBe(0);
+  });
+});
+
+describe('scoreEmpresaIntento', () => {
+  it('aggregates score and maxScore across all question types', () => {
+    const preguntas = [mc(), tf(), shortText()];
+    const summary = scoreEmpresaIntento(preguntas, {
+      q1: { value: 'B' },
+      q2: { value: true },
+      q3: 'regresion smoke test automatizacion',
+    });
+
+    expect(summary.maxScore).toBe(24); // 10 + 5 + 9
+    expect(summary.score).toBe(24);
+    expect(summary.breakdown).toHaveLength(3);
+  });
+
+  it('handles missing answers gracefully', () => {
+    const summary = scoreEmpresaIntento([mc()], {});
+    expect(summary.score).toBe(0);
+    expect(summary.breakdown[0].isCorrect).toBe(false);
+  });
+});

--- a/apps/frontend/src/actions/lib/empresa-scoring.ts
+++ b/apps/frontend/src/actions/lib/empresa-scoring.ts
@@ -1,0 +1,164 @@
+// Standalone scoring for empresa_pruebas — deliberately does not import from
+// apps/frontend/src/app/assessments/_shared/lib/scoring.ts to avoid coupling
+// the two domains' data shapes. Only 3 question types, so this stays small.
+
+export type EmpresaQuestionType =
+  | 'multiple_choice'
+  | 'true_false'
+  | 'short_text';
+
+export interface EmpresaPregunta {
+  id: string;
+  question_type: EmpresaQuestionType;
+  correct_answer: unknown;
+  expected_keywords?: string[] | null;
+  points: number;
+}
+
+export interface EmpresaScoreResult {
+  questionId: string;
+  score: number;
+  maxScore: number;
+  isCorrect: boolean;
+  autoScored: boolean;
+}
+
+function normalizeText(value: string) {
+  return value.normalize('NFD').replace(/[̀-ͯ]/g, '').toLowerCase().trim();
+}
+
+function parseStringAnswer(answer: unknown): string {
+  if (typeof answer === 'string') return answer;
+  if (answer && typeof answer === 'object' && 'value' in answer) {
+    const value = (answer as { value?: unknown }).value;
+    return typeof value === 'string' ? value : '';
+  }
+  return '';
+}
+
+function parseBooleanAnswer(answer: unknown): boolean {
+  if (typeof answer === 'boolean') return answer;
+  if (answer && typeof answer === 'object' && 'value' in answer) {
+    return Boolean((answer as { value?: unknown }).value);
+  }
+  return false;
+}
+
+function countKeywordMatches(text: string, keywords: string[]) {
+  const normalized = normalizeText(text);
+  return keywords.filter((keyword) =>
+    normalized.includes(normalizeText(keyword))
+  ).length;
+}
+
+function scoreMultipleChoice(
+  pregunta: EmpresaPregunta,
+  answer: unknown
+): EmpresaScoreResult {
+  const expected =
+    (pregunta.correct_answer as { value?: string } | null)?.value ?? '';
+  const actual = parseStringAnswer(answer);
+  const isCorrect =
+    normalizeText(actual) === normalizeText(expected) && actual !== '';
+  return {
+    questionId: pregunta.id,
+    score: isCorrect ? pregunta.points : 0,
+    maxScore: pregunta.points,
+    isCorrect,
+    autoScored: false,
+  };
+}
+
+function scoreTrueFalse(
+  pregunta: EmpresaPregunta,
+  answer: unknown
+): EmpresaScoreResult {
+  const expected = Boolean(
+    (pregunta.correct_answer as { value?: boolean } | null)?.value
+  );
+  const actual = parseBooleanAnswer(answer);
+  const isCorrect = actual === expected;
+  return {
+    questionId: pregunta.id,
+    score: isCorrect ? pregunta.points : 0,
+    maxScore: pregunta.points,
+    isCorrect,
+    autoScored: false,
+  };
+}
+
+function scoreShortText(
+  pregunta: EmpresaPregunta,
+  answer: unknown
+): EmpresaScoreResult {
+  const keywords = pregunta.expected_keywords ?? [];
+  const answerText = parseStringAnswer(answer);
+
+  if (keywords.length === 0 || !answerText.trim()) {
+    return {
+      questionId: pregunta.id,
+      score: 0,
+      maxScore: pregunta.points,
+      isCorrect: false,
+      autoScored: true,
+    };
+  }
+
+  const matches = countKeywordMatches(answerText, keywords);
+  const ratio = matches / keywords.length;
+  const score = Math.min(
+    pregunta.points,
+    Math.max(0, Math.round(pregunta.points * ratio))
+  );
+
+  return {
+    questionId: pregunta.id,
+    score,
+    maxScore: pregunta.points,
+    isCorrect: ratio >= 0.6,
+    autoScored: true,
+  };
+}
+
+export function scoreEmpresaPregunta(
+  pregunta: EmpresaPregunta,
+  answer: unknown
+): EmpresaScoreResult {
+  switch (pregunta.question_type) {
+    case 'multiple_choice':
+      return scoreMultipleChoice(pregunta, answer);
+    case 'true_false':
+      return scoreTrueFalse(pregunta, answer);
+    case 'short_text':
+      return scoreShortText(pregunta, answer);
+    default:
+      return {
+        questionId: pregunta.id,
+        score: 0,
+        maxScore: pregunta.points,
+        isCorrect: false,
+        autoScored: true,
+      };
+  }
+}
+
+export interface EmpresaScoringSummary {
+  score: number;
+  maxScore: number;
+  breakdown: EmpresaScoreResult[];
+}
+
+export function scoreEmpresaIntento(
+  preguntas: EmpresaPregunta[],
+  answers: Record<string, unknown>
+): EmpresaScoringSummary {
+  const breakdown = preguntas.map((pregunta) =>
+    scoreEmpresaPregunta(pregunta, answers[pregunta.id])
+  );
+
+  return {
+    score: breakdown.reduce((sum, result) => sum + result.score, 0),
+    maxScore: breakdown.reduce((sum, result) => sum + result.maxScore, 0),
+    breakdown,
+  };
+}

--- a/apps/frontend/src/app/empresa/pruebas/[pruebaId]/invitaciones/page.tsx
+++ b/apps/frontend/src/app/empresa/pruebas/[pruebaId]/invitaciones/page.tsx
@@ -1,0 +1,240 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useParams } from 'next/navigation';
+import Link from 'next/link';
+import { useTheme } from '@/contexts/ThemeContext';
+import {
+  getPruebaAction,
+  listPruebaInvitacionesAction,
+  createPruebaInvitacionAction,
+  revokePruebaInvitacionAction,
+  type EmpresaPrueba,
+  type EmpresaPruebaInvitacion,
+} from '@/actions/empresa-pruebas';
+
+export default function InvitacionesPage() {
+  const { isDarkMode } = useTheme();
+  const params = useParams<{ pruebaId: string }>();
+  const pruebaId = params.pruebaId;
+
+  const [prueba, setPrueba] = useState<EmpresaPrueba | null>(null);
+  const [invitaciones, setInvitaciones] = useState<EmpresaPruebaInvitacion[]>(
+    []
+  );
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [candidateEmail, setCandidateEmail] = useState('');
+  const [candidateName, setCandidateName] = useState('');
+  const [creating, setCreating] = useState(false);
+  const [copiedId, setCopiedId] = useState<string | null>(null);
+
+  const load = () => {
+    setLoading(true);
+    Promise.all([
+      getPruebaAction(pruebaId),
+      listPruebaInvitacionesAction(pruebaId),
+    ]).then(([pruebaRes, invRes]) => {
+      setPrueba(pruebaRes.data);
+      setInvitaciones(invRes.data ?? []);
+      setError(pruebaRes.error ?? invRes.error);
+      setLoading(false);
+    });
+  };
+
+  useEffect(() => {
+    load();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [pruebaId]);
+
+  const inputClass = `w-full rounded-lg border px-3 py-2 text-sm outline-none transition-colors focus:ring-2 focus:ring-indigo-500 ${
+    isDarkMode
+      ? 'bg-slate-700 border-slate-600 text-white placeholder-slate-400'
+      : 'bg-white border-gray-300 text-gray-900 placeholder-gray-400'
+  }`;
+  const labelClass = `block text-sm font-medium mb-1.5 ${isDarkMode ? 'text-slate-300' : 'text-gray-700'}`;
+  const cardClass = `rounded-xl border p-5 ${isDarkMode ? 'bg-dark-secondary border-slate-700' : 'bg-white border-gray-200'}`;
+
+  const handleCreate = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setCreating(true);
+    setError(null);
+    const { error } = await createPruebaInvitacionAction({
+      prueba_id: pruebaId,
+      candidate_email: candidateEmail.trim() || undefined,
+      candidate_name: candidateName.trim() || undefined,
+    });
+    setCreating(false);
+    if (error) {
+      setError(error);
+      return;
+    }
+    setCandidateEmail('');
+    setCandidateName('');
+    load();
+  };
+
+  const handleRevoke = async (invitacion: EmpresaPruebaInvitacion) => {
+    if (!confirm('¿Revocar esta invitación? El link dejará de funcionar.'))
+      return;
+    const { error } = await revokePruebaInvitacionAction(
+      invitacion.id,
+      pruebaId
+    );
+    if (error) {
+      setError(error);
+      return;
+    }
+    load();
+  };
+
+  const linkFor = (token: string) =>
+    typeof window !== 'undefined'
+      ? `${window.location.origin}/prueba/${token}`
+      : `/prueba/${token}`;
+
+  const handleCopy = (invitacion: EmpresaPruebaInvitacion) => {
+    navigator.clipboard.writeText(linkFor(invitacion.token));
+    setCopiedId(invitacion.id);
+    setTimeout(() => setCopiedId(null), 2000);
+  };
+
+  return (
+    <div
+      className={`min-h-screen transition-colors duration-300 ${isDarkMode ? 'bg-dark-bg' : 'bg-gray-50'}`}
+    >
+      <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+        <div className="mb-6">
+          <Link
+            href={`/empresa/pruebas/${pruebaId}`}
+            className={`text-sm ${isDarkMode ? 'text-indigo-400' : 'text-indigo-600'} hover:underline`}
+          >
+            ← {prueba?.title ?? 'Prueba'}
+          </Link>
+          <h1
+            className={`text-2xl font-bold mt-2 ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
+          >
+            Invitaciones
+          </h1>
+          <p
+            className={`text-sm mt-1 ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}
+          >
+            Generá un link por candidato (o genérico) para que rinda la prueba.
+          </p>
+        </div>
+
+        {error && (
+          <div className="rounded-lg border border-red-300 bg-red-50 text-red-700 px-4 py-3 text-sm mb-4">
+            {error}
+          </div>
+        )}
+
+        <form onSubmit={handleCreate} className={`${cardClass} space-y-4 mb-6`}>
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <label className={labelClass}>
+                Email del candidato{' '}
+                <span
+                  className={isDarkMode ? 'text-slate-500' : 'text-gray-400'}
+                >
+                  (opcional)
+                </span>
+              </label>
+              <input
+                type="email"
+                className={inputClass}
+                value={candidateEmail}
+                onChange={(e) => setCandidateEmail(e.target.value)}
+              />
+            </div>
+            <div>
+              <label className={labelClass}>
+                Nombre{' '}
+                <span
+                  className={isDarkMode ? 'text-slate-500' : 'text-gray-400'}
+                >
+                  (opcional)
+                </span>
+              </label>
+              <input
+                type="text"
+                className={inputClass}
+                value={candidateName}
+                onChange={(e) => setCandidateName(e.target.value)}
+              />
+            </div>
+          </div>
+          <button
+            type="submit"
+            disabled={creating}
+            className="px-5 py-2.5 rounded-lg text-sm font-semibold bg-indigo-600 text-white hover:bg-indigo-700 disabled:opacity-50 transition-colors"
+          >
+            {creating ? 'Generando...' : 'Generar link de invitación'}
+          </button>
+        </form>
+
+        {loading ? (
+          <p className={isDarkMode ? 'text-slate-400' : 'text-gray-500'}>
+            Cargando...
+          </p>
+        ) : invitaciones.length === 0 ? (
+          <div className={cardClass}>
+            <p
+              className={`text-sm ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}
+            >
+              Todavía no generaste ninguna invitación.
+            </p>
+          </div>
+        ) : (
+          <div className="space-y-3">
+            {invitaciones.map((invitacion) => (
+              <div key={invitacion.id} className={cardClass}>
+                <div className="flex items-start justify-between gap-4 flex-wrap">
+                  <div>
+                    <p
+                      className={`text-sm font-medium ${isDarkMode ? 'text-slate-200' : 'text-gray-800'}`}
+                    >
+                      {invitacion.candidate_name ||
+                        invitacion.candidate_email ||
+                        'Link genérico'}
+                    </p>
+                    <p
+                      className={`text-xs mt-0.5 font-mono break-all ${isDarkMode ? 'text-slate-500' : 'text-gray-400'}`}
+                    >
+                      {linkFor(invitacion.token)}
+                    </p>
+                    <span
+                      className={`inline-block mt-1 text-xs px-2 py-0.5 rounded-full ${
+                        invitacion.status === 'active'
+                          ? 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-300'
+                          : 'bg-gray-100 text-gray-600 dark:bg-slate-700 dark:text-slate-300'
+                      }`}
+                    >
+                      {invitacion.status === 'active' ? 'Activa' : 'Revocada'}
+                    </span>
+                  </div>
+                  <div className="flex gap-2 shrink-0">
+                    <button
+                      onClick={() => handleCopy(invitacion)}
+                      className={`px-3 py-1.5 rounded-lg border text-sm transition-colors ${isDarkMode ? 'border-slate-600 text-slate-300 hover:border-slate-500' : 'border-gray-300 text-gray-700 hover:border-gray-400'}`}
+                    >
+                      {copiedId === invitacion.id ? '✅ Copiado' : '📋 Copiar'}
+                    </button>
+                    {invitacion.status === 'active' && (
+                      <button
+                        onClick={() => handleRevoke(invitacion)}
+                        className="px-3 py-1.5 rounded-lg border border-red-300 text-red-600 text-sm hover:bg-red-50 dark:border-red-800 dark:text-red-400"
+                      >
+                        Revocar
+                      </button>
+                    )}
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/src/app/empresa/pruebas/[pruebaId]/page.tsx
+++ b/apps/frontend/src/app/empresa/pruebas/[pruebaId]/page.tsx
@@ -1,0 +1,479 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useParams } from 'next/navigation';
+import Link from 'next/link';
+import { useTheme } from '@/contexts/ThemeContext';
+import {
+  getPruebaAction,
+  listPreguntasAction,
+  upsertPreguntaAction,
+  deletePreguntaAction,
+  reorderPreguntasAction,
+  type EmpresaPrueba,
+  type EmpresaPreguntaRow,
+  type EmpresaPruebaQuestionType,
+} from '@/actions/empresa-pruebas';
+
+const QUESTION_TYPE_LABELS: Record<EmpresaPruebaQuestionType, string> = {
+  multiple_choice: 'Opción múltiple',
+  true_false: 'Verdadero / Falso',
+  short_text: 'Respuesta corta',
+};
+
+function emptyForm() {
+  return {
+    id: undefined as string | undefined,
+    question_type: 'multiple_choice' as EmpresaPruebaQuestionType,
+    prompt: '',
+    options: ['', ''],
+    correctOptionIndex: 0,
+    correctBool: true,
+    keywords: '',
+    points: 1,
+  };
+}
+
+export default function EditorPreguntasPage() {
+  const { isDarkMode } = useTheme();
+  const params = useParams<{ pruebaId: string }>();
+  const pruebaId = params.pruebaId;
+
+  const [prueba, setPrueba] = useState<EmpresaPrueba | null>(null);
+  const [preguntas, setPreguntas] = useState<EmpresaPreguntaRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [form, setForm] = useState(emptyForm());
+  const [saving, setSaving] = useState(false);
+
+  const load = () => {
+    setLoading(true);
+    Promise.all([
+      getPruebaAction(pruebaId),
+      listPreguntasAction(pruebaId),
+    ]).then(([pruebaRes, preguntasRes]) => {
+      setPrueba(pruebaRes.data);
+      setPreguntas(preguntasRes.data ?? []);
+      setError(pruebaRes.error ?? preguntasRes.error);
+      setLoading(false);
+    });
+  };
+
+  useEffect(() => {
+    load();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [pruebaId]);
+
+  const inputClass = `w-full rounded-lg border px-3 py-2 text-sm outline-none transition-colors focus:ring-2 focus:ring-indigo-500 ${
+    isDarkMode
+      ? 'bg-slate-700 border-slate-600 text-white placeholder-slate-400'
+      : 'bg-white border-gray-300 text-gray-900 placeholder-gray-400'
+  }`;
+  const labelClass = `block text-sm font-medium mb-1.5 ${isDarkMode ? 'text-slate-300' : 'text-gray-700'}`;
+  const cardClass = `rounded-xl border p-5 ${isDarkMode ? 'bg-dark-secondary border-slate-700' : 'bg-white border-gray-200'}`;
+
+  const startEdit = (pregunta: EmpresaPreguntaRow) => {
+    if (pregunta.question_type === 'multiple_choice') {
+      const options = (
+        (pregunta.options as string[] | null) ?? ['', '']
+      ).slice();
+      const correctValue =
+        (pregunta.correct_answer as { value?: string } | null)?.value ?? '';
+      setForm({
+        id: pregunta.id,
+        question_type: 'multiple_choice',
+        prompt: pregunta.prompt,
+        options: options.length >= 2 ? options : [...options, ''],
+        correctOptionIndex: Math.max(0, options.indexOf(correctValue)),
+        correctBool: true,
+        keywords: '',
+        points: pregunta.points,
+      });
+    } else if (pregunta.question_type === 'true_false') {
+      setForm({
+        id: pregunta.id,
+        question_type: 'true_false',
+        prompt: pregunta.prompt,
+        options: ['', ''],
+        correctOptionIndex: 0,
+        correctBool: Boolean(
+          (pregunta.correct_answer as { value?: boolean } | null)?.value
+        ),
+        keywords: '',
+        points: pregunta.points,
+      });
+    } else {
+      setForm({
+        id: pregunta.id,
+        question_type: 'short_text',
+        prompt: pregunta.prompt,
+        options: ['', ''],
+        correctOptionIndex: 0,
+        correctBool: true,
+        keywords: (pregunta.expected_keywords ?? []).join(', '),
+        points: pregunta.points,
+      });
+    }
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!form.prompt.trim()) {
+      setError('El enunciado es requerido.');
+      return;
+    }
+
+    let correct_answer: unknown;
+    let options: unknown;
+    let expected_keywords: string[] | undefined;
+
+    if (form.question_type === 'multiple_choice') {
+      const cleanOptions = form.options.map((o) => o.trim()).filter(Boolean);
+      if (cleanOptions.length < 2) {
+        setError('Agregá al menos 2 opciones.');
+        return;
+      }
+      options = cleanOptions;
+      correct_answer = {
+        value: cleanOptions[form.correctOptionIndex] ?? cleanOptions[0],
+      };
+    } else if (form.question_type === 'true_false') {
+      correct_answer = { value: form.correctBool };
+    } else {
+      expected_keywords = form.keywords
+        .split(',')
+        .map((k) => k.trim())
+        .filter(Boolean);
+      if (expected_keywords.length === 0) {
+        setError('Agregá al menos una palabra clave esperada.');
+        return;
+      }
+      correct_answer = { keywords: expected_keywords };
+    }
+
+    setSaving(true);
+    setError(null);
+
+    const { error } = await upsertPreguntaAction({
+      id: form.id,
+      prueba_id: pruebaId,
+      position: form.id
+        ? (preguntas.find((p) => p.id === form.id)?.position ??
+          preguntas.length)
+        : preguntas.length,
+      question_type: form.question_type,
+      prompt: form.prompt.trim(),
+      options,
+      correct_answer,
+      expected_keywords,
+      points: form.points,
+    });
+
+    setSaving(false);
+    if (error) {
+      setError(error);
+      return;
+    }
+
+    setForm(emptyForm());
+    load();
+  };
+
+  const handleDelete = async (pregunta: EmpresaPreguntaRow) => {
+    if (!confirm('¿Eliminar esta pregunta?')) return;
+    const { error } = await deletePreguntaAction(pregunta.id, pruebaId);
+    if (error) {
+      setError(error);
+      return;
+    }
+    load();
+  };
+
+  const handleMove = async (index: number, direction: -1 | 1) => {
+    const targetIndex = index + direction;
+    if (targetIndex < 0 || targetIndex >= preguntas.length) return;
+    const reordered = preguntas.slice();
+    [reordered[index], reordered[targetIndex]] = [
+      reordered[targetIndex],
+      reordered[index],
+    ];
+    setPreguntas(reordered);
+    const { error } = await reorderPreguntasAction(
+      pruebaId,
+      reordered.map((p) => p.id)
+    );
+    if (error) {
+      setError(error);
+      load();
+    }
+  };
+
+  if (loading) {
+    return (
+      <div
+        className={`min-h-screen ${isDarkMode ? 'bg-dark-bg' : 'bg-gray-50'}`}
+      >
+        <div className="max-w-3xl mx-auto px-4 py-12">
+          <p className={isDarkMode ? 'text-slate-400' : 'text-gray-500'}>
+            Cargando...
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className={`min-h-screen transition-colors duration-300 ${isDarkMode ? 'bg-dark-bg' : 'bg-gray-50'}`}
+    >
+      <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+        <div className="mb-6">
+          <Link
+            href="/empresa/pruebas"
+            className={`text-sm ${isDarkMode ? 'text-indigo-400' : 'text-indigo-600'} hover:underline`}
+          >
+            ← Mis pruebas
+          </Link>
+          <h1
+            className={`text-2xl font-bold mt-2 ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
+          >
+            {prueba?.title ?? 'Prueba'}
+          </h1>
+          <p
+            className={`text-sm mt-1 ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}
+          >
+            {preguntas.length} pregunta{preguntas.length === 1 ? '' : 's'}
+          </p>
+        </div>
+
+        {error && (
+          <div className="rounded-lg border border-red-300 bg-red-50 text-red-700 px-4 py-3 text-sm mb-4">
+            {error}
+          </div>
+        )}
+
+        <div className="space-y-3 mb-8">
+          {preguntas.map((pregunta, index) => (
+            <div key={pregunta.id} className={cardClass}>
+              <div className="flex items-start justify-between gap-4">
+                <div>
+                  <span
+                    className={`text-xs font-semibold uppercase tracking-wide ${isDarkMode ? 'text-indigo-400' : 'text-indigo-600'}`}
+                  >
+                    {QUESTION_TYPE_LABELS[pregunta.question_type]} ·{' '}
+                    {pregunta.points} pt
+                    {pregunta.points === 1 ? '' : 's'}
+                  </span>
+                  <p
+                    className={`text-sm mt-1 ${isDarkMode ? 'text-slate-200' : 'text-gray-800'}`}
+                  >
+                    {pregunta.prompt}
+                  </p>
+                </div>
+                <div className="flex gap-1 shrink-0">
+                  <button
+                    onClick={() => handleMove(index, -1)}
+                    disabled={index === 0}
+                    className={`px-2 py-1 rounded border text-xs disabled:opacity-30 ${isDarkMode ? 'border-slate-600 text-slate-300' : 'border-gray-300 text-gray-600'}`}
+                  >
+                    ↑
+                  </button>
+                  <button
+                    onClick={() => handleMove(index, 1)}
+                    disabled={index === preguntas.length - 1}
+                    className={`px-2 py-1 rounded border text-xs disabled:opacity-30 ${isDarkMode ? 'border-slate-600 text-slate-300' : 'border-gray-300 text-gray-600'}`}
+                  >
+                    ↓
+                  </button>
+                  <button
+                    onClick={() => startEdit(pregunta)}
+                    className={`px-2 py-1 rounded border text-xs ${isDarkMode ? 'border-slate-600 text-slate-300' : 'border-gray-300 text-gray-600'}`}
+                  >
+                    Editar
+                  </button>
+                  <button
+                    onClick={() => handleDelete(pregunta)}
+                    className="px-2 py-1 rounded border border-red-300 text-red-600 text-xs hover:bg-red-50 dark:border-red-800 dark:text-red-400"
+                  >
+                    Eliminar
+                  </button>
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+
+        <form onSubmit={handleSubmit} className={`${cardClass} space-y-4`}>
+          <h2
+            className={`font-semibold ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
+          >
+            {form.id ? 'Editar pregunta' : 'Agregar pregunta'}
+          </h2>
+
+          <div>
+            <label className={labelClass}>Tipo</label>
+            <select
+              className={inputClass}
+              value={form.question_type}
+              onChange={(e) =>
+                setForm({
+                  ...emptyForm(),
+                  question_type: e.target.value as EmpresaPruebaQuestionType,
+                })
+              }
+            >
+              <option value="multiple_choice">Opción múltiple</option>
+              <option value="true_false">Verdadero / Falso</option>
+              <option value="short_text">Respuesta corta</option>
+            </select>
+          </div>
+
+          <div>
+            <label className={labelClass}>Enunciado *</label>
+            <textarea
+              className={`${inputClass} resize-none`}
+              rows={2}
+              value={form.prompt}
+              onChange={(e) => setForm({ ...form, prompt: e.target.value })}
+            />
+          </div>
+
+          {form.question_type === 'multiple_choice' && (
+            <div>
+              <label className={labelClass}>Opciones (marcá la correcta)</label>
+              <div className="space-y-2">
+                {form.options.map((option, index) => (
+                  <div key={index} className="flex items-center gap-2">
+                    <input
+                      type="radio"
+                      name="correctOption"
+                      checked={form.correctOptionIndex === index}
+                      onChange={() =>
+                        setForm({ ...form, correctOptionIndex: index })
+                      }
+                    />
+                    <input
+                      type="text"
+                      className={inputClass}
+                      placeholder={`Opción ${index + 1}`}
+                      value={option}
+                      onChange={(e) => {
+                        const options = form.options.slice();
+                        options[index] = e.target.value;
+                        setForm({ ...form, options });
+                      }}
+                    />
+                    {form.options.length > 2 && (
+                      <button
+                        type="button"
+                        onClick={() =>
+                          setForm({
+                            ...form,
+                            options: form.options.filter((_, i) => i !== index),
+                          })
+                        }
+                        className="text-red-500 text-xs shrink-0"
+                      >
+                        Quitar
+                      </button>
+                    )}
+                  </div>
+                ))}
+              </div>
+              <button
+                type="button"
+                onClick={() =>
+                  setForm({ ...form, options: [...form.options, ''] })
+                }
+                className={`text-xs mt-2 ${isDarkMode ? 'text-indigo-400' : 'text-indigo-600'}`}
+              >
+                + Agregar opción
+              </button>
+            </div>
+          )}
+
+          {form.question_type === 'true_false' && (
+            <div>
+              <label className={labelClass}>Respuesta correcta</label>
+              <div className="flex gap-3">
+                {[true, false].map((value) => (
+                  <button
+                    key={String(value)}
+                    type="button"
+                    onClick={() => setForm({ ...form, correctBool: value })}
+                    className={`flex-1 py-2 rounded-lg text-sm font-medium border transition-colors ${
+                      form.correctBool === value
+                        ? 'border-indigo-500 bg-indigo-600 text-white'
+                        : isDarkMode
+                          ? 'border-slate-600 text-slate-300'
+                          : 'border-gray-300 text-gray-700'
+                    }`}
+                  >
+                    {value ? 'Verdadero' : 'Falso'}
+                  </button>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {form.question_type === 'short_text' && (
+            <div>
+              <label className={labelClass}>
+                Palabras clave esperadas (separadas por coma)
+              </label>
+              <input
+                type="text"
+                className={inputClass}
+                placeholder="ej. regresión, smoke test, automatización"
+                value={form.keywords}
+                onChange={(e) => setForm({ ...form, keywords: e.target.value })}
+              />
+              <p
+                className={`text-xs mt-1 ${isDarkMode ? 'text-slate-500' : 'text-gray-400'}`}
+              >
+                Se califica por coincidencia de palabras clave — recomendado
+                revisar manualmente en Resultados.
+              </p>
+            </div>
+          )}
+
+          <div>
+            <label className={labelClass}>Puntos</label>
+            <input
+              type="number"
+              min={1}
+              className={`${inputClass} w-24`}
+              value={form.points}
+              onChange={(e) =>
+                setForm({ ...form, points: Number(e.target.value) || 1 })
+              }
+            />
+          </div>
+
+          <div className="flex gap-3">
+            <button
+              type="submit"
+              disabled={saving}
+              className="px-5 py-2.5 rounded-lg text-sm font-semibold bg-indigo-600 text-white hover:bg-indigo-700 disabled:opacity-50 transition-colors"
+            >
+              {saving
+                ? 'Guardando...'
+                : form.id
+                  ? 'Guardar cambios'
+                  : 'Agregar pregunta'}
+            </button>
+            {form.id && (
+              <button
+                type="button"
+                onClick={() => setForm(emptyForm())}
+                className={`px-5 py-2.5 rounded-lg text-sm font-medium ${isDarkMode ? 'text-slate-300 hover:bg-slate-700' : 'text-gray-700 hover:bg-gray-100'}`}
+              >
+                Cancelar edición
+              </button>
+            )}
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/src/app/empresa/pruebas/[pruebaId]/resultados/page.tsx
+++ b/apps/frontend/src/app/empresa/pruebas/[pruebaId]/resultados/page.tsx
@@ -1,0 +1,198 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useParams } from 'next/navigation';
+import Link from 'next/link';
+import { useTheme } from '@/contexts/ThemeContext';
+import {
+  getPruebaAction,
+  listIntentosAction,
+  listPreguntasAction,
+  type EmpresaPrueba,
+  type EmpresaIntentoSummary,
+  type EmpresaPreguntaRow,
+} from '@/actions/empresa-pruebas';
+import type { EmpresaScoreResult } from '@/actions/lib/empresa-scoring';
+
+export default function ResultadosPage() {
+  const { isDarkMode } = useTheme();
+  const params = useParams<{ pruebaId: string }>();
+  const pruebaId = params.pruebaId;
+
+  const [prueba, setPrueba] = useState<EmpresaPrueba | null>(null);
+  const [intentos, setIntentos] = useState<EmpresaIntentoSummary[]>([]);
+  const [preguntas, setPreguntas] = useState<EmpresaPreguntaRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [expandedId, setExpandedId] = useState<string | null>(null);
+
+  useEffect(() => {
+    setLoading(true);
+    Promise.all([
+      getPruebaAction(pruebaId),
+      listIntentosAction(pruebaId),
+      listPreguntasAction(pruebaId),
+    ]).then(([pruebaRes, intentosRes, preguntasRes]) => {
+      setPrueba(pruebaRes.data);
+      setIntentos(intentosRes.data ?? []);
+      setPreguntas(preguntasRes.data ?? []);
+      setError(pruebaRes.error ?? intentosRes.error ?? preguntasRes.error);
+      setLoading(false);
+    });
+  }, [pruebaId]);
+
+  const cardClass = `rounded-xl border p-5 ${isDarkMode ? 'bg-dark-secondary border-slate-700' : 'bg-white border-gray-200'}`;
+  const preguntasById = new Map(preguntas.map((p) => [p.id, p]));
+
+  return (
+    <div
+      className={`min-h-screen transition-colors duration-300 ${isDarkMode ? 'bg-dark-bg' : 'bg-gray-50'}`}
+    >
+      <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+        <div className="mb-6">
+          <Link
+            href={`/empresa/pruebas/${pruebaId}`}
+            className={`text-sm ${isDarkMode ? 'text-indigo-400' : 'text-indigo-600'} hover:underline`}
+          >
+            ← {prueba?.title ?? 'Prueba'}
+          </Link>
+          <h1
+            className={`text-2xl font-bold mt-2 ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
+          >
+            Resultados
+          </h1>
+        </div>
+
+        {error && (
+          <div className="rounded-lg border border-red-300 bg-red-50 text-red-700 px-4 py-3 text-sm mb-4">
+            {error}
+          </div>
+        )}
+
+        {loading ? (
+          <p className={isDarkMode ? 'text-slate-400' : 'text-gray-500'}>
+            Cargando...
+          </p>
+        ) : intentos.length === 0 ? (
+          <div className={cardClass}>
+            <p
+              className={`text-sm ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}
+            >
+              Todavía nadie rindió esta prueba.
+            </p>
+          </div>
+        ) : (
+          <div className="space-y-3">
+            {intentos.map((intento) => {
+              const breakdown =
+                (intento.breakdown as EmpresaScoreResult[] | null) ?? [];
+              const answers =
+                (intento.answers as Record<string, unknown> | null) ?? {};
+              const percentage =
+                intento.score !== null && intento.max_score
+                  ? Math.round((intento.score / intento.max_score) * 100)
+                  : null;
+              const hasAutoScored = breakdown.some((b) => b.autoScored);
+              const isExpanded = expandedId === intento.id;
+
+              return (
+                <div key={intento.id} className={cardClass}>
+                  <div
+                    className="flex items-start justify-between gap-4 flex-wrap cursor-pointer"
+                    onClick={() =>
+                      setExpandedId(isExpanded ? null : intento.id)
+                    }
+                  >
+                    <div>
+                      <p
+                        className={`text-sm font-medium ${isDarkMode ? 'text-slate-200' : 'text-gray-800'}`}
+                      >
+                        {intento.candidate_name ||
+                          intento.candidate_email ||
+                          'Candidato sin nombre'}
+                      </p>
+                      <p
+                        className={`text-xs mt-0.5 ${isDarkMode ? 'text-slate-500' : 'text-gray-400'}`}
+                      >
+                        {intento.submitted_at
+                          ? `Enviado ${new Date(intento.submitted_at).toLocaleString()}`
+                          : 'En progreso'}
+                      </p>
+                      {hasAutoScored && (
+                        <span className="inline-block mt-1 text-xs px-2 py-0.5 rounded-full bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-300">
+                          Incluye puntaje automático — revisar
+                        </span>
+                      )}
+                    </div>
+                    <div className="text-right shrink-0">
+                      {intento.score !== null && intento.max_score !== null ? (
+                        <p
+                          className={`text-lg font-bold ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
+                        >
+                          {intento.score}/{intento.max_score}
+                          {percentage !== null && (
+                            <span
+                              className={`text-xs font-normal ml-1 ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}
+                            >
+                              ({percentage}%)
+                            </span>
+                          )}
+                        </p>
+                      ) : (
+                        <p
+                          className={`text-xs ${isDarkMode ? 'text-slate-500' : 'text-gray-400'}`}
+                        >
+                          Sin enviar
+                        </p>
+                      )}
+                    </div>
+                  </div>
+
+                  {isExpanded && (
+                    <div
+                      className={`mt-4 pt-4 border-t space-y-3 ${isDarkMode ? 'border-slate-700' : 'border-gray-200'}`}
+                    >
+                      {breakdown.map((result) => {
+                        const pregunta = preguntasById.get(result.questionId);
+                        if (!pregunta) return null;
+                        return (
+                          <div key={result.questionId} className="text-sm">
+                            <p
+                              className={`font-medium ${isDarkMode ? 'text-slate-200' : 'text-gray-800'}`}
+                            >
+                              {pregunta.prompt}{' '}
+                              <span
+                                className={
+                                  result.isCorrect
+                                    ? 'text-green-600'
+                                    : 'text-red-500'
+                                }
+                              >
+                                ({result.score}/{result.maxScore})
+                              </span>
+                              {result.autoScored && (
+                                <span className="ml-2 text-xs px-1.5 py-0.5 rounded bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-300">
+                                  automático — revisar
+                                </span>
+                              )}
+                            </p>
+                            <p
+                              className={`text-xs mt-0.5 ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}
+                            >
+                              Respuesta:{' '}
+                              {JSON.stringify(answers[result.questionId] ?? '')}
+                            </p>
+                          </div>
+                        );
+                      })}
+                    </div>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/src/app/empresa/pruebas/nuevo/page.tsx
+++ b/apps/frontend/src/app/empresa/pruebas/nuevo/page.tsx
@@ -1,0 +1,212 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { useTheme } from '@/contexts/ThemeContext';
+import {
+  createPruebaAction,
+  listCategoriasAction,
+} from '@/actions/empresa-pruebas';
+
+export default function NuevaPruebaPage() {
+  const { isDarkMode } = useTheme();
+  const router = useRouter();
+
+  const [title, setTitle] = useState('');
+  const [category, setCategory] = useState('');
+  const [newCategory, setNewCategory] = useState('');
+  const [categorias, setCategorias] = useState<string[]>([]);
+  const [description, setDescription] = useState('');
+  const [level, setLevel] = useState('');
+  const [durationMinutes, setDurationMinutes] = useState<number | ''>('');
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    listCategoriasAction().then(({ data }) => setCategorias(data));
+  }, []);
+
+  const inputClass = `w-full rounded-lg border px-3 py-2 text-sm outline-none transition-colors focus:ring-2 focus:ring-indigo-500 ${
+    isDarkMode
+      ? 'bg-slate-700 border-slate-600 text-white placeholder-slate-400'
+      : 'bg-white border-gray-300 text-gray-900 placeholder-gray-400'
+  }`;
+  const labelClass = `block text-sm font-medium mb-1.5 ${isDarkMode ? 'text-slate-300' : 'text-gray-700'}`;
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const finalCategory =
+      category === '__new__' ? newCategory.trim() : category;
+    if (!title.trim() || !finalCategory) {
+      setError('Título y categoría son requeridos.');
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+
+    const { data, error } = await createPruebaAction({
+      title: title.trim(),
+      category: finalCategory,
+      description: description.trim() || undefined,
+      level: level.trim() || undefined,
+      duration_minutes: durationMinutes === '' ? undefined : durationMinutes,
+    });
+
+    setLoading(false);
+    if (error || !data) {
+      setError(error ?? 'No se pudo crear la prueba.');
+      return;
+    }
+
+    router.push(`/empresa/pruebas/${data.id}`);
+  };
+
+  return (
+    <div
+      className={`min-h-screen transition-colors duration-300 ${isDarkMode ? 'bg-dark-bg' : 'bg-gray-50'}`}
+    >
+      <div className="max-w-2xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+        <div className="mb-8">
+          <h1
+            className={`text-2xl font-bold ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
+          >
+            Nueva prueba técnica
+          </h1>
+          <p
+            className={`text-sm mt-1 ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}
+          >
+            Definí los datos generales. Después agregás las preguntas.
+          </p>
+        </div>
+
+        <form
+          onSubmit={handleSubmit}
+          className={`rounded-xl border p-6 space-y-6 ${isDarkMode ? 'bg-dark-secondary border-slate-700' : 'bg-white border-gray-200'}`}
+        >
+          <div>
+            <label className={labelClass}>Título *</label>
+            <input
+              type="text"
+              className={inputClass}
+              placeholder="ej. QA Analyst - Prueba técnica"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              required
+              maxLength={120}
+            />
+          </div>
+
+          <div>
+            <label className={labelClass}>Categoría *</label>
+            <select
+              className={inputClass}
+              value={category}
+              onChange={(e) => setCategory(e.target.value)}
+              required
+            >
+              <option value="">— Seleccioná —</option>
+              {categorias.map((c) => (
+                <option key={c} value={c}>
+                  {c}
+                </option>
+              ))}
+              <option value="__new__">+ Crear nueva categoría</option>
+            </select>
+            {category === '__new__' && (
+              <input
+                type="text"
+                className={`${inputClass} mt-2`}
+                placeholder="Nombre de la categoría"
+                value={newCategory}
+                onChange={(e) => setNewCategory(e.target.value)}
+                maxLength={60}
+              />
+            )}
+          </div>
+
+          <div>
+            <label className={labelClass}>
+              Descripción{' '}
+              <span className={isDarkMode ? 'text-slate-500' : 'text-gray-400'}>
+                (opcional)
+              </span>
+            </label>
+            <textarea
+              className={`${inputClass} resize-none`}
+              rows={3}
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              maxLength={500}
+            />
+          </div>
+
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <label className={labelClass}>
+                Nivel{' '}
+                <span
+                  className={isDarkMode ? 'text-slate-500' : 'text-gray-400'}
+                >
+                  (opcional)
+                </span>
+              </label>
+              <input
+                type="text"
+                className={inputClass}
+                placeholder="ej. Junior"
+                value={level}
+                onChange={(e) => setLevel(e.target.value)}
+                maxLength={60}
+              />
+            </div>
+            <div>
+              <label className={labelClass}>
+                Duración (min){' '}
+                <span
+                  className={isDarkMode ? 'text-slate-500' : 'text-gray-400'}
+                >
+                  (opcional)
+                </span>
+              </label>
+              <input
+                type="number"
+                min={1}
+                className={inputClass}
+                value={durationMinutes}
+                onChange={(e) =>
+                  setDurationMinutes(
+                    e.target.value === '' ? '' : Number(e.target.value)
+                  )
+                }
+              />
+            </div>
+          </div>
+
+          {error && (
+            <div className="rounded-lg border border-red-300 bg-red-50 text-red-700 px-4 py-3 text-sm">
+              {error}
+            </div>
+          )}
+
+          <div className="flex gap-3 pt-2">
+            <button
+              type="submit"
+              disabled={loading || !title.trim()}
+              className="flex-1 py-2.5 rounded-lg text-sm font-semibold bg-indigo-600 text-white hover:bg-indigo-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+            >
+              {loading ? 'Creando...' : 'Crear prueba'}
+            </button>
+            <button
+              type="button"
+              onClick={() => router.push('/empresa/pruebas')}
+              className={`px-5 py-2.5 rounded-lg text-sm font-medium transition-colors ${isDarkMode ? 'text-slate-300 hover:bg-slate-700' : 'text-gray-700 hover:bg-gray-100'}`}
+            >
+              Cancelar
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/src/app/empresa/pruebas/page.tsx
+++ b/apps/frontend/src/app/empresa/pruebas/page.tsx
@@ -1,0 +1,186 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { useTheme } from '@/contexts/ThemeContext';
+import {
+  listPruebasAction,
+  deletePruebaAction,
+  togglePruebaActivaAction,
+  type EmpresaPrueba,
+} from '@/actions/empresa-pruebas';
+
+export default function PruebasPage() {
+  const { isDarkMode } = useTheme();
+  const [pruebas, setPruebas] = useState<EmpresaPrueba[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = () => {
+    setLoading(true);
+    listPruebasAction().then(({ data, error }) => {
+      setPruebas(data ?? []);
+      setError(error);
+      setLoading(false);
+    });
+  };
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  const handleToggle = async (prueba: EmpresaPrueba) => {
+    const { error } = await togglePruebaActivaAction(
+      prueba.id,
+      !prueba.is_active
+    );
+    if (error) {
+      setError(error);
+      return;
+    }
+    load();
+  };
+
+  const handleDelete = async (prueba: EmpresaPrueba) => {
+    if (
+      !confirm(
+        `¿Eliminar la prueba "${prueba.title}"? Esta acción no se puede deshacer.`
+      )
+    )
+      return;
+    const { error } = await deletePruebaAction(prueba.id);
+    if (error) {
+      setError(error);
+      return;
+    }
+    load();
+  };
+
+  const cardClass = `rounded-xl border p-5 ${isDarkMode ? 'bg-dark-secondary border-slate-700' : 'bg-white border-gray-200'}`;
+
+  return (
+    <div
+      className={`min-h-screen transition-colors duration-300 ${isDarkMode ? 'bg-dark-bg' : 'bg-gray-50'}`}
+    >
+      <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+        <div className="mb-6 flex items-start justify-between gap-4 flex-wrap">
+          <div>
+            <div className="flex items-center gap-2 mb-1">
+              <h1
+                className={`text-2xl font-bold ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
+              >
+                Mis pruebas técnicas
+              </h1>
+              <span className="text-xs font-semibold px-2 py-0.5 rounded-full bg-indigo-100 text-indigo-700 dark:bg-indigo-900/40 dark:text-indigo-300">
+                Beta
+              </span>
+            </div>
+            <p
+              className={`text-sm ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}
+            >
+              Armá tus propias pruebas técnicas e invitá candidatos a rendirlas
+              por link.
+            </p>
+          </div>
+          <Link
+            href="/empresa/pruebas/nuevo"
+            className="px-4 py-2.5 rounded-lg text-sm font-semibold bg-indigo-600 text-white hover:bg-indigo-700 transition-colors shrink-0"
+          >
+            + Nueva prueba
+          </Link>
+        </div>
+
+        {error && (
+          <div className="rounded-lg border border-red-300 bg-red-50 text-red-700 px-4 py-3 text-sm mb-4">
+            {error}
+          </div>
+        )}
+
+        {loading ? (
+          <p
+            className={`text-sm ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}
+          >
+            Cargando...
+          </p>
+        ) : pruebas.length === 0 ? (
+          <div className={cardClass}>
+            <p
+              className={`text-sm ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}
+            >
+              Todavía no creaste ninguna prueba.
+            </p>
+          </div>
+        ) : (
+          <div className="space-y-3">
+            {pruebas.map((prueba) => (
+              <div key={prueba.id} className={cardClass}>
+                <div className="flex items-start justify-between gap-4 flex-wrap">
+                  <div>
+                    <div className="flex items-center gap-2 flex-wrap">
+                      <Link
+                        href={`/empresa/pruebas/${prueba.id}`}
+                        className={`font-semibold hover:underline ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
+                      >
+                        {prueba.title}
+                      </Link>
+                      <span
+                        className={`text-xs px-2 py-0.5 rounded-full ${
+                          prueba.is_active
+                            ? 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-300'
+                            : 'bg-gray-100 text-gray-600 dark:bg-slate-700 dark:text-slate-300'
+                        }`}
+                      >
+                        {prueba.is_active ? 'Activa' : 'Inactiva'}
+                      </span>
+                    </div>
+                    <p
+                      className={`text-xs mt-1 ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}
+                    >
+                      {prueba.category}
+                      {prueba.level ? ` · ${prueba.level}` : ''}
+                      {prueba.duration_minutes
+                        ? ` · ${prueba.duration_minutes} min`
+                        : ''}
+                    </p>
+                  </div>
+                  <div className="flex gap-2 flex-wrap text-sm">
+                    <Link
+                      href={`/empresa/pruebas/${prueba.id}`}
+                      className={`px-3 py-1.5 rounded-lg border transition-colors ${isDarkMode ? 'border-slate-600 text-slate-300 hover:border-slate-500' : 'border-gray-300 text-gray-700 hover:border-gray-400'}`}
+                    >
+                      Preguntas
+                    </Link>
+                    <Link
+                      href={`/empresa/pruebas/${prueba.id}/invitaciones`}
+                      className={`px-3 py-1.5 rounded-lg border transition-colors ${isDarkMode ? 'border-slate-600 text-slate-300 hover:border-slate-500' : 'border-gray-300 text-gray-700 hover:border-gray-400'}`}
+                    >
+                      Invitaciones
+                    </Link>
+                    <Link
+                      href={`/empresa/pruebas/${prueba.id}/resultados`}
+                      className={`px-3 py-1.5 rounded-lg border transition-colors ${isDarkMode ? 'border-slate-600 text-slate-300 hover:border-slate-500' : 'border-gray-300 text-gray-700 hover:border-gray-400'}`}
+                    >
+                      Resultados
+                    </Link>
+                    <button
+                      onClick={() => handleToggle(prueba)}
+                      className={`px-3 py-1.5 rounded-lg border transition-colors ${isDarkMode ? 'border-slate-600 text-slate-300 hover:border-slate-500' : 'border-gray-300 text-gray-700 hover:border-gray-400'}`}
+                    >
+                      {prueba.is_active ? 'Desactivar' : 'Activar'}
+                    </button>
+                    <button
+                      onClick={() => handleDelete(prueba)}
+                      className="px-3 py-1.5 rounded-lg border border-red-300 text-red-600 hover:bg-red-50 dark:border-red-800 dark:text-red-400 dark:hover:bg-red-900/20 transition-colors"
+                    >
+                      Eliminar
+                    </button>
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/src/app/prueba/[token]/page.tsx
+++ b/apps/frontend/src/app/prueba/[token]/page.tsx
@@ -1,0 +1,364 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useParams } from 'next/navigation';
+import { useTheme } from '@/contexts/ThemeContext';
+import {
+  getPruebaByTokenAction,
+  startIntentoAction,
+  submitIntentoAction,
+  type PublicPregunta,
+} from '@/actions/empresa-pruebas-candidato';
+
+type Stage = 'loading' | 'error' | 'welcome' | 'taking' | 'submitting' | 'done';
+
+const ERROR_MESSAGES: Record<string, string> = {
+  not_found: 'Este link de invitación no es válido.',
+  revoked: 'Esta invitación fue revocada.',
+  expired: 'Esta invitación expiró.',
+  no_attempts_left:
+    'Ya se agotaron los intentos disponibles para esta invitación.',
+};
+
+export default function TomarPruebaPage() {
+  const { isDarkMode } = useTheme();
+  const params = useParams<{ token: string }>();
+  const token = params.token;
+
+  const [stage, setStage] = useState<Stage>('loading');
+  const [errorCode, setErrorCode] = useState<string | null>(null);
+  const [pruebaTitle, setPruebaTitle] = useState('');
+  const [pruebaDescription, setPruebaDescription] = useState<string | null>(
+    null
+  );
+  const [durationMinutes, setDurationMinutes] = useState<number | null>(null);
+  const [preguntas, setPreguntas] = useState<PublicPregunta[]>([]);
+  const [candidateName, setCandidateName] = useState('');
+  const [candidateEmail, setCandidateEmail] = useState('');
+  const [needsCandidateInfo, setNeedsCandidateInfo] = useState(false);
+  const [intentoId, setIntentoId] = useState<string | null>(null);
+  const [startedAt, setStartedAt] = useState<number | null>(null);
+  const [answers, setAnswers] = useState<Record<string, unknown>>({});
+  const [remainingSeconds, setRemainingSeconds] = useState<number | null>(null);
+
+  useEffect(() => {
+    getPruebaByTokenAction(token).then(({ data, error }) => {
+      if (error || !data) {
+        setErrorCode(error);
+        setStage('error');
+        return;
+      }
+      setPruebaTitle(data.prueba.title);
+      setPruebaDescription(data.prueba.description);
+      setDurationMinutes(data.prueba.duration_minutes);
+      setPreguntas(data.preguntas);
+      setCandidateName(data.candidate_name ?? '');
+      setCandidateEmail(data.candidate_email ?? '');
+      setNeedsCandidateInfo(!data.candidate_name && !data.candidate_email);
+      setStage('welcome');
+    });
+  }, [token]);
+
+  useEffect(() => {
+    if (stage !== 'taking' || !startedAt || !durationMinutes) return;
+    const deadline = startedAt + durationMinutes * 60 * 1000;
+
+    const tick = () => {
+      const secondsLeft = Math.max(
+        0,
+        Math.round((deadline - Date.now()) / 1000)
+      );
+      setRemainingSeconds(secondsLeft);
+      if (secondsLeft === 0) handleSubmit();
+    };
+
+    tick();
+    const interval = setInterval(tick, 1000);
+    return () => clearInterval(interval);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [stage, startedAt, durationMinutes]);
+
+  const inputClass = `w-full rounded-lg border px-3 py-2 text-sm outline-none transition-colors focus:ring-2 focus:ring-indigo-500 ${
+    isDarkMode
+      ? 'bg-slate-700 border-slate-600 text-white placeholder-slate-400'
+      : 'bg-white border-gray-300 text-gray-900 placeholder-gray-400'
+  }`;
+  const cardClass = `rounded-2xl border p-8 ${isDarkMode ? 'bg-dark-secondary border-slate-700' : 'bg-white border-gray-200'}`;
+
+  const handleStart = async () => {
+    if (needsCandidateInfo && !candidateName.trim() && !candidateEmail.trim())
+      return;
+    const { data, error } = await startIntentoAction(token, {
+      candidate_name: candidateName.trim() || undefined,
+      candidate_email: candidateEmail.trim() || undefined,
+    });
+    if (error || !data) {
+      setErrorCode(error);
+      setStage('error');
+      return;
+    }
+    setIntentoId(data.intentoId);
+    setStartedAt(Date.now());
+    setStage('taking');
+  };
+
+  const handleSubmit = async () => {
+    if (!intentoId) return;
+    setStage('submitting');
+    const { error } = await submitIntentoAction(token, intentoId, answers);
+    if (error && error !== 'time_expired') {
+      setErrorCode(error);
+      setStage('error');
+      return;
+    }
+    setStage('done');
+  };
+
+  const formatTime = (seconds: number) => {
+    const m = Math.floor(seconds / 60);
+    const s = seconds % 60;
+    return `${m}:${String(s).padStart(2, '0')}`;
+  };
+
+  if (stage === 'loading') {
+    return (
+      <div
+        className={`min-h-screen flex items-center justify-center ${isDarkMode ? 'bg-dark-bg' : 'bg-gray-50'}`}
+      >
+        <p className={isDarkMode ? 'text-slate-400' : 'text-gray-500'}>
+          Cargando...
+        </p>
+      </div>
+    );
+  }
+
+  if (stage === 'error') {
+    return (
+      <div
+        className={`min-h-screen flex items-center justify-center px-4 ${isDarkMode ? 'bg-dark-bg' : 'bg-gray-50'}`}
+      >
+        <div className={`${cardClass} max-w-md text-center`}>
+          <p className="text-4xl mb-4">⚠️</p>
+          <h1
+            className={`text-xl font-bold mb-2 ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
+          >
+            No se pudo abrir la prueba
+          </h1>
+          <p
+            className={`text-sm ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}
+          >
+            {ERROR_MESSAGES[errorCode ?? ''] ?? 'Ocurrió un error inesperado.'}
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  if (stage === 'done') {
+    return (
+      <div
+        className={`min-h-screen flex items-center justify-center px-4 ${isDarkMode ? 'bg-dark-bg' : 'bg-gray-50'}`}
+      >
+        <div className={`${cardClass} max-w-md text-center`}>
+          <p className="text-5xl mb-4">✅</p>
+          <h1
+            className={`text-xl font-bold mb-2 ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
+          >
+            ¡Gracias por completar la prueba!
+          </h1>
+          <p
+            className={`text-sm ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}
+          >
+            Tus respuestas fueron enviadas. La empresa se pondrá en contacto con
+            vos.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  if (stage === 'welcome') {
+    return (
+      <div
+        className={`min-h-screen flex items-center justify-center px-4 ${isDarkMode ? 'bg-dark-bg' : 'bg-gray-50'}`}
+      >
+        <div className={`${cardClass} max-w-md w-full`}>
+          <h1
+            className={`text-xl font-bold mb-2 ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
+          >
+            {pruebaTitle}
+          </h1>
+          {pruebaDescription && (
+            <p
+              className={`text-sm mb-4 ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}
+            >
+              {pruebaDescription}
+            </p>
+          )}
+          <p
+            className={`text-sm mb-6 ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}
+          >
+            {preguntas.length} pregunta{preguntas.length === 1 ? '' : 's'}
+            {durationMinutes ? ` · ${durationMinutes} minutos` : ''}
+          </p>
+
+          {needsCandidateInfo && (
+            <div className="space-y-3 mb-6">
+              <input
+                type="text"
+                className={inputClass}
+                placeholder="Tu nombre"
+                value={candidateName}
+                onChange={(e) => setCandidateName(e.target.value)}
+              />
+              <input
+                type="email"
+                className={inputClass}
+                placeholder="Tu email"
+                value={candidateEmail}
+                onChange={(e) => setCandidateEmail(e.target.value)}
+              />
+            </div>
+          )}
+
+          <button
+            onClick={handleStart}
+            disabled={
+              needsCandidateInfo &&
+              !candidateName.trim() &&
+              !candidateEmail.trim()
+            }
+            className="w-full py-2.5 rounded-lg text-sm font-semibold bg-indigo-600 text-white hover:bg-indigo-700 disabled:opacity-50 transition-colors"
+          >
+            Comenzar
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className={`min-h-screen transition-colors duration-300 ${isDarkMode ? 'bg-dark-bg' : 'bg-gray-50'}`}
+    >
+      <div className="max-w-2xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+        <div className="flex items-center justify-between mb-6">
+          <h1
+            className={`text-xl font-bold ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
+          >
+            {pruebaTitle}
+          </h1>
+          {remainingSeconds !== null && (
+            <span
+              className={`text-sm font-mono px-3 py-1 rounded-full ${
+                remainingSeconds < 60
+                  ? 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-300'
+                  : isDarkMode
+                    ? 'bg-slate-700 text-slate-300'
+                    : 'bg-gray-100 text-gray-600'
+              }`}
+            >
+              ⏱ {formatTime(remainingSeconds)}
+            </span>
+          )}
+        </div>
+
+        <div className="space-y-4">
+          {preguntas.map((pregunta, index) => (
+            <div key={pregunta.id} className={cardClass}>
+              <p
+                className={`text-sm font-medium mb-3 ${isDarkMode ? 'text-slate-200' : 'text-gray-800'}`}
+              >
+                {index + 1}. {pregunta.prompt}
+              </p>
+
+              {pregunta.question_type === 'multiple_choice' && (
+                <div className="space-y-2">
+                  {((pregunta.options as string[]) ?? []).map((option) => (
+                    <label
+                      key={option}
+                      className={`flex items-center gap-2 px-3 py-2 rounded-lg border cursor-pointer text-sm ${
+                        isDarkMode ? 'border-slate-600' : 'border-gray-200'
+                      }`}
+                    >
+                      <input
+                        type="radio"
+                        name={pregunta.id}
+                        checked={
+                          (
+                            answers[pregunta.id] as
+                              | { value?: string }
+                              | undefined
+                          )?.value === option
+                        }
+                        onChange={() =>
+                          setAnswers({
+                            ...answers,
+                            [pregunta.id]: { value: option },
+                          })
+                        }
+                      />
+                      <span
+                        className={
+                          isDarkMode ? 'text-slate-300' : 'text-gray-700'
+                        }
+                      >
+                        {option}
+                      </span>
+                    </label>
+                  ))}
+                </div>
+              )}
+
+              {pregunta.question_type === 'true_false' && (
+                <div className="flex gap-3">
+                  {[true, false].map((value) => (
+                    <button
+                      key={String(value)}
+                      type="button"
+                      onClick={() =>
+                        setAnswers({ ...answers, [pregunta.id]: { value } })
+                      }
+                      className={`flex-1 py-2 rounded-lg text-sm font-medium border transition-colors ${
+                        (
+                          answers[pregunta.id] as
+                            | { value?: boolean }
+                            | undefined
+                        )?.value === value
+                          ? 'border-indigo-500 bg-indigo-600 text-white'
+                          : isDarkMode
+                            ? 'border-slate-600 text-slate-300'
+                            : 'border-gray-300 text-gray-700'
+                      }`}
+                    >
+                      {value ? 'Verdadero' : 'Falso'}
+                    </button>
+                  ))}
+                </div>
+              )}
+
+              {pregunta.question_type === 'short_text' && (
+                <textarea
+                  className={`${inputClass} resize-none`}
+                  rows={3}
+                  value={(answers[pregunta.id] as string) ?? ''}
+                  onChange={(e) =>
+                    setAnswers({ ...answers, [pregunta.id]: e.target.value })
+                  }
+                />
+              )}
+            </div>
+          ))}
+        </div>
+
+        <button
+          onClick={handleSubmit}
+          disabled={stage === 'submitting'}
+          className="w-full mt-6 py-2.5 rounded-lg text-sm font-semibold bg-indigo-600 text-white hover:bg-indigo-700 disabled:opacity-50 transition-colors"
+        >
+          {stage === 'submitting' ? 'Enviando...' : 'Enviar respuestas'}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/src/components/Header.tsx
+++ b/apps/frontend/src/components/Header.tsx
@@ -23,6 +23,7 @@ const navLinks = [
 const empresaNavLinks = [
   { href: '/empresa', label: 'Panel', emoji: '🏢' },
   { href: '/empresa/procesos', label: 'Mis procesos', emoji: '📂' },
+  { href: '/empresa/pruebas', label: 'Mis pruebas', emoji: '📝' },
   { href: '/empresa/buscar-candidatos', label: 'Buscar talento', emoji: '👥' },
   { href: '/empresa/candidatos', label: 'Evaluados', emoji: '📊' },
   { href: '/empresa/admin/usuarios', label: 'Usuarios', emoji: '👤' },

--- a/supabase/migrations/20260709_000000_empresa_pruebas.sql
+++ b/supabase/migrations/20260709_000000_empresa_pruebas.sql
@@ -1,0 +1,171 @@
+-- =========================================
+-- Empresa pruebas: company-owned technical tests
+-- Fully additive — zero changes to assessments*/exam_results tables or policies.
+-- Reuses existing public.is_active_empresa_member() / public.auth_user_empresa_role()
+-- and public.set_updated_at() defined in 20260505_000000_add_empresas_ruc_multiuser.sql.
+-- =========================================
+
+-- 1. empresa_pruebas
+CREATE TABLE IF NOT EXISTS public.empresa_pruebas (
+  id               UUID        DEFAULT gen_random_uuid() PRIMARY KEY,
+  empresa_id       UUID        NOT NULL REFERENCES public.empresas(id) ON DELETE CASCADE,
+  created_by       UUID        REFERENCES auth.users(id) ON DELETE SET NULL,
+  title            TEXT        NOT NULL,
+  category         TEXT        NOT NULL,
+  description      TEXT,
+  level            TEXT,
+  duration_minutes INT,
+  is_active        BOOLEAN     NOT NULL DEFAULT true,
+  created_at       TIMESTAMPTZ DEFAULT now() NOT NULL,
+  updated_at       TIMESTAMPTZ DEFAULT now() NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS empresa_pruebas_empresa_idx ON public.empresa_pruebas (empresa_id);
+
+DROP TRIGGER IF EXISTS empresa_pruebas_updated_at ON public.empresa_pruebas;
+CREATE TRIGGER empresa_pruebas_updated_at
+  BEFORE UPDATE ON public.empresa_pruebas
+  FOR EACH ROW EXECUTE FUNCTION public.set_updated_at();
+
+-- 2. empresa_preguntas
+CREATE TABLE IF NOT EXISTS public.empresa_preguntas (
+  id                UUID        DEFAULT gen_random_uuid() PRIMARY KEY,
+  prueba_id         UUID        NOT NULL REFERENCES public.empresa_pruebas(id) ON DELETE CASCADE,
+  position          INT         NOT NULL,
+  question_type     TEXT        NOT NULL CHECK (question_type IN ('multiple_choice', 'true_false', 'short_text')),
+  prompt            TEXT        NOT NULL,
+  options           JSONB,
+  correct_answer    JSONB       NOT NULL,
+  expected_keywords TEXT[],
+  points            NUMERIC     NOT NULL DEFAULT 1,
+  created_at        TIMESTAMPTZ DEFAULT now() NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS empresa_preguntas_prueba_position_idx
+  ON public.empresa_preguntas (prueba_id, position);
+
+-- 3. empresa_prueba_invitaciones
+-- Named distinctly from the pre-existing public.empresa_invitaciones table
+-- (candidate invitations to hiring processes — a different domain).
+CREATE TABLE IF NOT EXISTS public.empresa_prueba_invitaciones (
+  id              UUID        DEFAULT gen_random_uuid() PRIMARY KEY,
+  prueba_id       UUID        NOT NULL REFERENCES public.empresa_pruebas(id) ON DELETE CASCADE,
+  token           TEXT        NOT NULL UNIQUE,
+  candidate_email TEXT,
+  candidate_name  TEXT,
+  expires_at      TIMESTAMPTZ,
+  max_attempts    INT         NOT NULL DEFAULT 1,
+  status          TEXT        NOT NULL DEFAULT 'active' CHECK (status IN ('active', 'revoked')),
+  created_by      UUID        REFERENCES auth.users(id) ON DELETE SET NULL,
+  created_at      TIMESTAMPTZ DEFAULT now() NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS empresa_prueba_invitaciones_prueba_idx
+  ON public.empresa_prueba_invitaciones (prueba_id);
+
+-- 4. empresa_intentos
+-- No RLS write policies for `authenticated` on purpose — candidates never touch
+-- this table directly. All reads/writes on the candidate side go through server
+-- actions using the service-role client, validated by invitation token.
+CREATE TABLE IF NOT EXISTS public.empresa_intentos (
+  id             UUID        DEFAULT gen_random_uuid() PRIMARY KEY,
+  prueba_id      UUID        NOT NULL REFERENCES public.empresa_pruebas(id) ON DELETE CASCADE,
+  invitacion_id  UUID        NOT NULL REFERENCES public.empresa_prueba_invitaciones(id) ON DELETE CASCADE,
+  candidate_name TEXT,
+  candidate_email TEXT,
+  started_at     TIMESTAMPTZ,
+  submitted_at   TIMESTAMPTZ,
+  answers        JSONB,
+  score          NUMERIC,
+  max_score      NUMERIC,
+  breakdown      JSONB,
+  created_at     TIMESTAMPTZ DEFAULT now() NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS empresa_intentos_prueba_idx ON public.empresa_intentos (prueba_id);
+CREATE INDEX IF NOT EXISTS empresa_intentos_invitacion_idx ON public.empresa_intentos (invitacion_id);
+
+-- 5. RLS
+ALTER TABLE public.empresa_pruebas             ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.empresa_preguntas           ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.empresa_prueba_invitaciones ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.empresa_intentos            ENABLE ROW LEVEL SECURITY;
+
+-- empresa_pruebas: any active member of the empresa can read; only owner/admin can write.
+CREATE POLICY "empresa_pruebas_members_read" ON public.empresa_pruebas
+  FOR SELECT TO authenticated
+  USING (public.is_active_empresa_member(empresa_id));
+
+CREATE POLICY "empresa_pruebas_admin_write" ON public.empresa_pruebas
+  FOR ALL TO authenticated
+  USING     (public.auth_user_empresa_role(empresa_id) IN ('owner', 'admin'))
+  WITH CHECK (public.auth_user_empresa_role(empresa_id) IN ('owner', 'admin'));
+
+-- empresa_preguntas: scoped through the parent prueba's empresa_id.
+CREATE POLICY "empresa_preguntas_members_read" ON public.empresa_preguntas
+  FOR SELECT TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.empresa_pruebas ep
+      WHERE ep.id = empresa_preguntas.prueba_id
+        AND public.is_active_empresa_member(ep.empresa_id)
+    )
+  );
+
+CREATE POLICY "empresa_preguntas_admin_write" ON public.empresa_preguntas
+  FOR ALL TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.empresa_pruebas ep
+      WHERE ep.id = empresa_preguntas.prueba_id
+        AND public.auth_user_empresa_role(ep.empresa_id) IN ('owner', 'admin')
+    )
+  )
+  WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM public.empresa_pruebas ep
+      WHERE ep.id = empresa_preguntas.prueba_id
+        AND public.auth_user_empresa_role(ep.empresa_id) IN ('owner', 'admin')
+    )
+  );
+
+-- empresa_prueba_invitaciones: scoped through the parent prueba's empresa_id.
+CREATE POLICY "empresa_prueba_invitaciones_members_read" ON public.empresa_prueba_invitaciones
+  FOR SELECT TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.empresa_pruebas ep
+      WHERE ep.id = empresa_prueba_invitaciones.prueba_id
+        AND public.is_active_empresa_member(ep.empresa_id)
+    )
+  );
+
+CREATE POLICY "empresa_prueba_invitaciones_admin_write" ON public.empresa_prueba_invitaciones
+  FOR ALL TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.empresa_pruebas ep
+      WHERE ep.id = empresa_prueba_invitaciones.prueba_id
+        AND public.auth_user_empresa_role(ep.empresa_id) IN ('owner', 'admin')
+    )
+  )
+  WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM public.empresa_pruebas ep
+      WHERE ep.id = empresa_prueba_invitaciones.prueba_id
+        AND public.auth_user_empresa_role(ep.empresa_id) IN ('owner', 'admin')
+    )
+  );
+
+-- empresa_intentos: read-only for empresa members, scoped through prueba's empresa_id.
+-- No INSERT/UPDATE/DELETE policy for `authenticated` — candidate flow writes via
+-- the service-role client (apps/frontend/src/lib/supabase/admin.ts), bypassing RLS.
+CREATE POLICY "empresa_intentos_members_read" ON public.empresa_intentos
+  FOR SELECT TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.empresa_pruebas ep
+      WHERE ep.id = empresa_intentos.prueba_id
+        AND public.is_active_empresa_member(ep.empresa_id)
+    )
+  );


### PR DESCRIPTION
## Resumen
- Permite que cada empresa arme sus propias pruebas técnicas (opción múltiple, verdadero/falso, respuesta corta) e invite candidatos por link con token — sin tocar el sistema de exámenes globales `/assessments`.
- Migración aditiva: `empresa_pruebas`, `empresa_preguntas`, `empresa_prueba_invitaciones`, `empresa_intentos`. RLS reusa `is_active_empresa_member()` / `auth_user_empresa_role()` ya existentes.
- Server actions separadas: lado empresa (sesión, `apps/frontend/src/actions/empresa-pruebas.ts`) y lado candidato (token + service-role client, sin exponer `correct_answer`, `apps/frontend/src/actions/empresa-pruebas-candidato.ts`).
- Scoring puro (`apps/frontend/src/actions/lib/empresa-scoring.ts`) con tests unitarios.
- Rutas nuevas: `/empresa/pruebas/*` (builder) y `/prueba/[token]` (candidato).
- Único cambio a código existente: link "Mis pruebas" en `Header.tsx`.

## Por qué el nombre `empresa_prueba_invitaciones` y no `empresa_invitaciones`
Ya existe una tabla `empresa_invitaciones` para invitaciones de candidatos a procesos de contratación (dominio distinto). Se renombró para evitar colisión.

## Verificado
- [x] Migración aplicada al proyecto Supabase `aiquaa`; hash de políticas RLS de `assessment*`/`exam_results` idéntico antes/después (cero impacto)
- [x] `get_advisors` (security) sin warnings nuevos en las 4 tablas nuevas
- [x] `pnpm lint` limpio
- [x] `tsc --noEmit` limpio (encontré y arreglé un bug de narrowing TS en un helper propio)
- [x] `next build` exitoso, todas las rutas nuevas compilan
- [x] 13 tests unitarios de scoring, todos pasan
- [x] Pre-push hook (type-check) OK

## Test plan
- [ ] Owner crea prueba → agrega 1 pregunta de cada tipo → genera invitación → abre `/prueba/{token}` en incógnito → inspecciona payload de red (sin `correct_answer`) → somete → resultado visible en `resultados/`
- [ ] Token inventado → 404 / revocado / expirado → rechazo
- [ ] Cross-tenant: empresa B no puede leer/editar pruebas de empresa A

## Fuera de alcance (documentado en PR aparte)
- Fix de leak de `correct_answer` en `assessments/_shared/lib/serializers.ts` (confirmado real durante esta exploración, pertenece al sistema existente, no a este PR)

🤖 Generado con [Claude Code](https://claude.com/claude-code)