### PR TITLE
feat(home): carrusel promocional con pruebas tecnicas 2026 y ranking

### DIFF
--- a/apps/frontend/src/app/page.tsx
+++ b/apps/frontend/src/app/page.tsx
@@ -5,6 +5,7 @@ import { useEffect, useState } from 'react';
 import { useTheme } from '@/contexts/ThemeContext';
 import { useLanguage } from '@/contexts/LanguageContext';
 import LogoMark from '@/components/LogoMark';
+import HomePromoCarousel from '@/components/HomePromoCarousel';
 import ISTQBHighlight from '@/components/ISTQBHighlight';
 import { SuruFloating } from '@/components/Suru';
 import { LABS_TOOL_COUNT } from '@/lib/labsCatalog';
@@ -14,7 +15,9 @@ export default function HomePage() {
   const { isDarkMode } = useTheme();
   const { t } = useLanguage();
   const [memberCount, setMemberCount] = useState<string>('80+');
-  const [memberLabel, setMemberLabel] = useState<string>('usuarios registrados');
+  const [memberLabel, setMemberLabel] = useState<string>(
+    'usuarios registrados'
+  );
   // Sección de planes oculta hasta que el plan Pro esté disponible.
   const SHOW_PRICING = false;
 
@@ -233,6 +236,8 @@ export default function HomePage() {
         />
       </section>
 
+      <HomePromoCarousel />
+
       <ISTQBHighlight />
 
       {/* Featured Tools */}
@@ -343,72 +348,146 @@ export default function HomePage() {
 
       {/* Planes / Pricing */}
       {SHOW_PRICING && (
-      <section
-        className={`py-16 md:py-20 transition-colors duration-300 ${
-          isDarkMode
-            ? 'bg-slate-800'
-            : 'bg-gradient-to-br from-indigo-50 via-white to-purple-50'
-        }`}
-      >
-        <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="text-center mb-12">
-            <h2
-              className={`text-3xl md:text-4xl font-bold mb-4 ${
-                isDarkMode ? 'text-white' : 'text-slate-900'
-              }`}
-            >
-              Elegí tu plan
-            </h2>
-            <p
-              className={`text-lg max-w-2xl mx-auto ${
-                isDarkMode ? 'text-slate-300' : 'text-slate-600'
-              }`}
-            >
-              Empezá gratis, crecé a tu ritmo
-            </p>
-          </div>
+        <section
+          className={`py-16 md:py-20 transition-colors duration-300 ${
+            isDarkMode
+              ? 'bg-slate-800'
+              : 'bg-gradient-to-br from-indigo-50 via-white to-purple-50'
+          }`}
+        >
+          <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div className="text-center mb-12">
+              <h2
+                className={`text-3xl md:text-4xl font-bold mb-4 ${
+                  isDarkMode ? 'text-white' : 'text-slate-900'
+                }`}
+              >
+                Elegí tu plan
+              </h2>
+              <p
+                className={`text-lg max-w-2xl mx-auto ${
+                  isDarkMode ? 'text-slate-300' : 'text-slate-600'
+                }`}
+              >
+                Empezá gratis, crecé a tu ritmo
+              </p>
+            </div>
 
-          <div className="grid md:grid-cols-3 gap-8 items-stretch">
-            {/* Free */}
-            <div
-              className={`relative rounded-2xl border-2 border-indigo-500 shadow-xl flex flex-col ${
-                isDarkMode ? 'bg-slate-900' : 'bg-white'
-              }`}
-            >
-              <div className="absolute -top-4 left-1/2 -translate-x-1/2">
-                <span className="bg-indigo-600 text-white text-xs font-bold px-4 py-1 rounded-full shadow">
-                  ACTUAL
-                </span>
-              </div>
-              <div className="p-8 flex flex-col flex-1">
-                <div className="mb-6">
-                  <h3
-                    className={`text-xl font-bold mb-1 ${isDarkMode ? 'text-white' : 'text-slate-900'}`}
-                  >
-                    Free
-                  </h3>
-                  <p
-                    className={`text-sm ${isDarkMode ? 'text-slate-400' : 'text-slate-500'}`}
-                  >
-                    Siempre gratis
-                  </p>
-                  <div
-                    className={`mt-4 text-4xl font-extrabold ${isDarkMode ? 'text-white' : 'text-slate-900'}`}
-                  >
-                    $0
-                    <span
-                      className={`text-base font-normal ml-1 ${isDarkMode ? 'text-slate-400' : 'text-slate-500'}`}
+            <div className="grid md:grid-cols-3 gap-8 items-stretch">
+              {/* Free */}
+              <div
+                className={`relative rounded-2xl border-2 border-indigo-500 shadow-xl flex flex-col ${
+                  isDarkMode ? 'bg-slate-900' : 'bg-white'
+                }`}
+              >
+                <div className="absolute -top-4 left-1/2 -translate-x-1/2">
+                  <span className="bg-indigo-600 text-white text-xs font-bold px-4 py-1 rounded-full shadow">
+                    ACTUAL
+                  </span>
+                </div>
+                <div className="p-8 flex flex-col flex-1">
+                  <div className="mb-6">
+                    <h3
+                      className={`text-xl font-bold mb-1 ${isDarkMode ? 'text-white' : 'text-slate-900'}`}
                     >
-                      /mes
-                    </span>
+                      Free
+                    </h3>
+                    <p
+                      className={`text-sm ${isDarkMode ? 'text-slate-400' : 'text-slate-500'}`}
+                    >
+                      Siempre gratis
+                    </p>
+                    <div
+                      className={`mt-4 text-4xl font-extrabold ${isDarkMode ? 'text-white' : 'text-slate-900'}`}
+                    >
+                      $0
+                      <span
+                        className={`text-base font-normal ml-1 ${isDarkMode ? 'text-slate-400' : 'text-slate-500'}`}
+                      >
+                        /mes
+                      </span>
+                    </div>
+                  </div>
+                  <ul className="space-y-3 flex-1">
+                    {['Labs completo', 'Simulador ISTQB', 'Comunidad'].map(
+                      (item) => (
+                        <li key={item} className="flex items-center gap-3">
+                          <svg
+                            className="w-5 h-5 text-indigo-500 flex-shrink-0"
+                            fill="currentColor"
+                            viewBox="0 0 20 20"
+                          >
+                            <path
+                              fillRule="evenodd"
+                              d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
+                              clipRule="evenodd"
+                            />
+                          </svg>
+                          <span
+                            className={`text-sm ${isDarkMode ? 'text-slate-300' : 'text-slate-700'}`}
+                          >
+                            {item}
+                          </span>
+                        </li>
+                      )
+                    )}
+                  </ul>
+                  <div className="mt-8">
+                    <Link
+                      href="/labs"
+                      className="block w-full text-center px-6 py-3 rounded-xl font-bold text-white bg-gradient-to-r from-indigo-600 to-purple-600 hover:shadow-lg hover:scale-105 transition-all duration-200"
+                    >
+                      Empezar gratis
+                    </Link>
                   </div>
                 </div>
-                <ul className="space-y-3 flex-1">
-                  {['Labs completo', 'Simulador ISTQB', 'Comunidad'].map(
-                    (item) => (
+              </div>
+
+              {/* Pro */}
+              <div
+                className={`relative rounded-2xl border-2 flex flex-col opacity-80 ${
+                  isDarkMode
+                    ? 'bg-slate-900 border-slate-700'
+                    : 'bg-white border-slate-200'
+                }`}
+              >
+                <div className="absolute -top-4 left-1/2 -translate-x-1/2">
+                  <span className="bg-amber-500 text-white text-xs font-bold px-4 py-1 rounded-full shadow">
+                    PRÓXIMAMENTE
+                  </span>
+                </div>
+                <div className="p-8 flex flex-col flex-1">
+                  <div className="mb-6">
+                    <h3
+                      className={`text-xl font-bold mb-1 ${isDarkMode ? 'text-white' : 'text-slate-900'}`}
+                    >
+                      Pro
+                    </h3>
+                    <p
+                      className={`text-sm ${isDarkMode ? 'text-slate-400' : 'text-slate-500'}`}
+                    >
+                      Para profesionales
+                    </p>
+                    <div
+                      className={`mt-4 text-4xl font-extrabold ${isDarkMode ? 'text-white' : 'text-slate-900'}`}
+                    >
+                      ~$9
+                      <span
+                        className={`text-base font-normal ml-1 ${isDarkMode ? 'text-slate-400' : 'text-slate-500'}`}
+                      >
+                        /mes
+                      </span>
+                    </div>
+                  </div>
+                  <ul className="space-y-3 flex-1">
+                    {[
+                      'Cursos con certificado',
+                      'Rutas de aprendizaje IA',
+                      'Soporte prioritario',
+                    ].map((item) => (
                       <li key={item} className="flex items-center gap-3">
                         <svg
-                          className="w-5 h-5 text-indigo-500 flex-shrink-0"
+                          className="w-5 h-5 text-amber-500 flex-shrink-0"
                           fill="currentColor"
                           viewBox="0 0 20 20"
                         >
@@ -424,152 +503,78 @@ export default function HomePage() {
                           {item}
                         </span>
                       </li>
-                    )
-                  )}
-                </ul>
-                <div className="mt-8">
-                  <Link
-                    href="/labs"
-                    className="block w-full text-center px-6 py-3 rounded-xl font-bold text-white bg-gradient-to-r from-indigo-600 to-purple-600 hover:shadow-lg hover:scale-105 transition-all duration-200"
-                  >
-                    Empezar gratis
-                  </Link>
-                </div>
-              </div>
-            </div>
-
-            {/* Pro */}
-            <div
-              className={`relative rounded-2xl border-2 flex flex-col opacity-80 ${
-                isDarkMode
-                  ? 'bg-slate-900 border-slate-700'
-                  : 'bg-white border-slate-200'
-              }`}
-            >
-              <div className="absolute -top-4 left-1/2 -translate-x-1/2">
-                <span className="bg-amber-500 text-white text-xs font-bold px-4 py-1 rounded-full shadow">
-                  PRÓXIMAMENTE
-                </span>
-              </div>
-              <div className="p-8 flex flex-col flex-1">
-                <div className="mb-6">
-                  <h3
-                    className={`text-xl font-bold mb-1 ${isDarkMode ? 'text-white' : 'text-slate-900'}`}
-                  >
-                    Pro
-                  </h3>
-                  <p
-                    className={`text-sm ${isDarkMode ? 'text-slate-400' : 'text-slate-500'}`}
-                  >
-                    Para profesionales
-                  </p>
-                  <div
-                    className={`mt-4 text-4xl font-extrabold ${isDarkMode ? 'text-white' : 'text-slate-900'}`}
-                  >
-                    ~$9
-                    <span
-                      className={`text-base font-normal ml-1 ${isDarkMode ? 'text-slate-400' : 'text-slate-500'}`}
+                    ))}
+                  </ul>
+                  <div className="mt-8">
+                    <button
+                      disabled
+                      className={`block w-full text-center px-6 py-3 rounded-xl font-bold cursor-not-allowed ${
+                        isDarkMode
+                          ? 'bg-slate-700 text-slate-400'
+                          : 'bg-slate-100 text-slate-400'
+                      }`}
                     >
-                      /mes
-                    </span>
+                      Próximamente
+                    </button>
                   </div>
-                </div>
-                <ul className="space-y-3 flex-1">
-                  {[
-                    'Cursos con certificado',
-                    'Rutas de aprendizaje IA',
-                    'Soporte prioritario',
-                  ].map((item) => (
-                    <li key={item} className="flex items-center gap-3">
-                      <svg
-                        className="w-5 h-5 text-amber-500 flex-shrink-0"
-                        fill="currentColor"
-                        viewBox="0 0 20 20"
-                      >
-                        <path
-                          fillRule="evenodd"
-                          d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
-                          clipRule="evenodd"
-                        />
-                      </svg>
-                      <span
-                        className={`text-sm ${isDarkMode ? 'text-slate-300' : 'text-slate-700'}`}
-                      >
-                        {item}
-                      </span>
-                    </li>
-                  ))}
-                </ul>
-                <div className="mt-8">
-                  <button
-                    disabled
-                    className={`block w-full text-center px-6 py-3 rounded-xl font-bold cursor-not-allowed ${
-                      isDarkMode
-                        ? 'bg-slate-700 text-slate-400'
-                        : 'bg-slate-100 text-slate-400'
-                    }`}
-                  >
-                    Próximamente
-                  </button>
                 </div>
               </div>
-            </div>
 
-            {/* Empresas */}
-            <div
-              className={`relative rounded-2xl border-2 flex flex-col ${
-                isDarkMode
-                  ? 'bg-gradient-to-br from-slate-900 to-indigo-950 border-indigo-800'
-                  : 'bg-gradient-to-br from-slate-900 to-indigo-900 border-indigo-700'
-              }`}
-            >
-              <div className="p-8 flex flex-col flex-1">
-                <div className="mb-6">
-                  <h3 className="text-xl font-bold mb-1 text-white">
-                    Empresas
-                  </h3>
-                  <p className="text-sm text-indigo-300">
-                    A medida para tu equipo
-                  </p>
-                  <div className="mt-4 text-4xl font-extrabold text-white">
-                    Custom
+              {/* Empresas */}
+              <div
+                className={`relative rounded-2xl border-2 flex flex-col ${
+                  isDarkMode
+                    ? 'bg-gradient-to-br from-slate-900 to-indigo-950 border-indigo-800'
+                    : 'bg-gradient-to-br from-slate-900 to-indigo-900 border-indigo-700'
+                }`}
+              >
+                <div className="p-8 flex flex-col flex-1">
+                  <div className="mb-6">
+                    <h3 className="text-xl font-bold mb-1 text-white">
+                      Empresas
+                    </h3>
+                    <p className="text-sm text-indigo-300">
+                      A medida para tu equipo
+                    </p>
+                    <div className="mt-4 text-4xl font-extrabold text-white">
+                      Custom
+                    </div>
                   </div>
-                </div>
-                <ul className="space-y-3 flex-1">
-                  {[
-                    'Capacitación de equipos QA',
-                    'Onboarding corporativo',
-                    'Contactanos',
-                  ].map((item) => (
-                    <li key={item} className="flex items-center gap-3">
-                      <svg
-                        className="w-5 h-5 text-indigo-400 flex-shrink-0"
-                        fill="currentColor"
-                        viewBox="0 0 20 20"
-                      >
-                        <path
-                          fillRule="evenodd"
-                          d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
-                          clipRule="evenodd"
-                        />
-                      </svg>
-                      <span className="text-sm text-indigo-100">{item}</span>
-                    </li>
-                  ))}
-                </ul>
-                <div className="mt-8">
-                  <a
-                    href="mailto:admin@aiquaa.com"
-                    className="block w-full text-center px-6 py-3 rounded-xl font-bold text-indigo-900 bg-white hover:bg-indigo-50 hover:scale-105 transition-all duration-200 shadow-lg"
-                  >
-                    Contactanos
-                  </a>
+                  <ul className="space-y-3 flex-1">
+                    {[
+                      'Capacitación de equipos QA',
+                      'Onboarding corporativo',
+                      'Contactanos',
+                    ].map((item) => (
+                      <li key={item} className="flex items-center gap-3">
+                        <svg
+                          className="w-5 h-5 text-indigo-400 flex-shrink-0"
+                          fill="currentColor"
+                          viewBox="0 0 20 20"
+                        >
+                          <path
+                            fillRule="evenodd"
+                            d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
+                            clipRule="evenodd"
+                          />
+                        </svg>
+                        <span className="text-sm text-indigo-100">{item}</span>
+                      </li>
+                    ))}
+                  </ul>
+                  <div className="mt-8">
+                    <a
+                      href="mailto:admin@aiquaa.com"
+                      className="block w-full text-center px-6 py-3 rounded-xl font-bold text-indigo-900 bg-white hover:bg-indigo-50 hover:scale-105 transition-all duration-200 shadow-lg"
+                    >
+                      Contactanos
+                    </a>
+                  </div>
                 </div>
               </div>
             </div>
           </div>
-        </div>
-      </section>
+        </section>
       )}
 
       {/* Final CTA */}

--- a/apps/frontend/src/components/HomePromoCarousel.tsx
+++ b/apps/frontend/src/components/HomePromoCarousel.tsx
@@ -1,0 +1,244 @@
+'use client';
+
+import Link from 'next/link';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useTheme } from '@/contexts/ThemeContext';
+import { apiDeveloperFundamentalsDefinition } from '@/app/assessments/api-developer-fundamentals/data/assessment-definition';
+import { apiTestingFundamentalsDefinition } from '@/app/assessments/api-testing-fundamentals/data/assessment-definition';
+import { databaseFundamentalsDefinition } from '@/app/assessments/database-fundamentals/data/assessment-definition';
+import { databasePracticeDefinition } from '@/app/assessments/database-practice/data/assessment-definition';
+import { infrastructureFundamentalsDefinition } from '@/app/assessments/infrastructure-fundamentals/data/assessment-definition';
+
+interface PromoSlide {
+  id: string;
+  badge: string;
+  icon: string;
+  title: string;
+  description: string;
+  meta: string[];
+  href: string;
+  cta: string;
+  color: string;
+}
+
+const AUTOPLAY_MS = 5000;
+
+function assessmentSlide(
+  definition: {
+    slug: string;
+    title: string;
+    level: string;
+    duration_minutes: number;
+    total_score: number;
+  },
+  description: string,
+  color: string
+): PromoSlide {
+  return {
+    id: definition.slug,
+    badge: '🆕 Nuevo 2026',
+    icon: '🧪',
+    title: definition.title,
+    description,
+    meta: [
+      definition.level,
+      `${definition.duration_minutes} min`,
+      `${definition.total_score} pts`,
+    ],
+    href: `/assessments/${definition.slug}`,
+    cta: 'Ver assessment →',
+    color,
+  };
+}
+
+const SLIDES: PromoSlide[] = [
+  {
+    id: 'ranking',
+    badge: '🏆 Ranking',
+    icon: '🏆',
+    title: 'Ranking AIQUAA',
+    description:
+      'Competí en el podio de cada categoría, subí de nivel y ganá XP en la comunidad.',
+    meta: ['Leaderboards por categoría', 'XP de comunidad', 'Tiempo real'],
+    href: '/ranking',
+    cta: 'Ver ranking →',
+    color: 'from-purple-500 to-fuchsia-600',
+  },
+  assessmentSlide(
+    apiTestingFundamentalsDefinition,
+    'Interpretá documentación de API y analizá respuestas como en un caso real.',
+    'from-cyan-500 to-sky-600'
+  ),
+  assessmentSlide(
+    databaseFundamentalsDefinition,
+    'Modelo relacional, claves y consultas SELECT desde cero.',
+    'from-amber-500 to-yellow-600'
+  ),
+  assessmentSlide(
+    databasePracticeDefinition,
+    'Detectá bugs en queries y escribí SQL para resolver casos reales.',
+    'from-emerald-500 to-teal-600'
+  ),
+  assessmentSlide(
+    infrastructureFundamentalsDefinition,
+    'Docker y Kubernetes: de fundamentos a arquitectura.',
+    'from-blue-500 to-indigo-600'
+  ),
+  assessmentSlide(
+    apiDeveloperFundamentalsDefinition,
+    'Fundamentos de APIs REST pensados para quien recién arranca a programar.',
+    'from-indigo-500 to-violet-600'
+  ),
+  {
+    id: 'api-banking',
+    badge: '🆕 Nuevo 2026',
+    icon: '🧪',
+    title: 'API Testing — Challenge práctico',
+    description:
+      'Elegí entre Rick and Morty, Chuck Norris o NASA. Diseñá casos, documentá hallazgos y generá un reporte profesional.',
+    meta: ['Semi Senior', '90-120 min', '100 pts'],
+    href: '/assessments/api-banking',
+    cta: 'Ver challenge →',
+    color: 'from-rose-500 to-red-600',
+  },
+];
+
+export default function HomePromoCarousel() {
+  const { isDarkMode } = useTheme();
+  const [activeIndex, setActiveIndex] = useState(0);
+  const [isPaused, setIsPaused] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const goTo = useCallback((index: number) => {
+    setActiveIndex(((index % SLIDES.length) + SLIDES.length) % SLIDES.length);
+  }, []);
+
+  const goNext = useCallback(() => goTo(activeIndex + 1), [activeIndex, goTo]);
+  const goPrev = useCallback(() => goTo(activeIndex - 1), [activeIndex, goTo]);
+
+  useEffect(() => {
+    if (isPaused) return;
+    if (
+      typeof window !== 'undefined' &&
+      window.matchMedia('(prefers-reduced-motion: reduce)').matches
+    ) {
+      return;
+    }
+    const id = setInterval(() => {
+      setActiveIndex((i) => (i + 1) % SLIDES.length);
+    }, AUTOPLAY_MS);
+    return () => clearInterval(id);
+  }, [isPaused]);
+
+  return (
+    <section
+      className={`py-12 md:py-16 transition-colors duration-300 ${
+        isDarkMode ? 'bg-slate-950' : 'bg-gray-50'
+      }`}
+    >
+      <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div
+          ref={containerRef}
+          role="region"
+          aria-roledescription="carousel"
+          aria-label="Novedades: pruebas técnicas 2026 y ranking"
+          tabIndex={0}
+          onMouseEnter={() => setIsPaused(true)}
+          onMouseLeave={() => setIsPaused(false)}
+          onFocus={() => setIsPaused(true)}
+          onBlur={() => setIsPaused(false)}
+          onKeyDown={(e) => {
+            if (e.key === 'ArrowRight') goNext();
+            else if (e.key === 'ArrowLeft') goPrev();
+          }}
+          className="relative rounded-2xl overflow-hidden shadow-xl focus:outline-none focus:ring-4 focus:ring-indigo-500/40"
+        >
+          <div
+            className="flex transition-transform duration-500 ease-out"
+            style={{ transform: `translateX(-${activeIndex * 100}%)` }}
+          >
+            {SLIDES.map((slide) => (
+              <div
+                key={slide.id}
+                className="w-full shrink-0"
+                aria-hidden={slide.id !== SLIDES[activeIndex].id}
+                aria-live={
+                  slide.id === SLIDES[activeIndex].id ? 'polite' : undefined
+                }
+              >
+                <Link
+                  href={slide.href}
+                  className={`block bg-gradient-to-r ${slide.color} p-8 md:p-12 text-white`}
+                >
+                  <div className="flex flex-col md:flex-row md:items-center gap-6 px-9 md:px-0">
+                    <div className="text-5xl md:text-6xl shrink-0">
+                      {slide.icon}
+                    </div>
+                    <div className="flex-1 min-w-0">
+                      <span className="inline-block px-3 py-1 bg-white/20 backdrop-blur-sm rounded-full text-xs font-bold mb-3">
+                        {slide.badge}
+                      </span>
+                      <h3 className="text-2xl md:text-3xl font-bold mb-2">
+                        {slide.title}
+                      </h3>
+                      <p className="text-white/90 text-sm md:text-base mb-4 max-w-2xl">
+                        {slide.description}
+                      </p>
+                      <div className="flex flex-wrap gap-2 mb-4">
+                        {slide.meta.map((m) => (
+                          <span
+                            key={m}
+                            className="px-2.5 py-1 rounded-full text-xs font-medium bg-white/15"
+                          >
+                            {m}
+                          </span>
+                        ))}
+                      </div>
+                      <span className="inline-flex items-center gap-2 font-semibold text-sm underline underline-offset-4">
+                        {slide.cta}
+                      </span>
+                    </div>
+                  </div>
+                </Link>
+              </div>
+            ))}
+          </div>
+
+          {/* Flechas */}
+          <button
+            type="button"
+            onClick={goPrev}
+            aria-label="Novedad anterior"
+            className="absolute left-2 top-1/2 -translate-y-1/2 w-9 h-9 rounded-full bg-black/30 hover:bg-black/50 text-white flex items-center justify-center transition-colors"
+          >
+            ←
+          </button>
+          <button
+            type="button"
+            onClick={goNext}
+            aria-label="Siguiente novedad"
+            className="absolute right-2 top-1/2 -translate-y-1/2 w-9 h-9 rounded-full bg-black/30 hover:bg-black/50 text-white flex items-center justify-center transition-colors"
+          >
+            →
+          </button>
+
+          {/* Dots */}
+          <div className="absolute bottom-3 left-1/2 -translate-x-1/2 flex gap-2">
+            {SLIDES.map((slide, i) => (
+              <button
+                key={slide.id}
+                type="button"
+                onClick={() => goTo(i)}
+                aria-label={`Ir a novedad ${i + 1}: ${slide.title}`}
+                aria-current={i === activeIndex}
+                className={`w-2.5 h-2.5 rounded-full transition-all ${
+                  i === activeIndex ? 'bg-white w-6' : 'bg-white/50'
+                }`}
+              />
+            ))}
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/apps/frontend/test/components/HomePromoCarousel.test.tsx
+++ b/apps/frontend/test/components/HomePromoCarousel.test.tsx
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, act, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import HomePromoCarousel from '@/components/HomePromoCarousel';
+
+vi.mock('@/contexts/ThemeContext', () => ({
+  useTheme: () => ({ isDarkMode: false }),
+}));
+
+describe('HomePromoCarousel', () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    window.matchMedia = vi.fn().mockReturnValue({ matches: false });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('renderiza el slide de ranking activo por defecto', () => {
+    render(<HomePromoCarousel />);
+
+    expect(screen.getByText('Ranking AIQUAA')).toBeInTheDocument();
+    expect(
+      screen.getByLabelText('Ir a novedad 1: Ranking AIQUAA')
+    ).toHaveAttribute('aria-current', 'true');
+  });
+
+  it('incluye un link por cada evaluación destacada y por el ranking', () => {
+    const { container } = render(<HomePromoCarousel />);
+
+    const hrefs = Array.from(container.querySelectorAll('a[href]')).map((a) =>
+      a.getAttribute('href')
+    );
+
+    expect(hrefs).toContain('/ranking');
+    expect(hrefs).toContain('/assessments/api-testing-fundamentals');
+    expect(hrefs).toContain('/assessments/database-fundamentals');
+    expect(hrefs).toContain('/assessments/database-practice');
+    expect(hrefs).toContain('/assessments/infrastructure-fundamentals');
+    expect(hrefs).toContain('/assessments/api-developer-fundamentals');
+    expect(hrefs).toContain('/assessments/api-banking');
+  });
+
+  it('avanza de slide automáticamente con el tiempo', () => {
+    render(<HomePromoCarousel />);
+
+    act(() => {
+      vi.advanceTimersByTime(5000);
+    });
+
+    expect(
+      screen.getByLabelText('Ir a novedad 2: API Testing — Fundamentos')
+    ).toHaveAttribute('aria-current', 'true');
+  });
+
+  it('pausa el autoplay al pasar el mouse (hover)', () => {
+    render(<HomePromoCarousel />);
+
+    const region = screen.getByRole('region', { name: /Novedades/i });
+    fireEvent.mouseEnter(region);
+
+    act(() => {
+      vi.advanceTimersByTime(10000);
+    });
+
+    expect(
+      screen.getByLabelText('Ir a novedad 1: Ranking AIQUAA')
+    ).toHaveAttribute('aria-current', 'true');
+  });
+
+  it('navega manualmente con las flechas prev/next', async () => {
+    const user = userEvent.setup({ delay: null });
+    render(<HomePromoCarousel />);
+
+    await user.click(screen.getByLabelText('Siguiente novedad'));
+    expect(
+      screen.getByLabelText('Ir a novedad 2: API Testing — Fundamentos')
+    ).toHaveAttribute('aria-current', 'true');
+
+    await user.click(screen.getByLabelText('Novedad anterior'));
+    expect(
+      screen.getByLabelText('Ir a novedad 1: Ranking AIQUAA')
+    ).toHaveAttribute('aria-current', 'true');
+  });
+
+  it('navega con teclado (flecha derecha) sobre el carrusel', async () => {
+    const user = userEvent.setup({ delay: null });
+    render(<HomePromoCarousel />);
+
+    const region = screen.getByRole('region', { name: /Novedades/i });
+    region.focus();
+    await user.keyboard('{ArrowRight}');
+
+    expect(
+      screen.getByLabelText('Ir a novedad 2: API Testing — Fundamentos')
+    ).toHaveAttribute('aria-current', 'true');
+  });
+
+  it('permite ir directo a un slide haciendo click en su dot', async () => {
+    const user = userEvent.setup({ delay: null });
+    render(<HomePromoCarousel />);
+
+    await user.click(
+      screen.getByLabelText(/Ir a novedad 3: Bases de Datos — Fundamentos/i)
+    );
+
+    expect(
+      screen.getByLabelText(/Ir a novedad 3: Bases de Datos — Fundamentos/i)
+    ).toHaveAttribute('aria-current', 'true');
+  });
+});


### PR DESCRIPTION
## Summary
- Nuevo carrusel promocional en el home (`HomePromoCarousel`), insertado justo despues del Hero, antes de `ISTQBHighlight`.
- Publicita el catalogo de 6 evaluaciones tecnicas de `/assessments` (API Testing, API Banking, Database Fundamentals/Practice, Infrastructure Fundamentals, API Developer Fundamentals) y la pagina de `/ranking`, que hasta ahora no tenian visibilidad en el landing page.
- Autoplay (5s) con pausa on hover/focus, respeta `prefers-reduced-motion`, navegacion por flechas/dots/teclado (ArrowLeft/Right), accesible (`aria-roledescription`, `aria-current`, `aria-hidden` en slides inactivos).
- Los datos de cada slide de evaluacion (titulo, nivel, duracion, puntaje) se reusan directo de cada `assessment-definition.ts` para no duplicar contenido.

## Test plan
- [x] Tests unitarios nuevos (`apps/frontend/test/components/HomePromoCarousel.test.tsx`, 7 tests) — pasan.
- [x] Lint limpio en los archivos modificados.
- [x] Type-check limpio (`pnpm --filter @aiquaa/frontend type-check`).
- [x] Verificado visualmente con preview local: autoplay, flechas, dots, dark/light mode, responsive mobile (se corrigio un overlap de las flechas con el texto en mobile).
- [x] Confirmados los 7 links de destino (`/ranking` + 6 `/assessments/{slug}`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)