### PR TITLE
fix(assessments): no exponer correct_answer al candidato mientras rinde

### DIFF
--- a/apps/frontend/src/actions/assessments.ts
+++ b/apps/frontend/src/actions/assessments.ts
@@ -23,6 +23,7 @@ import {
   mapQuestion,
   mapSection,
   mapSectionScore,
+  stripAnswerKey,
 } from '@/app/assessments/_shared/lib/serializers';
 import type {
   AssessmentFeedback,
@@ -335,7 +336,7 @@ export async function getAssessmentSectionAction(
   return {
     attempt: bundle.attempt,
     section: bundle.section,
-    questions: bundle.questions,
+    questions: bundle.questions.map(stripAnswerKey),
     answers: bundle.answers,
     scores: bundle.scores,
     sections: bundle.sections,

--- a/apps/frontend/src/app/assessments/_shared/lib/__tests__/serializers.test.ts
+++ b/apps/frontend/src/app/assessments/_shared/lib/__tests__/serializers.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'vitest';
+import { mapQuestion, stripAnswerKey } from '../serializers';
+
+describe('mapQuestion', () => {
+  it('includes the answer-key fields (needed by server-only scoring paths)', () => {
+    const question = mapQuestion({
+      id: 'q1',
+      section_id: 's1',
+      question_type: 'multiple_choice',
+      prompt: '¿Qué es QA?',
+      correct_answer: { value: 'b' },
+      expected_keywords: ['regresion'],
+      scoring_rules: { strict: true },
+      rubric: { criteria: ['x'] },
+      points: 10,
+      order_index: 0,
+    });
+
+    expect(question.correct_answer).toEqual({ value: 'b' });
+    expect(question.expected_keywords).toEqual(['regresion']);
+    expect(question.scoring_rules).toEqual({ strict: true });
+    expect(question.rubric).toEqual({ criteria: ['x'] });
+  });
+});
+
+describe('stripAnswerKey', () => {
+  it('nulls/empties every answer-key field regardless of input', () => {
+    const question = mapQuestion({
+      id: 'q1',
+      section_id: 's1',
+      question_type: 'multiple_choice',
+      prompt: '¿Qué es QA?',
+      correct_answer: { value: 'b' },
+      expected_keywords: ['regresion', 'smoke'],
+      scoring_rules: { strict: true },
+      rubric: { criteria: ['x'] },
+      points: 10,
+      order_index: 0,
+    });
+
+    const sanitized = stripAnswerKey(question);
+
+    expect(sanitized.correct_answer).toBeNull();
+    expect(sanitized.expected_keywords).toEqual([]);
+    expect(sanitized.scoring_rules).toEqual({});
+    expect(sanitized.rubric).toEqual({});
+  });
+
+  it('preserves every non-answer-key field untouched', () => {
+    const question = mapQuestion({
+      id: 'q1',
+      section_id: 's1',
+      question_type: 'short_text',
+      prompt: 'Explicá regresión',
+      description: 'desc',
+      options: [{ label: 'A', value: 'a' }],
+      explanation: 'explicacion',
+      points: 5,
+      order_index: 2,
+    });
+
+    const sanitized = stripAnswerKey(question);
+
+    expect(sanitized).toMatchObject({
+      id: 'q1',
+      section_id: 's1',
+      question_type: 'short_text',
+      prompt: 'Explicá regresión',
+      description: 'desc',
+      options: [{ label: 'A', value: 'a' }],
+      explanation: 'explicacion',
+      points: 5,
+      order_index: 2,
+    });
+  });
+
+  it('handles a question with no answer-key data set (still returns safe empties)', () => {
+    const question = mapQuestion({
+      id: 'q2',
+      section_id: 's1',
+      question_type: 'true_false',
+      prompt: 'Verdadero o falso',
+      points: 3,
+      order_index: 1,
+    });
+
+    const sanitized = stripAnswerKey(question);
+
+    expect(sanitized.correct_answer).toBeNull();
+    expect(sanitized.expected_keywords).toEqual([]);
+    expect(sanitized.scoring_rules).toEqual({});
+    expect(sanitized.rubric).toEqual({});
+  });
+});

--- a/apps/frontend/src/app/assessments/_shared/lib/serializers.ts
+++ b/apps/frontend/src/app/assessments/_shared/lib/serializers.ts
@@ -64,6 +64,25 @@ export function mapQuestion(row: Record<string, unknown>): AssessmentQuestion {
   };
 }
 
+/**
+ * Strips answer-key fields from a mapped question before it is sent to the
+ * client while a candidate is actively answering. mapQuestion() keeps these
+ * fields because it also backs server-only scoring paths (loadSectionBundle /
+ * submitAssessmentSectionAction in actions/assessments.ts) that need the
+ * full row — only the client-facing return value should go through this.
+ */
+export function stripAnswerKey(
+  question: AssessmentQuestion
+): AssessmentQuestion {
+  return {
+    ...question,
+    correct_answer: null,
+    expected_keywords: [],
+    scoring_rules: {},
+    rubric: {},
+  };
+}
+
 export function mapAttempt(row: Record<string, unknown>): AssessmentAttempt {
   return {
     id: String(row.id),


### PR DESCRIPTION
## Resumen
Bug de seguridad detectado durante la exploración previa al PR #273, documentado ahí como fix pendiente separado (no era parte de ese PR para no tocar el sistema de assessments).

`getAssessmentSectionAction` (`apps/frontend/src/actions/assessments.ts`) — el único punto que expone preguntas al candidato mientras rinde un examen — devolvía el objeto de pregunta completo, incluyendo `correct_answer`, `expected_keywords`, `scoring_rules` y `rubric`. Esto es visible en el payload de red del navegador (Network tab) **antes de que el candidato conteste**, para cualquier examen del sistema `/assessments`.

## Por qué es seguro el fix
- El componente cliente `AssessmentSectionScreen.tsx` nunca lee esos 4 campos (verificado por grep) — no hay regresión funcional posible.
- La única ruta interna que sí necesita el dato completo para calificar (`submitAssessmentSectionAction`) usa `loadSectionBundle()` directamente, **no** pasa por `getAssessmentSectionAction` — queda intacta.
- `mapQuestion()` (usado por ambas rutas) no se toca — solo se agrega `stripAnswerKey()`, aplicado únicamente al retorno de la acción pública.

## Cambio
- `apps/frontend/src/app/assessments/_shared/lib/serializers.ts` — nueva función `stripAnswerKey()`.
- `apps/frontend/src/actions/assessments.ts` — `getAssessmentSectionAction` aplica `stripAnswerKey` a cada pregunta antes de devolverlas.
- Test nuevo: `apps/frontend/src/app/assessments/_shared/lib/__tests__/serializers.test.ts`.

## Verificado
- [x] 4 tests nuevos (incluye caso sin datos de answer-key seteados)
- [x] Suite completa de `src/app/assessments` — **52/52 tests pasan**, sin regresiones en scoring de ningún examen
- [x] `pnpm lint` limpio
- [x] `tsc --noEmit` limpio
- [x] `next build` exitoso
- [x] Pre-push hook (type-check) OK

## Nota para el reviewer
Además de esto, hay un vector más profundo (no incluido en este PR): la política RLS de `assessment_questions` permite `SELECT` de la fila completa —incluyendo `correct_answer`— a cualquier usuario `authenticated` vía la API REST de Supabase directamente (bypaseando el server action). Restringir eso requiere separar el acceso server-side de scoring (que hoy usa el cliente con sesión del usuario) a un cliente service-role, o una vista sin columnas sensibles — un cambio más invasivo al esquema. Queda fuera de este PR; lo documento para decidir si se aborda en uno futuro.

🤖 Generado con [Claude Code](https://claude.com/claude-code)