### PR TITLE
fix(config): raise Server Actions body limit to 4mb (413 en test-app/report)

### DIFF
--- a/apps/frontend/next.config.mjs
+++ b/apps/frontend/next.config.mjs
@@ -58,7 +58,13 @@ const securityHeaders = [
 const nextConfig = {
   transpilePackages: ['@aiquaa/allpairs-core'],
   experimental: {
-    serverActions: true,
+    // Default is 1mb; the test-app bug report form attaches base64-encoded
+    // screenshots (up to 5MB each) to the saveExamResultAction payload,
+    // which was tripping the default limit and failing exam submissions
+    // for users who attached evidence images (see issue in QA-CYCLE log).
+    serverActions: {
+      bodySizeLimit: '4mb',
+    },
   },
   images: {
     remotePatterns: [


### PR DESCRIPTION
## Resumen
Este fix fue implementado y pusheado a esta rama durante el ciclo de QA del 2026-07-03 (issue #262), pero nunca se abrió un PR — quedó huérfano en `claude/nice-galileo-odmb5t` sin mergear durante 7 ciclos semanales de revisión consecutivos (#262 → #271), cada uno reconfirmando que seguía sin mergear. Este PR simplemente lo pone a disposición para review y merge.

## Bug
`/labs/test-app/report` (Bug Hunt) falla con **HTTP 413 "Body exceeded 1mb limit"** para cualquier candidato que adjunte evidencia de bugs con capturas de pantalla (`ImageEvidence.base64Data`, hasta 5MB por imagen) en `handleSaveToDb`. El límite por defecto de Next.js para el body de un Server Action es 1MB.

**Impacto confirmado en producción** (Vercel runtime errors, proyecto `prj_utOkqNUA0dIJ7QNPE5w7yyARb7KL`): 17 ocurrencias / 6 usuarios distintos entre 2026-07-03 y 2026-07-05. No pudieron entregar su examen de Bug Hunt — un flujo core del lab `test-app`.

## Fix
`apps/frontend/next.config.mjs` — `experimental.serverActions` pasa de `true` a `{ bodySizeLimit: '4mb' }`.

Nota (documentada en el ciclo original): 4mb es el techo práctico porque Vercel Serverless Functions tienen un límite de plataforma ~4.5MB en el body de la request que ninguna config de Next.js puede superar. Con varias imágenes grandes en un mismo reporte, el error puede seguir apareciendo ocasionalmente — el fix estructural recomendado a mediano plazo es subir las imágenes a Supabase Storage desde el cliente y enviar solo URLs en el metadata, no el base64 completo (fuera de alcance de este PR de una línea).

## Verificado esta sesión
- [x] Diff aislado a un único archivo de configuración, sin cambios funcionales de código
- [x] `git merge-tree` contra `main` actual (`1ba2e09`) → mergea limpio, sin conflictos
- [x] Runtime errors de Vercel confirman que el 413 es real y recurrente (no hipotético)

🤖 Generado con [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ceq4STq5PEP4XcBDBh8Lwr)_