### PR TITLE
fix: harden exam persistence and company notifications

### DIFF
--- a/apps/frontend/next.config.mjs
+++ b/apps/frontend/next.config.mjs
@@ -58,13 +58,9 @@ const securityHeaders = [
 const nextConfig = {
   transpilePackages: ['@aiquaa/allpairs-core'],
   experimental: {
-    // Default is 1mb; the test-app bug report form attaches base64-encoded
-    // screenshots (up to 5MB each) to the saveExamResultAction payload,
-    // which was tripping the default limit and failing exam submissions
-    // for users who attached evidence images (see issue in QA-CYCLE log).
-    serverActions: {
-      bodySizeLimit: '4mb',
-    },
+    // Evidence images are uploaded to Supabase Storage before submit, so
+    // Server Actions can stay on the Next 13-compatible boolean setting.
+    serverActions: true,
   },
   images: {
     remotePatterns: [

--- a/apps/frontend/scripts/check-env.js
+++ b/apps/frontend/scripts/check-env.js
@@ -1,102 +1,130 @@
 #!/usr/bin/env node
 
 /**
- * Script para verificar que las variables de entorno estén configuradas
- * Se ejecuta antes del build para evitar errores en producción
+ * Verifies build-time environment variables without printing secrets.
  */
 
-// Cargar variables de entorno desde .env.local
 const fs = require('fs');
 const path = require('path');
 
 const envPath = path.join(__dirname, '..', '.env.local');
-console.log('🔍 Buscando archivo .env.local en:', envPath);
-console.log('📁 Archivo existe:', fs.existsSync(envPath));
+const requiredEnvVars = ['NEXT_PUBLIC_API_URL', 'NEXT_PUBLIC_BACKEND_URL'];
+const optionalEnvVars = [
+  'NEXT_PUBLIC_GA_MEASUREMENT_ID',
+  'NEXT_PUBLIC_SENTRY_DSN',
+  'REVALIDATE_TOKEN',
+];
+const oauthEnvVars = [
+  'NEXT_PUBLIC_GOOGLE_CLIENT_ID',
+  'NEXT_PUBLIC_GITHUB_CLIENT_ID',
+];
 
-if (fs.existsSync(envPath)) {
+function redactValue(varName, value) {
+  if (!value) return 'NO CONFIGURADA';
+
+  const isSensitive =
+    /SECRET|TOKEN|KEY|PASSWORD|POSTGRES|DATABASE|SUPABASE/i.test(varName) ||
+    value.length > 80;
+
+  if (isSensitive) {
+    return '[redacted]';
+  }
+
+  return value;
+}
+
+function loadLocalEnv() {
+  console.log(
+    'Checking .env.local:',
+    fs.existsSync(envPath) ? 'found' : 'not found'
+  );
+
+  if (!fs.existsSync(envPath)) {
+    return;
+  }
+
   const envContent = fs.readFileSync(envPath, 'utf8');
-  console.log('📄 Contenido del archivo:', envContent);
-  
-  envContent.split('\n').forEach(line => {
-    const [key, ...valueParts] = line.split('=');
-    if (key && valueParts.length > 0) {
-      const value = valueParts.join('=').trim();
-      if (value && !process.env[key]) {
-        process.env[key] = value;
-        console.log(`✅ Cargada variable: ${key}=${value}`);
-      }
+
+  envContent.split(/\r?\n/).forEach((rawLine) => {
+    const line = rawLine.trim();
+
+    if (!line || line.startsWith('#')) {
+      return;
+    }
+
+    const separatorIndex = line.indexOf('=');
+
+    if (separatorIndex === -1) {
+      return;
+    }
+
+    const key = line.slice(0, separatorIndex).trim();
+    const value = line
+      .slice(separatorIndex + 1)
+      .trim()
+      .replace(/^['"]|['"]$/g, '');
+
+    if (key && value && !process.env[key]) {
+      process.env[key] = value;
+      console.log(`Loaded ${key}: ${redactValue(key, value)}`);
     }
   });
 }
 
-const requiredEnvVars = [
-  'NEXT_PUBLIC_API_URL',
-  'NEXT_PUBLIC_BACKEND_URL'
-];
+function printEnvGroup(title, vars, options = {}) {
+  console.log(`\n${title}:`);
 
-const optionalEnvVars = [
-  'NEXT_PUBLIC_GA_MEASUREMENT_ID',
-  'NEXT_PUBLIC_SENTRY_DSN',
-  'REVALIDATE_TOKEN'
-];
+  let hasErrors = false;
 
-const oauthEnvVars = [
-  'NEXT_PUBLIC_GOOGLE_CLIENT_ID',
-  'NEXT_PUBLIC_GITHUB_CLIENT_ID'
-];
+  vars.forEach((varName) => {
+    const value = process.env[varName];
 
-console.log('🔍 Verificando variables de entorno...\n');
+    if (value) {
+      console.log(`  OK ${varName}: ${redactValue(varName, value)}`);
+      return;
+    }
 
-let hasErrors = false;
+    console.log(
+      `  ${options.required ? 'MISSING' : 'WARN'} ${varName}: NO CONFIGURADA`
+    );
+    hasErrors = hasErrors || Boolean(options.required);
+  });
 
-// Verificar variables requeridas
-console.log('📋 Variables requeridas:');
-requiredEnvVars.forEach(varName => {
-  const value = process.env[varName];
-  if (value) {
-    console.log(`  ✅ ${varName}: ${value}`);
-  } else {
-    console.log(`  ❌ ${varName}: NO CONFIGURADA`);
-    hasErrors = true;
+  return hasErrors;
+}
+
+loadLocalEnv();
+
+console.log('\nVerificando variables de entorno...');
+
+const hasRequiredErrors = printEnvGroup(
+  'Variables requeridas',
+  requiredEnvVars,
+  {
+    required: true,
   }
-});
+);
+printEnvGroup('Variables opcionales', optionalEnvVars);
+printEnvGroup('Variables de OAuth', oauthEnvVars);
 
-console.log('\n📋 Variables opcionales:');
-optionalEnvVars.forEach(varName => {
-  const value = process.env[varName];
-  if (value) {
-    console.log(`  ✅ ${varName}: ${value}`);
-  } else {
-    console.log(`  ⚠️  ${varName}: NO CONFIGURADA (opcional)`);
-  }
-});
+console.log('\nEntorno:', process.env.NODE_ENV || 'development');
 
-console.log('\n🔐 Variables de OAuth:');
-oauthEnvVars.forEach(varName => {
-  const value = process.env[varName];
-  if (value) {
-    console.log(`  ✅ ${varName}: ${value}`);
-  } else {
-    console.log(`  ⚠️  ${varName}: NO CONFIGURADA (OAuth no funcionará)`);
-  }
-});
-
-console.log('\n🌍 Entorno:', process.env.NODE_ENV || 'development');
-
-if (hasErrors) {
-  console.log('\n❌ ERROR: Algunas variables de entorno requeridas no están configuradas.');
-  console.log('💡 Solución: Configura las variables en Vercel o en tu archivo .env.local');
-  console.log('📖 Ver VERCEL_DEPLOYMENT.md para más detalles');
+if (hasRequiredErrors) {
+  console.log(
+    '\nERROR: Algunas variables de entorno requeridas no estan configuradas.'
+  );
+  console.log('Solucion: configura las variables en Vercel o en .env.local.');
   process.exit(1);
+}
+
+console.log('\nTodas las variables de entorno requeridas estan configuradas.');
+
+const oauthConfigured = oauthEnvVars.some((varName) => process.env[varName]);
+
+if (oauthConfigured) {
+  console.log('OAuth esta configurado.');
 } else {
-  console.log('\n✅ Todas las variables de entorno requeridas están configuradas.');
-  console.log('🚀 El build debería funcionar correctamente.');
-  
-  // Verificar si OAuth está configurado
-  const oauthConfigured = oauthEnvVars.some(varName => process.env[varName]);
-  if (oauthConfigured) {
-    console.log('🔐 OAuth está configurado y funcionará correctamente.');
-  } else {
-    console.log('⚠️  OAuth no está configurado. Los botones de Google/GitHub no funcionarán.');
-  }
+  console.log(
+    'OAuth no esta configurado. Los botones de Google/GitHub no funcionaran.'
+  );
 }

--- a/apps/frontend/src/actions/empresa-invitaciones.ts
+++ b/apps/frontend/src/actions/empresa-invitaciones.ts
@@ -43,7 +43,23 @@ async function sendInvitacionEmailIfEnabled(
   supabase: Awaited<ReturnType<typeof createClient>>,
   inv: EmpresaInvitacion
 ) {
-  if (!EMAIL_SENDING_ENABLED || !inv.token) return inv;
+  if (!EMAIL_SENDING_ENABLED || !inv.token) {
+    const emailError = !EMAIL_SENDING_ENABLED
+      ? 'EMAIL_SENDING_ENABLED is not true'
+      : 'Invitation token missing';
+    const updateResult = await supabase
+      .from('empresa_invitaciones')
+      .update({
+        email_sent: false,
+        email_error: emailError,
+      })
+      .eq('id', inv.id)
+      .select('*, hiring_processes(position_name, code)')
+      .single();
+    const updated = updateResult?.data;
+
+    return updated ? (updated as EmpresaInvitacion) : inv;
+  }
 
   const { data: empresaRow } = await supabase
     .from('empresas')
@@ -88,7 +104,7 @@ async function sendInvitacionEmailIfEnabled(
     html
   );
 
-  const { data: updated } = await supabase
+  const updateResult = await supabase
     .from('empresa_invitaciones')
     .update({
       email_sent: !emailErr,
@@ -97,6 +113,7 @@ async function sendInvitacionEmailIfEnabled(
     .eq('id', inv.id)
     .select('*, hiring_processes(position_name, code)')
     .single();
+  const updated = updateResult?.data;
 
   return updated ? (updated as EmpresaInvitacion) : inv;
 }
@@ -255,6 +272,46 @@ export async function cancelInvitacionAction(invitacionId: string): Promise<{
 
   if (error) return { error: error.message };
   return { error: null };
+}
+
+export async function resendInvitacionEmailAction(
+  invitacionId: string
+): Promise<{ data: EmpresaInvitacion | null; error: string | null }> {
+  const supabase = await createClient();
+  const {
+    data: { user },
+    error: authErr,
+  } = await supabase.auth.getUser();
+  if (authErr || !user) return { data: null, error: 'No autenticado' };
+
+  const membership = await getCallerEmpresaId(supabase, user.id);
+  if (!membership || !['owner', 'admin'].includes(membership.role)) {
+    return { data: null, error: 'Sin permisos' };
+  }
+
+  const { data, error } = await supabase
+    .from('empresa_invitaciones')
+    .select('*, hiring_processes(position_name, code)')
+    .eq('id', invitacionId)
+    .eq('empresa_id', membership.empresa_id)
+    .single();
+
+  if (error || !data) {
+    return { data: null, error: error?.message ?? 'Invitacion no encontrada' };
+  }
+
+  const inv = data as EmpresaInvitacion;
+  if (!['pendiente', 'vista'].includes(inv.status)) {
+    return {
+      data: inv,
+      error: 'Solo se pueden reenviar invitaciones pendientes o vistas',
+    };
+  }
+
+  return {
+    data: await sendInvitacionEmailIfEnabled(supabase, inv),
+    error: null,
+  };
 }
 
 export async function getPendingInvitacionesCountAction(): Promise<number> {

--- a/apps/frontend/src/actions/empresa-result-notifications.ts
+++ b/apps/frontend/src/actions/empresa-result-notifications.ts
@@ -1,0 +1,95 @@
+'use server';
+
+import { createAdminClient } from '@/lib/supabase/admin';
+import { sendEmail } from '@/lib/resend';
+
+type ResultNotificationInput = {
+  processCode?: string | null;
+  candidateName?: string | null;
+  candidateEmail?: string | null;
+  examType: string;
+  percentage: number;
+  passed: boolean;
+};
+
+function formatExamType(examType: string) {
+  return examType
+    .split('-')
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ');
+}
+
+export async function notifyEmpresaExamCompleted(
+  input: ResultNotificationInput
+) {
+  if (!input.processCode?.trim()) return;
+
+  try {
+    const supabase = createAdminClient();
+    const { data: processRow } = await supabase
+      .from('hiring_processes')
+      .select(
+        'id, empresa_id, position_name, code, empresas(razon_social, nombre_comercial)'
+      )
+      .ilike('code', input.processCode.trim())
+      .maybeSingle();
+
+    if (!processRow?.empresa_id) return;
+
+    const { data: members } = await supabase
+      .from('empresa_miembros')
+      .select('profiles(email, display_name)')
+      .eq('empresa_id', processRow.empresa_id)
+      .eq('status', 'active')
+      .in('role', ['owner', 'admin']);
+
+    const recipients = (members ?? [])
+      .map((member: any) => member.profiles?.email)
+      .filter((email: unknown): email is string => typeof email === 'string');
+
+    if (recipients.length === 0) return;
+
+    const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? 'https://aiquaa.com';
+    const processUrl = `${siteUrl}/empresa/procesos/${processRow.id}`;
+    const empresa = processRow.empresas as {
+      razon_social?: string | null;
+      nombre_comercial?: string | null;
+    } | null;
+    const empresaName =
+      empresa?.nombre_comercial || empresa?.razon_social || 'AIQUAA';
+    const candidateName =
+      input.candidateName || input.candidateEmail || 'Un candidato';
+    const resultLabel = input.passed ? 'aprobado' : 'no aprobado';
+    const subject = `${candidateName} completo ${formatExamType(input.examType)} (${Math.round(input.percentage)}%)`;
+    const html = `
+<!DOCTYPE html>
+<html lang="es">
+<head><meta charset="UTF-8" /></head>
+<body style="font-family:sans-serif;background:#f9fafb;padding:24px">
+  <div style="max-width:520px;margin:0 auto;background:#fff;border-radius:12px;padding:32px;border:1px solid #e5e7eb">
+    <p style="color:#6b7280;font-size:13px;margin:0 0 8px">${empresaName}</p>
+    <h2 style="margin:0 0 12px;font-size:20px;color:#111827">Nuevo resultado disponible</h2>
+    <p style="color:#374151;font-size:14px;line-height:1.6;margin:0 0 16px">
+      <strong>${candidateName}</strong> completo <strong>${formatExamType(input.examType)}</strong>
+      para el proceso <strong>${processRow.position_name}</strong>.
+    </p>
+    <p style="color:#374151;font-size:14px;line-height:1.6;margin:0 0 16px">
+      Resultado: <strong>${Math.round(input.percentage)}%</strong> (${resultLabel}).
+    </p>
+    <a href="${processUrl}" style="display:inline-block;background:#4f46e5;color:#fff;text-decoration:none;font-size:14px;font-weight:600;padding:12px 20px;border-radius:8px">
+      Ver proceso
+    </a>
+  </div>
+</body>
+</html>`;
+
+    await Promise.all(
+      Array.from(new Set(recipients)).map((recipient) =>
+        sendEmail(recipient, subject, html)
+      )
+    );
+  } catch (error) {
+    console.warn('[empresa-result-notifications] email failed', error);
+  }
+}

--- a/apps/frontend/src/actions/exam-review.ts
+++ b/apps/frontend/src/actions/exam-review.ts
@@ -1,6 +1,7 @@
 'use server';
 
 import { createClient } from '@/lib/supabase/server';
+import { createAdminClient } from '@/lib/supabase/admin';
 
 type BugReviewItem = {
   approved: boolean;
@@ -17,7 +18,11 @@ type ReviewData = {
 type BugImageEvidence = {
   id: string;
   fileName: string;
-  base64Data: string;
+  base64Data?: string;
+  storageBucket?: string;
+  storagePath?: string;
+  signedUrl?: string;
+  uploadError?: string;
   mimeType: string;
   size: number;
   uploadedAt: string;
@@ -90,7 +95,30 @@ export async function getExamDetailAction(
   if (error) return { data: null, error: error.message };
   if (!data) return { data: null, error: 'Resultado no encontrado' };
 
-  return { data: data as unknown as ExamDetail, error: null };
+  const detail = data as unknown as ExamDetail;
+  const bugs = detail.metadata?.bugs ?? [];
+  const images = bugs.flatMap((bug) => bug.images ?? []);
+  const storageImages = images.filter(
+    (image) => image.storageBucket && image.storagePath
+  );
+
+  if (storageImages.length > 0) {
+    try {
+      const admin = createAdminClient();
+      await Promise.all(
+        storageImages.map(async (image) => {
+          const { data: signed } = await admin.storage
+            .from(image.storageBucket!)
+            .createSignedUrl(image.storagePath!, 60 * 60);
+          image.signedUrl = signed?.signedUrl;
+        })
+      );
+    } catch (storageError) {
+      console.warn('[exam-review] evidence signed URL failed', storageError);
+    }
+  }
+
+  return { data: detail, error: null };
 }
 
 export async function saveExamReviewAction(

--- a/apps/frontend/src/actions/exams.ts
+++ b/apps/frontend/src/actions/exams.ts
@@ -6,6 +6,8 @@ import {
   getRankingAchievementsForUser,
   syncRankingAchievementsForUser,
 } from '@/lib/ranking-achievements';
+import { notifyEmpresaExamCompleted } from '@/actions/empresa-result-notifications';
+import { recalculateLegacyExamPayload } from '@/actions/lib/legacy-exam-scoring';
 
 interface SaveExamResultPayload {
   exam_type:
@@ -62,6 +64,7 @@ interface SaveExamResultPayload {
 const NEEDS_MANUAL_CORRECTION_EXAM_TYPES = new Set(['test-app']);
 
 export async function saveExamResultAction(payload: SaveExamResultPayload) {
+  const normalizedPayload = recalculateLegacyExamPayload(payload);
   const supabase = createClient();
   const {
     data: { user },
@@ -76,17 +79,18 @@ export async function saveExamResultAction(payload: SaveExamResultPayload) {
     .single();
 
   const resolvedName =
-    payload.participant_name?.trim() ||
+    normalizedPayload.participant_name?.trim() ||
     profile?.display_name?.trim() ||
     user.user_metadata?.full_name?.trim() ||
     null;
 
-  const resolvedEmail = payload.participant_email?.trim() || user.email || null;
+  const resolvedEmail =
+    normalizedPayload.participant_email?.trim() || user.email || null;
 
   // hiring_processes.code is stored with mixed case; match case-insensitively
   // and use the canonical stored value so it satisfies exam_results'
   // FK to hiring_processes(code) regardless of how the candidate typed it.
-  const rawProcessCode = payload.process_code?.trim() || undefined;
+  const rawProcessCode = normalizedPayload.process_code?.trim() || undefined;
   let resolvedProcessCode: string | undefined;
   if (rawProcessCode) {
     const { data: process } = await supabase
@@ -106,11 +110,13 @@ export async function saveExamResultAction(payload: SaveExamResultPayload) {
 
   const { error } = await supabase.from('exam_results').insert({
     user_id: user.id,
-    ...payload,
+    ...normalizedPayload,
     process_code: resolvedProcessCode,
     participant_name: resolvedName,
     participant_email: resolvedEmail,
-    review_status: NEEDS_MANUAL_CORRECTION_EXAM_TYPES.has(payload.exam_type)
+    review_status: NEEDS_MANUAL_CORRECTION_EXAM_TYPES.has(
+      normalizedPayload.exam_type
+    )
       ? 'pending_correction'
       : undefined,
   });
@@ -143,6 +149,17 @@ export async function saveExamResultAction(payload: SaveExamResultPayload) {
         invErr
       );
     }
+  }
+
+  if (resolvedProcessCode) {
+    await notifyEmpresaExamCompleted({
+      processCode: resolvedProcessCode,
+      candidateName: resolvedName,
+      candidateEmail: resolvedEmail,
+      examType: normalizedPayload.exam_type,
+      percentage: normalizedPayload.percentage,
+      passed: normalizedPayload.passed,
+    });
   }
 
   try {

--- a/apps/frontend/src/actions/lib/__tests__/legacy-exam-scoring.test.ts
+++ b/apps/frontend/src/actions/lib/__tests__/legacy-exam-scoring.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { recalculateLegacyExamPayload } from '../legacy-exam-scoring';
+import { loadExamData } from '@/app/labs/git/utils';
+
+describe('legacy exam server-side scoring', () => {
+  it('recalculates Git scores from the server question bank instead of trusting client totals', () => {
+    const firstQuestion = loadExamData().questions[0];
+    const recalculated = recalculateLegacyExamPayload({
+      exam_type: 'git',
+      exam_mode: 'exam',
+      participant_name: 'QA Tester',
+      github_profile: 'https://github.com/qa',
+      exam_purpose: 'practica',
+      score: 999,
+      total_questions: 1,
+      correct_answers: 999,
+      incorrect_answers: 0,
+      passed: true,
+      percentage: 100,
+      time_spent: 60,
+      answers: [
+        {
+          questionId: firstQuestion.id,
+          userAnswer: ['__wrong__'],
+        },
+      ],
+    });
+
+    expect(recalculated.score).toBe(0);
+    expect(recalculated.correct_answers).toBe(0);
+    expect(recalculated.incorrect_answers).toBe(1);
+    expect(recalculated.percentage).toBe(0);
+    expect(recalculated.passed).toBe(false);
+  });
+});

--- a/apps/frontend/src/actions/lib/legacy-exam-scoring.ts
+++ b/apps/frontend/src/actions/lib/legacy-exam-scoring.ts
@@ -1,0 +1,165 @@
+import {
+  generateExamResult as generateGitExamResult,
+  loadExamData as loadGitExamData,
+} from '@/app/labs/git/utils';
+import {
+  generateExamResult as generateIstqbExamResult,
+  loadExamData as loadIstqbExamData,
+} from '@/app/labs/istqb/utils';
+import {
+  generateExamResult as generatePerformanceExamResult,
+  loadExamData as loadPerformanceExamData,
+} from '@/app/labs/performance/utils';
+
+type LegacyExamType = 'git' | 'istqb' | 'performance';
+
+type LegacyAnswer = {
+  questionId?: unknown;
+  userAnswer?: unknown;
+  timeSpent?: unknown;
+};
+
+type LegacyPayload = {
+  exam_type: string;
+  participant_name?: string;
+  github_profile?: string;
+  exam_purpose?: string;
+  company_name?: string;
+  model?: string;
+  language?: string;
+  answers?: object;
+};
+
+function isLegacyExamType(value: string): value is LegacyExamType {
+  return value === 'git' || value === 'istqb' || value === 'performance';
+}
+
+function normalizeAnswerRows(answers: object | undefined): LegacyAnswer[] {
+  return Array.isArray(answers) ? (answers as LegacyAnswer[]) : [];
+}
+
+function answersToMap(rows: LegacyAnswer[]) {
+  const map = new Map<number, string[]>();
+  for (const row of rows) {
+    const questionId = Number(row.questionId);
+    const userAnswer = Array.isArray(row.userAnswer)
+      ? row.userAnswer.filter(
+          (item): item is string => typeof item === 'string'
+        )
+      : [];
+    if (Number.isFinite(questionId)) {
+      map.set(questionId, userAnswer);
+    }
+  }
+  return map;
+}
+
+function durationsToMap(rows: LegacyAnswer[]) {
+  const map = new Map<number, number>();
+  for (const row of rows) {
+    const questionId = Number(row.questionId);
+    const timeSpent = Number(row.timeSpent);
+    if (Number.isFinite(questionId) && Number.isFinite(timeSpent)) {
+      map.set(questionId, timeSpent);
+    }
+  }
+  return map;
+}
+
+export function recalculateLegacyExamPayload<T extends LegacyPayload>(
+  payload: T
+): T {
+  if (!isLegacyExamType(payload.exam_type)) return payload;
+
+  const answerRows = normalizeAnswerRows(payload.answers);
+  if (answerRows.length === 0) return payload;
+
+  const answerMap = answersToMap(answerRows);
+  const questionIds = new Set(answerRows.map((row) => Number(row.questionId)));
+  const questionDurations = durationsToMap(answerRows);
+
+  if (payload.exam_type === 'istqb') {
+    const language = payload.language === 'en' ? 'en' : 'es';
+    const model = ['A', 'B', 'C'].includes(String(payload.model))
+      ? String(payload.model).toLowerCase()
+      : 'a';
+    const examData = loadIstqbExamData(`${language}-model-${model}`);
+    const questions = examData.questions.filter((question) =>
+      questionIds.has(question.id)
+    );
+    const result = generateIstqbExamResult(
+      payload.participant_name ?? '',
+      questions,
+      answerMap,
+      0,
+      examData.examInfo.passingScore,
+      questionDurations
+    );
+    return {
+      ...payload,
+      score: result.score,
+      total_questions: result.totalQuestions,
+      correct_answers: result.correctAnswers,
+      incorrect_answers: result.incorrectAnswers,
+      passed: result.passed,
+      percentage: result.percentage,
+      answers: result.answers,
+      learning_objectives: result.learningObjectiveAnalysis,
+    };
+  }
+
+  if (payload.exam_type === 'git') {
+    const examData = loadGitExamData();
+    const questions = examData.questions.filter((question) =>
+      questionIds.has(question.id)
+    );
+    const result = generateGitExamResult(
+      payload.participant_name ?? '',
+      payload.github_profile ?? '',
+      (payload.exam_purpose as 'capacitacion') ?? 'capacitacion',
+      payload.company_name,
+      questions,
+      answerMap,
+      0,
+      examData.examInfo.passingScore
+    );
+    return {
+      ...payload,
+      score: result.score,
+      total_questions: result.totalQuestions,
+      correct_answers: result.correctAnswers,
+      incorrect_answers: result.incorrectAnswers,
+      passed: result.passed,
+      percentage: result.percentage,
+      answers: result.answers,
+      learning_objectives: result.learningObjectiveAnalysis,
+    };
+  }
+
+  const examData = loadPerformanceExamData();
+  const questions = examData.questions.filter((question) =>
+    questionIds.has(question.id)
+  );
+  const result = generatePerformanceExamResult(
+    payload.participant_name ?? '',
+    payload.github_profile ?? '',
+    (payload.exam_purpose as 'capacitacion') ?? 'capacitacion',
+    payload.company_name,
+    questions,
+    answerMap,
+    0,
+    examData.examInfo.passingScore
+  );
+  return {
+    ...payload,
+    score: result.score,
+    total_questions: result.totalQuestions,
+    max_possible_score: result.maxPossibleScore,
+    correct_answers: result.correctAnswers,
+    incorrect_answers: result.incorrectAnswers,
+    passed: result.passed,
+    percentage: result.percentage,
+    answers: result.answers,
+    learning_objectives: result.learningObjectiveAnalysis,
+  };
+}

--- a/apps/frontend/src/app/api/assessments/[attemptId]/submit/route.ts
+++ b/apps/frontend/src/app/api/assessments/[attemptId]/submit/route.ts
@@ -16,6 +16,7 @@ import {
   ensureXpRules,
   grantGamificationXpEvent,
 } from '@/lib/gamification/grant-xp';
+import { notifyEmpresaExamCompleted } from '@/actions/empresa-result-notifications';
 import { selectAttemptForSubmitWithApiTargetFallback } from '../../_lib/apiTargetPersistence';
 
 export const runtime = 'nodejs';
@@ -199,6 +200,15 @@ export async function POST(
         '[api-banking] no se pudo guardar exam_results',
         examResultError.message
       );
+    } else {
+      await notifyEmpresaExamCompleted({
+        processCode: attempt.process_code ?? null,
+        candidateName: attempt.candidate_name,
+        candidateEmail: attempt.candidate_email,
+        examType: 'api-banking',
+        percentage: totalScore,
+        passed,
+      });
     }
 
     try {

--- a/apps/frontend/src/app/api/labs/test-app/admin/verify/route.ts
+++ b/apps/frontend/src/app/api/labs/test-app/admin/verify/route.ts
@@ -3,7 +3,7 @@ import { NextRequest, NextResponse } from 'next/server';
 /**
  * POST /api/labs/test-app/admin/verify
  *
- * Verifies the admin key server-side (ADMIN_KEY is a server-only env var,
+ * Verifies the admin key server-side (TEST_APP_ADMIN_KEY is a server-only env var,
  * never exposed to the client bundle). On success, sets an httpOnly cookie
  * so the client doesn't need to keep resubmitting the key.
  *
@@ -22,7 +22,8 @@ export async function POST(request: NextRequest) {
   try {
     const body = await request.json();
     const key = typeof body?.key === 'string' ? body.key : '';
-    const adminKey = process.env.ADMIN_KEY || '';
+    const adminKey =
+      process.env.TEST_APP_ADMIN_KEY || process.env.ADMIN_KEY || '';
 
     // Empty ADMIN_KEY means admin is disabled — reject even empty-string match
     if (!adminKey || key !== adminKey) {

--- a/apps/frontend/src/app/empresa/evaluar/[resultId]/page.tsx
+++ b/apps/frontend/src/app/empresa/evaluar/[resultId]/page.tsx
@@ -613,26 +613,31 @@ export default function EvaluarPage() {
                               Imágenes evidencia ({bug.images.length})
                             </p>
                             <div className="grid grid-cols-2 sm:grid-cols-3 gap-3 mt-2">
-                              {bug.images.map((image) => (
-                                <a
-                                  key={image.id}
-                                  href={image.base64Data}
-                                  target="_blank"
-                                  rel="noopener noreferrer"
-                                  className="block rounded-lg overflow-hidden border border-slate-600/40"
-                                >
-                                  <img
-                                    src={image.base64Data}
-                                    alt={image.fileName}
-                                    className="w-full h-32 object-cover"
-                                  />
-                                  <p
-                                    className={`text-xs px-1.5 py-1 truncate ${isDarkMode ? 'bg-slate-800 text-slate-400' : 'bg-gray-100 text-gray-600'}`}
+                              {bug.images.map((image) => {
+                                const imageUrl =
+                                  image.signedUrl ?? image.base64Data;
+                                if (!imageUrl) return null;
+                                return (
+                                  <a
+                                    key={image.id}
+                                    href={imageUrl}
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    className="block rounded-lg overflow-hidden border border-slate-600/40"
                                   >
-                                    {image.fileName}
-                                  </p>
-                                </a>
-                              ))}
+                                    <img
+                                      src={imageUrl}
+                                      alt={image.fileName}
+                                      className="w-full h-32 object-cover"
+                                    />
+                                    <p
+                                      className={`text-xs px-1.5 py-1 truncate ${isDarkMode ? 'bg-slate-800 text-slate-400' : 'bg-gray-100 text-gray-600'}`}
+                                    >
+                                      {image.fileName}
+                                    </p>
+                                  </a>
+                                );
+                              })}
                             </div>
                           </div>
                         )}

--- a/apps/frontend/src/app/empresa/invitaciones/page.tsx
+++ b/apps/frontend/src/app/empresa/invitaciones/page.tsx
@@ -8,19 +8,41 @@ import {
   getEmpresaInvitacionesAction,
   createInvitacionAction,
   cancelInvitacionAction,
+  resendInvitacionEmailAction,
   type EmpresaInvitacion,
 } from '@/actions/empresa-invitaciones';
 
-type HiringProcess = { id: string; code: string; position_name: string; status: string };
+type HiringProcess = {
+  id: string;
+  code: string;
+  position_name: string;
+  status: string;
+};
 
 const STATUS_CONFIG: Record<
   string,
   { label: string; color: string; darkColor: string }
 > = {
-  pendiente: { label: 'Pendiente', color: 'bg-amber-100 text-amber-700', darkColor: 'bg-amber-900/40 text-amber-300' },
-  vista: { label: 'Vista', color: 'bg-blue-100 text-blue-700', darkColor: 'bg-blue-900/40 text-blue-300' },
-  completada: { label: 'Completada', color: 'bg-green-100 text-green-700', darkColor: 'bg-green-900/40 text-green-300' },
-  rechazada: { label: 'Rechazada', color: 'bg-red-100 text-red-600', darkColor: 'bg-red-900/40 text-red-300' },
+  pendiente: {
+    label: 'Pendiente',
+    color: 'bg-amber-100 text-amber-700',
+    darkColor: 'bg-amber-900/40 text-amber-300',
+  },
+  vista: {
+    label: 'Vista',
+    color: 'bg-blue-100 text-blue-700',
+    darkColor: 'bg-blue-900/40 text-blue-300',
+  },
+  completada: {
+    label: 'Completada',
+    color: 'bg-green-100 text-green-700',
+    darkColor: 'bg-green-900/40 text-green-300',
+  },
+  rechazada: {
+    label: 'Rechazada',
+    color: 'bg-red-100 text-red-600',
+    darkColor: 'bg-red-900/40 text-red-300',
+  },
 };
 
 function InvitarModal({
@@ -50,7 +72,10 @@ function InvitarModal({
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    if (!email.trim()) { setError('El email es requerido'); return; }
+    if (!email.trim()) {
+      setError('El email es requerido');
+      return;
+    }
 
     setSaving(true);
     setError(null);
@@ -63,44 +88,83 @@ function InvitarModal({
     });
 
     setSaving(false);
-    if (err || !data) { setError(err ?? 'Error al crear la invitación'); return; }
+    if (err || !data) {
+      setError(err ?? 'Error al crear la invitación');
+      return;
+    }
     onCreated(data);
     onClose();
   };
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
-      <div className={`w-full max-w-lg rounded-2xl shadow-2xl ${isDarkMode ? 'bg-slate-800' : 'bg-white'}`}>
-        <div className={`flex items-center justify-between px-6 py-4 border-b ${isDarkMode ? 'border-slate-700' : 'border-gray-200'}`}>
-          <h2 className={`font-semibold text-base ${isDarkMode ? 'text-white' : 'text-gray-900'}`}>
+      <div
+        className={`w-full max-w-lg rounded-2xl shadow-2xl ${isDarkMode ? 'bg-slate-800' : 'bg-white'}`}
+      >
+        <div
+          className={`flex items-center justify-between px-6 py-4 border-b ${isDarkMode ? 'border-slate-700' : 'border-gray-200'}`}
+        >
+          <h2
+            className={`font-semibold text-base ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
+          >
             Invitar candidato
           </h2>
-          <button onClick={onClose} className={`text-lg ${isDarkMode ? 'text-slate-400 hover:text-white' : 'text-gray-400 hover:text-gray-600'}`}>✕</button>
+          <button
+            onClick={onClose}
+            className={`text-lg ${isDarkMode ? 'text-slate-400 hover:text-white' : 'text-gray-400 hover:text-gray-600'}`}
+          >
+            ✕
+          </button>
         </div>
 
         <form onSubmit={handleSubmit} className="px-6 py-5 space-y-4">
           <div>
             <label className={labelClass}>Email del candidato *</label>
-            <input type="email" value={email} onChange={(e) => setEmail(e.target.value)} placeholder="candidato@ejemplo.com" className={inputClass} autoFocus />
+            <input
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              placeholder="candidato@ejemplo.com"
+              className={inputClass}
+              autoFocus
+            />
           </div>
 
           <div>
             <label className={labelClass}>Nombre del candidato</label>
-            <input type="text" value={name} onChange={(e) => setName(e.target.value)} placeholder="Ej: María García" className={inputClass} />
+            <input
+              type="text"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="Ej: María García"
+              className={inputClass}
+            />
           </div>
 
           <div>
-            <label className={labelClass}>Proceso de selección (opcional)</label>
-            <select value={processId} onChange={(e) => setProcessId(e.target.value)} className={inputClass}>
+            <label className={labelClass}>
+              Proceso de selección (opcional)
+            </label>
+            <select
+              value={processId}
+              onChange={(e) => setProcessId(e.target.value)}
+              className={inputClass}
+            >
               <option value="">Sin proceso asignado</option>
-              {processes.filter((p) => p.status === 'active').map((p) => (
-                <option key={p.id} value={p.id}>{p.position_name} ({p.code})</option>
-              ))}
+              {processes
+                .filter((p) => p.status === 'active')
+                .map((p) => (
+                  <option key={p.id} value={p.id}>
+                    {p.position_name} ({p.code})
+                  </option>
+                ))}
             </select>
           </div>
 
           <div>
-            <label className={labelClass}>Mensaje personalizado (opcional)</label>
+            <label className={labelClass}>
+              Mensaje personalizado (opcional)
+            </label>
             <textarea
               value={message}
               onChange={(e) => setMessage(e.target.value)}
@@ -114,10 +178,18 @@ function InvitarModal({
           {error && <p className="text-sm text-red-500">{error}</p>}
 
           <div className="flex justify-end gap-2 pt-1">
-            <button type="button" onClick={onClose} className={`px-4 py-2 rounded-lg text-sm font-medium transition-colors ${isDarkMode ? 'text-slate-300 hover:bg-slate-700' : 'text-gray-600 hover:bg-gray-100'}`}>
+            <button
+              type="button"
+              onClick={onClose}
+              className={`px-4 py-2 rounded-lg text-sm font-medium transition-colors ${isDarkMode ? 'text-slate-300 hover:bg-slate-700' : 'text-gray-600 hover:bg-gray-100'}`}
+            >
               Cancelar
             </button>
-            <button type="submit" disabled={saving} className="px-4 py-2 rounded-lg text-sm font-medium bg-indigo-600 text-white hover:bg-indigo-700 disabled:opacity-50 transition-colors">
+            <button
+              type="submit"
+              disabled={saving}
+              className="px-4 py-2 rounded-lg text-sm font-medium bg-indigo-600 text-white hover:bg-indigo-700 disabled:opacity-50 transition-colors"
+            >
               {saving ? 'Enviando...' : 'Enviar invitación'}
             </button>
           </div>
@@ -134,6 +206,7 @@ export default function InvitacionesPage() {
   const [loading, setLoading] = useState(true);
   const [showModal, setShowModal] = useState(false);
   const [cancellingId, setCancellingId] = useState<string | null>(null);
+  const [resendingId, setResendingId] = useState<string | null>(null);
   const [filterStatus, setFilterStatus] = useState<string>('all');
 
   useEffect(() => {
@@ -141,7 +214,10 @@ export default function InvitacionesPage() {
       const supabase = createClient();
       const [{ data: invs }, { data: procs }] = await Promise.all([
         getEmpresaInvitacionesAction(),
-        supabase.from('hiring_processes').select('id, code, position_name, status').order('created_at', { ascending: false }),
+        supabase
+          .from('hiring_processes')
+          .select('id, code, position_name, status')
+          .order('created_at', { ascending: false }),
       ]);
       setInvitaciones(invs ?? []);
       setProcesses(procs ?? []);
@@ -158,26 +234,46 @@ export default function InvitacionesPage() {
     setCancellingId(null);
   };
 
+  const handleResend = async (id: string) => {
+    setResendingId(id);
+    const { data } = await resendInvitacionEmailAction(id);
+    if (data) {
+      setInvitaciones((prev) =>
+        prev.map((item) => (item.id === data.id ? data : item))
+      );
+    }
+    setResendingId(null);
+  };
+
   const filtered = invitaciones.filter(
     (i) => filterStatus === 'all' || i.status === filterStatus
   );
 
-  const card = isDarkMode ? 'bg-dark-secondary border-slate-700' : 'bg-white border-gray-200';
+  const card = isDarkMode
+    ? 'bg-dark-secondary border-slate-700'
+    : 'bg-white border-gray-200';
   const inputClass = `rounded-lg border px-3 py-2 text-sm outline-none transition-colors focus:ring-2 focus:ring-indigo-500 ${
-    isDarkMode ? 'bg-slate-700 border-slate-600 text-white' : 'bg-white border-gray-300 text-gray-900'
+    isDarkMode
+      ? 'bg-slate-700 border-slate-600 text-white'
+      : 'bg-white border-gray-300 text-gray-900'
   }`;
 
   return (
-    <div className={`min-h-screen transition-colors duration-300 ${isDarkMode ? 'bg-dark-bg' : 'bg-gray-50'}`}>
+    <div
+      className={`min-h-screen transition-colors duration-300 ${isDarkMode ? 'bg-dark-bg' : 'bg-gray-50'}`}
+    >
       <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-12 space-y-6">
-
         {/* Header */}
         <div className="flex items-center justify-between">
           <div>
-            <h1 className={`text-2xl font-bold ${isDarkMode ? 'text-white' : 'text-gray-900'}`}>
+            <h1
+              className={`text-2xl font-bold ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
+            >
               Invitaciones a candidatos
             </h1>
-            <p className={`text-sm mt-1 ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}>
+            <p
+              className={`text-sm mt-1 ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}
+            >
               Invitá candidatos QA directamente a rendir tu evaluación
             </p>
           </div>
@@ -193,9 +289,23 @@ export default function InvitacionesPage() {
         {!loading && invitaciones.length > 0 && (
           <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
             {[
-              { label: 'Total', value: invitaciones.length, color: 'text-indigo-500' },
-              { label: 'Pendientes', value: invitaciones.filter((i) => i.status === 'pendiente').length, color: 'text-amber-500' },
-              { label: 'Completadas', value: invitaciones.filter((i) => i.status === 'completada').length, color: 'text-green-500' },
+              {
+                label: 'Total',
+                value: invitaciones.length,
+                color: 'text-indigo-500',
+              },
+              {
+                label: 'Pendientes',
+                value: invitaciones.filter((i) => i.status === 'pendiente')
+                  .length,
+                color: 'text-amber-500',
+              },
+              {
+                label: 'Completadas',
+                value: invitaciones.filter((i) => i.status === 'completada')
+                  .length,
+                color: 'text-green-500',
+              },
               {
                 label: 'Tasa respuesta',
                 value: `${Math.round((invitaciones.filter((i) => i.status === 'completada').length / invitaciones.length) * 100)}%`,
@@ -204,7 +314,11 @@ export default function InvitacionesPage() {
             ].map(({ label, value, color }) => (
               <div key={label} className={`rounded-xl border p-4 ${card}`}>
                 <p className={`text-xl font-bold ${color}`}>{value}</p>
-                <p className={`text-xs mt-1 ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}>{label}</p>
+                <p
+                  className={`text-xs mt-1 ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}
+                >
+                  {label}
+                </p>
               </div>
             ))}
           </div>
@@ -213,10 +327,16 @@ export default function InvitacionesPage() {
         {/* Filter */}
         {invitaciones.length > 0 && (
           <div className={`rounded-xl border p-4 ${card}`}>
-            <select value={filterStatus} onChange={(e) => setFilterStatus(e.target.value)} className={inputClass}>
+            <select
+              value={filterStatus}
+              onChange={(e) => setFilterStatus(e.target.value)}
+              className={inputClass}
+            >
               <option value="all">Todos los estados</option>
               {Object.entries(STATUS_CONFIG).map(([val, cfg]) => (
-                <option key={val} value={val}>{cfg.label}</option>
+                <option key={val} value={val}>
+                  {cfg.label}
+                </option>
               ))}
             </select>
           </div>
@@ -224,12 +344,20 @@ export default function InvitacionesPage() {
 
         {/* Content */}
         {loading ? (
-          <div className={`text-center py-16 ${isDarkMode ? 'text-slate-400' : 'text-gray-400'}`}>Cargando...</div>
+          <div
+            className={`text-center py-16 ${isDarkMode ? 'text-slate-400' : 'text-gray-400'}`}
+          >
+            Cargando...
+          </div>
         ) : invitaciones.length === 0 ? (
-          <div className={`text-center py-16 rounded-xl border-2 border-dashed ${isDarkMode ? 'border-slate-700 text-slate-500' : 'border-gray-200 text-gray-400'}`}>
+          <div
+            className={`text-center py-16 rounded-xl border-2 border-dashed ${isDarkMode ? 'border-slate-700 text-slate-500' : 'border-gray-200 text-gray-400'}`}
+          >
             <p className="text-4xl mb-3">📧</p>
             <p className="font-medium mb-1">Sin invitaciones enviadas</p>
-            <p className="text-sm mb-6">Invitá candidatos QA directamente para que rindan tu evaluación</p>
+            <p className="text-sm mb-6">
+              Invitá candidatos QA directamente para que rindan tu evaluación
+            </p>
             <button
               onClick={() => setShowModal(true)}
               className="inline-flex items-center gap-2 px-5 py-2.5 rounded-lg text-sm font-semibold bg-indigo-600 text-white hover:bg-indigo-700 transition-colors"
@@ -239,7 +367,11 @@ export default function InvitacionesPage() {
           </div>
         ) : filtered.length === 0 ? (
           <div className={`text-center py-12 rounded-xl border ${card}`}>
-            <p className={`text-sm ${isDarkMode ? 'text-slate-500' : 'text-gray-400'}`}>Sin invitaciones para el filtro seleccionado</p>
+            <p
+              className={`text-sm ${isDarkMode ? 'text-slate-500' : 'text-gray-400'}`}
+            >
+              Sin invitaciones para el filtro seleccionado
+            </p>
           </div>
         ) : (
           <div className={`rounded-xl border overflow-hidden ${card}`}>
@@ -247,44 +379,114 @@ export default function InvitacionesPage() {
               <table className="w-full text-sm">
                 <thead>
                   <tr className={isDarkMode ? 'bg-slate-800/60' : 'bg-gray-50'}>
-                    {['Candidato', 'Proceso', 'Estado', 'Enviada', ''].map((h) => (
-                      <th key={h} className={`px-5 py-3 text-left text-xs font-semibold uppercase tracking-wide ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}>{h}</th>
+                    {[
+                      'Candidato',
+                      'Proceso',
+                      'Estado',
+                      'Email',
+                      'Enviada',
+                      '',
+                    ].map((h) => (
+                      <th
+                        key={h}
+                        className={`px-5 py-3 text-left text-xs font-semibold uppercase tracking-wide ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}
+                      >
+                        {h}
+                      </th>
                     ))}
                   </tr>
                 </thead>
                 <tbody>
                   {filtered.map((inv, i) => {
-                    const sc = STATUS_CONFIG[inv.status] ?? STATUS_CONFIG.pendiente;
+                    const sc =
+                      STATUS_CONFIG[inv.status] ?? STATUS_CONFIG.pendiente;
                     return (
                       <tr
                         key={inv.id}
                         className={`border-t ${isDarkMode ? 'border-slate-700' : 'border-gray-100'} ${
                           i % 2 === 0
-                            ? isDarkMode ? 'bg-dark-secondary' : 'bg-white'
-                            : isDarkMode ? 'bg-slate-800/30' : 'bg-gray-50/50'
+                            ? isDarkMode
+                              ? 'bg-dark-secondary'
+                              : 'bg-white'
+                            : isDarkMode
+                              ? 'bg-slate-800/30'
+                              : 'bg-gray-50/50'
                         }`}
                       >
                         <td className="px-5 py-3">
-                          <div className={`font-medium ${isDarkMode ? 'text-white' : 'text-gray-900'}`}>
+                          <div
+                            className={`font-medium ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
+                          >
                             {inv.candidate_name || inv.candidate_email}
                           </div>
                           {inv.candidate_name && (
-                            <div className={`text-xs ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}>{inv.candidate_email}</div>
+                            <div
+                              className={`text-xs ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}
+                            >
+                              {inv.candidate_email}
+                            </div>
                           )}
                         </td>
-                        <td className={`px-5 py-3 text-xs ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}>
+                        <td
+                          className={`px-5 py-3 text-xs ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}
+                        >
                           {inv.hiring_processes ? (
-                            <Link href={`/empresa/procesos/${inv.process_id}`} className={`hover:underline ${isDarkMode ? 'text-indigo-400' : 'text-indigo-600'}`}>
+                            <Link
+                              href={`/empresa/procesos/${inv.process_id}`}
+                              className={`hover:underline ${isDarkMode ? 'text-indigo-400' : 'text-indigo-600'}`}
+                            >
                               {inv.hiring_processes.position_name}
                             </Link>
-                          ) : '—'}
+                          ) : (
+                            '—'
+                          )}
                         </td>
                         <td className="px-5 py-3">
-                          <span className={`text-xs font-medium px-2 py-0.5 rounded-full ${isDarkMode ? sc.darkColor : sc.color}`}>
+                          <span
+                            className={`text-xs font-medium px-2 py-0.5 rounded-full ${isDarkMode ? sc.darkColor : sc.color}`}
+                          >
                             {sc.label}
                           </span>
                         </td>
-                        <td className={`px-5 py-3 text-xs ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}>
+                        <td className="px-5 py-3">
+                          {inv.email_sent ? (
+                            <span
+                              className={`text-xs font-medium px-2 py-0.5 rounded-full ${isDarkMode ? 'bg-emerald-900/40 text-emerald-300' : 'bg-emerald-100 text-emerald-700'}`}
+                            >
+                              Enviado
+                            </span>
+                          ) : (
+                            <div className="space-y-1">
+                              <span
+                                className={`inline-flex text-xs font-medium px-2 py-0.5 rounded-full ${isDarkMode ? 'bg-red-900/40 text-red-300' : 'bg-red-100 text-red-700'}`}
+                                title={inv.email_error ?? undefined}
+                              >
+                                No entregado
+                              </span>
+                              {['pendiente', 'vista'].includes(inv.status) && (
+                                <button
+                                  onClick={() => handleResend(inv.id)}
+                                  disabled={resendingId === inv.id}
+                                  className={`block text-[11px] font-medium transition-colors ${isDarkMode ? 'text-indigo-400 hover:text-indigo-300' : 'text-indigo-600 hover:text-indigo-700'}`}
+                                >
+                                  {resendingId === inv.id
+                                    ? 'Reenviando...'
+                                    : 'Reenviar email'}
+                                </button>
+                              )}
+                              {inv.email_error && (
+                                <div
+                                  className={`max-w-[180px] truncate text-[11px] ${isDarkMode ? 'text-slate-500' : 'text-gray-400'}`}
+                                >
+                                  {inv.email_error}
+                                </div>
+                              )}
+                            </div>
+                          )}
+                        </td>
+                        <td
+                          className={`px-5 py-3 text-xs ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}
+                        >
                           {new Date(inv.sent_at).toLocaleDateString('es-PY')}
                         </td>
                         <td className="px-5 py-3">
@@ -309,7 +511,10 @@ export default function InvitacionesPage() {
         )}
 
         <div>
-          <Link href="/empresa" className={`text-sm ${isDarkMode ? 'text-slate-500 hover:text-slate-300' : 'text-gray-400 hover:text-gray-600'} transition-colors`}>
+          <Link
+            href="/empresa"
+            className={`text-sm ${isDarkMode ? 'text-slate-500 hover:text-slate-300' : 'text-gray-400 hover:text-gray-600'} transition-colors`}
+          >
             ← Volver al panel
           </Link>
         </div>

--- a/apps/frontend/src/app/labs/git/GitClient.tsx
+++ b/apps/frontend/src/app/labs/git/GitClient.tsx
@@ -60,6 +60,7 @@ export default function GitClient() {
       github_profile: result.githubProfile,
       exam_purpose: result.examPurpose,
       company_name: result.companyName,
+      answers: result.answers as any,
       learning_objectives: result.learningObjectiveAnalysis,
       process_code: processCode.trim() || undefined,
     });

--- a/apps/frontend/src/app/labs/git/components/ResultsScreen.tsx
+++ b/apps/frontend/src/app/labs/git/components/ResultsScreen.tsx
@@ -1,10 +1,9 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import { useTheme } from '@/contexts/ThemeContext';
 import type { ExamResult } from '../types';
 import { exportToCSV, downloadCSV, formatTime, exportToPDF } from '../utils';
-import { saveExamResultAction } from '@/actions/exams';
 
 interface ResultsScreenProps {
   result: ExamResult;
@@ -18,28 +17,9 @@ export default function ResultsScreen({
   mode,
 }: ResultsScreenProps) {
   const { isDarkMode } = useTheme();
-  const [activeTab, setActiveTab] = useState<'summary' | 'learning-objectives' | 'details'>('summary');
-
-  useEffect(() => {
-    saveExamResultAction({
-      exam_type: 'git',
-      exam_mode: mode,
-      participant_name: result.participantName,
-      github_profile: result.githubProfile,
-      exam_purpose: result.examPurpose,
-      company_name: result.companyName,
-      score: result.score,
-      total_questions: result.totalQuestions,
-      correct_answers: result.correctAnswers,
-      incorrect_answers: result.incorrectAnswers,
-      passing_score: 26,
-      passed: result.passed,
-      percentage: result.percentage,
-      time_spent: result.timeSpent,
-      answers: result.answers as any,
-      learning_objectives: result.learningObjectiveAnalysis as any,
-    }).catch((err) => console.error('Error guardando resultado Git:', err));
-  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+  const [activeTab, setActiveTab] = useState<
+    'summary' | 'learning-objectives' | 'details'
+  >('summary');
 
   const handleExportCSV = () => {
     const csv = exportToCSV(result);
@@ -57,20 +37,30 @@ export default function ResultsScreen({
   };
 
   return (
-    <div className={`min-h-screen py-8 transition-colors ${isDarkMode ? 'bg-slate-900' : 'bg-gray-50'}`}>
+    <div
+      className={`min-h-screen py-8 transition-colors ${isDarkMode ? 'bg-slate-900' : 'bg-gray-50'}`}
+    >
       <div className="container mx-auto px-4 max-w-6xl">
         <div className="mb-8 text-center">
-          <h1 className={`text-4xl font-bold mb-2 ${isDarkMode ? 'text-white' : 'text-gray-900'}`}>
+          <h1
+            className={`text-4xl font-bold mb-2 ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
+          >
             AIQUAA | Examen Técnico GIT
           </h1>
-          <p className={isDarkMode ? 'text-slate-400' : 'text-gray-600'}>Resultados del Examen</p>
+          <p className={isDarkMode ? 'text-slate-400' : 'text-gray-600'}>
+            Resultados del Examen
+          </p>
         </div>
 
-        <div className={`rounded-lg shadow-lg mb-6 ${isDarkMode ? 'bg-slate-800' : 'bg-white'}`}>
+        <div
+          className={`rounded-lg shadow-lg mb-6 ${isDarkMode ? 'bg-slate-800' : 'bg-white'}`}
+        >
           <div className="p-6 border-b border-gray-200 dark:border-gray-700">
             <div className="flex flex-col md:flex-row items-start md:items-center justify-between gap-4">
               <div>
-                <h2 className={`text-2xl font-bold ${isDarkMode ? 'text-white' : 'text-gray-900'}`}>
+                <h2
+                  className={`text-2xl font-bold ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
+                >
                   {result.participantName}
                 </h2>
                 <a
@@ -79,24 +69,45 @@ export default function ResultsScreen({
                   rel="noopener noreferrer"
                   className={`text-sm ${isDarkMode ? 'text-blue-400 hover:text-blue-300' : 'text-blue-600 hover:text-blue-700'} flex items-center gap-1`}
                 >
-                  <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 24 24">
-                    <path fillRule="evenodd" clipRule="evenodd" d="M12 2C6.477 2 2 6.477 2 12c0 4.42 2.865 8.17 6.839 9.49.5.092.682-.217.682-.482 0-.237-.008-.866-.013-1.7-2.782.603-3.369-1.34-3.369-1.34-.454-1.156-1.11-1.463-1.11-1.463-.908-.62.069-.608.069-.608 1.003.07 1.531 1.03 1.531 1.03.892 1.529 2.341 1.087 2.91.831.092-.646.35-1.086.636-1.336-2.22-.253-4.555-1.11-4.555-4.943 0-1.091.39-1.984 1.029-2.683-.103-.253-.446-1.27.098-2.647 0 0 .84-.269 2.75 1.025A9.578 9.578 0 0112 6.836c.85.004 1.705.114 2.504.336 1.909-1.294 2.747-1.025 2.747-1.025.546 1.377.203 2.394.1 2.647.64.699 1.028 1.592 1.028 2.683 0 3.842-2.339 4.687-4.566 4.935.359.309.678.919.678 1.852 0 1.336-.012 2.415-.012 2.743 0 .267.18.578.688.48C19.138 20.167 22 16.418 22 12c0-5.523-4.477-10-10-10z"/>
+                  <svg
+                    className="w-4 h-4"
+                    fill="currentColor"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      fillRule="evenodd"
+                      clipRule="evenodd"
+                      d="M12 2C6.477 2 2 6.477 2 12c0 4.42 2.865 8.17 6.839 9.49.5.092.682-.217.682-.482 0-.237-.008-.866-.013-1.7-2.782.603-3.369-1.34-3.369-1.34-.454-1.156-1.11-1.463-1.11-1.463-.908-.62.069-.608.069-.608 1.003.07 1.531 1.03 1.531 1.03.892 1.529 2.341 1.087 2.91.831.092-.646.35-1.086.636-1.336-2.22-.253-4.555-1.11-4.555-4.943 0-1.091.39-1.984 1.029-2.683-.103-.253-.446-1.27.098-2.647 0 0 .84-.269 2.75 1.025A9.578 9.578 0 0112 6.836c.85.004 1.705.114 2.504.336 1.909-1.294 2.747-1.025 2.747-1.025.546 1.377.203 2.394.1 2.647.64.699 1.028 1.592 1.028 2.683 0 3.842-2.339 4.687-4.566 4.935.359.309.678.919.678 1.852 0 1.336-.012 2.415-.012 2.743 0 .267.18.578.688.48C19.138 20.167 22 16.418 22 12c0-5.523-4.477-10-10-10z"
+                    />
                   </svg>
-                  {result.githubProfile.replace(/^https?:\/\/(www\.)?github\.com\//, '@')}
+                  {result.githubProfile.replace(
+                    /^https?:\/\/(www\.)?github\.com\//,
+                    '@'
+                  )}
                 </a>
-                <p className={`text-sm ${isDarkMode ? 'text-slate-400' : 'text-gray-600'}`}>
+                <p
+                  className={`text-sm ${isDarkMode ? 'text-slate-400' : 'text-gray-600'}`}
+                >
                   Modo: {mode === 'exam' ? 'Examen' : 'Entrenamiento'}
                 </p>
-                <p className={`text-sm ${isDarkMode ? 'text-slate-400' : 'text-gray-600'}`}>
-                  Motivo: {
-                    result.examPurpose === 'capacitacion' ? 'Capacitación' :
-                    result.examPurpose === 'postulacion' ? 'Postulación / Proceso de Selección' :
-                    result.examPurpose === 'practica' ? 'Práctica' :
-                    'Otro'
-                  }
-                  {result.examPurpose === 'postulacion' && result.companyName && (
-                    <span className="font-medium"> ({result.companyName})</span>
-                  )}
+                <p
+                  className={`text-sm ${isDarkMode ? 'text-slate-400' : 'text-gray-600'}`}
+                >
+                  Motivo:{' '}
+                  {result.examPurpose === 'capacitacion'
+                    ? 'Capacitación'
+                    : result.examPurpose === 'postulacion'
+                      ? 'Postulación / Proceso de Selección'
+                      : result.examPurpose === 'practica'
+                        ? 'Práctica'
+                        : 'Otro'}
+                  {result.examPurpose === 'postulacion' &&
+                    result.companyName && (
+                      <span className="font-medium">
+                        {' '}
+                        ({result.companyName})
+                      </span>
+                    )}
                 </p>
               </div>
               <div className="flex flex-wrap gap-2 w-full md:w-auto">
@@ -130,85 +141,145 @@ export default function ResultsScreen({
             </div>
           </div>
           <div className="p-6">
-            <div className={`mb-6 p-4 rounded-lg border-2 ${
-              result.passed
-                ? isDarkMode
-                  ? 'bg-green-900/20 border-green-700'
-                  : 'bg-green-50 border-green-300'
-                : isDarkMode
-                ? 'bg-red-900/20 border-red-700'
-                : 'bg-red-50 border-red-300'
-            }`}>
+            <div
+              className={`mb-6 p-4 rounded-lg border-2 ${
+                result.passed
+                  ? isDarkMode
+                    ? 'bg-green-900/20 border-green-700'
+                    : 'bg-green-50 border-green-300'
+                  : isDarkMode
+                    ? 'bg-red-900/20 border-red-700'
+                    : 'bg-red-50 border-red-300'
+              }`}
+            >
               <div className="flex items-center justify-between">
                 <div className="flex items-center gap-2">
                   <span className="text-2xl">{result.passed ? '🏆' : '✗'}</span>
-                  <span className={`text-lg font-semibold ${
-                    result.passed
-                      ? isDarkMode ? 'text-green-300' : 'text-green-900'
-                      : isDarkMode ? 'text-red-300' : 'text-red-900'
-                  }`}>
+                  <span
+                    className={`text-lg font-semibold ${
+                      result.passed
+                        ? isDarkMode
+                          ? 'text-green-300'
+                          : 'text-green-900'
+                        : isDarkMode
+                          ? 'text-red-300'
+                          : 'text-red-900'
+                    }`}
+                  >
                     {result.passed ? '¡APROBADO!' : 'NO APROBADO'}
                   </span>
                 </div>
-                <span className={`text-2xl font-bold ${isDarkMode ? 'text-white' : 'text-gray-900'}`}>
+                <span
+                  className={`text-2xl font-bold ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
+                >
                   {result.score} / {result.totalQuestions}
                 </span>
               </div>
             </div>
 
             <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-              <div className={`text-center p-5 rounded-xl border-2 shadow-sm ${
-                isDarkMode
-                  ? 'bg-amber-900/30 border-amber-700'
-                  : 'bg-amber-50 border-amber-200'
-              }`}>
+              <div
+                className={`text-center p-5 rounded-xl border-2 shadow-sm ${
+                  isDarkMode
+                    ? 'bg-amber-900/30 border-amber-700'
+                    : 'bg-amber-50 border-amber-200'
+                }`}
+              >
                 <span className="text-4xl block mb-2">🏆</span>
-                <p className={`text-sm font-medium mb-1 ${isDarkMode ? 'text-amber-300' : 'text-amber-700'}`}>Puntaje</p>
-                <p className={`text-3xl font-bold ${isDarkMode ? 'text-amber-200' : 'text-amber-900'}`}>{result.score}</p>
+                <p
+                  className={`text-sm font-medium mb-1 ${isDarkMode ? 'text-amber-300' : 'text-amber-700'}`}
+                >
+                  Puntaje
+                </p>
+                <p
+                  className={`text-3xl font-bold ${isDarkMode ? 'text-amber-200' : 'text-amber-900'}`}
+                >
+                  {result.score}
+                </p>
               </div>
 
-              <div className={`text-center p-5 rounded-xl border-2 shadow-sm ${
-                isDarkMode
-                  ? 'bg-green-900/30 border-green-700'
-                  : 'bg-green-50 border-green-200'
-              }`}>
+              <div
+                className={`text-center p-5 rounded-xl border-2 shadow-sm ${
+                  isDarkMode
+                    ? 'bg-green-900/30 border-green-700'
+                    : 'bg-green-50 border-green-200'
+                }`}
+              >
                 <span className="text-4xl block mb-2">✓</span>
-                <p className={`text-sm font-medium mb-1 ${isDarkMode ? 'text-green-300' : 'text-green-700'}`}>Correctas</p>
-                <p className={`text-3xl font-bold ${isDarkMode ? 'text-green-200' : 'text-green-800'}`}>{result.correctAnswers}</p>
+                <p
+                  className={`text-sm font-medium mb-1 ${isDarkMode ? 'text-green-300' : 'text-green-700'}`}
+                >
+                  Correctas
+                </p>
+                <p
+                  className={`text-3xl font-bold ${isDarkMode ? 'text-green-200' : 'text-green-800'}`}
+                >
+                  {result.correctAnswers}
+                </p>
               </div>
 
-              <div className={`text-center p-5 rounded-xl border-2 shadow-sm ${
-                isDarkMode
-                  ? 'bg-red-900/30 border-red-700'
-                  : 'bg-red-50 border-red-200'
-              }`}>
+              <div
+                className={`text-center p-5 rounded-xl border-2 shadow-sm ${
+                  isDarkMode
+                    ? 'bg-red-900/30 border-red-700'
+                    : 'bg-red-50 border-red-200'
+                }`}
+              >
                 <span className="text-4xl block mb-2">✗</span>
-                <p className={`text-sm font-medium mb-1 ${isDarkMode ? 'text-red-300' : 'text-red-700'}`}>Incorrectas</p>
-                <p className={`text-3xl font-bold ${isDarkMode ? 'text-red-200' : 'text-red-800'}`}>{result.incorrectAnswers}</p>
+                <p
+                  className={`text-sm font-medium mb-1 ${isDarkMode ? 'text-red-300' : 'text-red-700'}`}
+                >
+                  Incorrectas
+                </p>
+                <p
+                  className={`text-3xl font-bold ${isDarkMode ? 'text-red-200' : 'text-red-800'}`}
+                >
+                  {result.incorrectAnswers}
+                </p>
               </div>
 
-              <div className={`text-center p-5 rounded-xl border-2 shadow-sm ${
-                isDarkMode
-                  ? 'bg-slate-700 border-slate-600'
-                  : 'bg-slate-50 border-slate-200'
-              }`}>
+              <div
+                className={`text-center p-5 rounded-xl border-2 shadow-sm ${
+                  isDarkMode
+                    ? 'bg-slate-700 border-slate-600'
+                    : 'bg-slate-50 border-slate-200'
+                }`}
+              >
                 <span className="text-4xl block mb-2">⏱️</span>
-                <p className={`text-sm font-medium mb-1 ${isDarkMode ? 'text-slate-300' : 'text-slate-700'}`}>Tiempo</p>
-                <p className={`text-3xl font-bold ${isDarkMode ? 'text-slate-200' : 'text-slate-900'}`}>{formatTime(result.timeSpent)}</p>
+                <p
+                  className={`text-sm font-medium mb-1 ${isDarkMode ? 'text-slate-300' : 'text-slate-700'}`}
+                >
+                  Tiempo
+                </p>
+                <p
+                  className={`text-3xl font-bold ${isDarkMode ? 'text-slate-200' : 'text-slate-900'}`}
+                >
+                  {formatTime(result.timeSpent)}
+                </p>
               </div>
             </div>
 
             <div className="mt-6">
-              <div className={`flex justify-between mb-2 text-sm ${isDarkMode ? 'text-slate-300' : 'text-gray-700'}`}>
+              <div
+                className={`flex justify-between mb-2 text-sm ${isDarkMode ? 'text-slate-300' : 'text-gray-700'}`}
+              >
                 <span className="font-semibold">Porcentaje de Acierto</span>
-                <span className="font-bold text-base">{result.percentage.toFixed(2)}%</span>
+                <span className="font-bold text-base">
+                  {result.percentage.toFixed(2)}%
+                </span>
               </div>
-              <div className={`w-full rounded-full h-3 shadow-inner ${isDarkMode ? 'bg-slate-700' : 'bg-gray-200'}`}>
+              <div
+                className={`w-full rounded-full h-3 shadow-inner ${isDarkMode ? 'bg-slate-700' : 'bg-gray-200'}`}
+              >
                 <div
                   className={`h-3 rounded-full transition-all shadow-sm ${
                     result.passed
-                      ? isDarkMode ? 'bg-green-500' : 'bg-green-600'
-                      : isDarkMode ? 'bg-red-500' : 'bg-red-600'
+                      ? isDarkMode
+                        ? 'bg-green-500'
+                        : 'bg-green-600'
+                      : isDarkMode
+                        ? 'bg-red-500'
+                        : 'bg-red-600'
                   }`}
                   style={{ width: `${result.percentage}%` }}
                 />
@@ -217,7 +288,9 @@ export default function ResultsScreen({
           </div>
         </div>
 
-        <div className={`rounded-lg shadow-lg ${isDarkMode ? 'bg-slate-800' : 'bg-white'}`}>
+        <div
+          className={`rounded-lg shadow-lg ${isDarkMode ? 'bg-slate-800' : 'bg-white'}`}
+        >
           <div className="border-b border-gray-200 dark:border-gray-700">
             <div className="flex">
               <button
@@ -228,8 +301,8 @@ export default function ResultsScreen({
                       ? 'bg-slate-700 text-white border-b-2 border-amber-500'
                       : 'bg-white text-gray-900 border-b-2 border-amber-600'
                     : isDarkMode
-                    ? 'text-slate-400 hover:text-white'
-                    : 'text-gray-600 hover:text-gray-900'
+                      ? 'text-slate-400 hover:text-white'
+                      : 'text-gray-600 hover:text-gray-900'
                 }`}
               >
                 🎯 Resumen
@@ -242,8 +315,8 @@ export default function ResultsScreen({
                       ? 'bg-slate-700 text-white border-b-2 border-amber-500'
                       : 'bg-white text-gray-900 border-b-2 border-amber-600'
                     : isDarkMode
-                    ? 'text-slate-400 hover:text-white'
-                    : 'text-gray-600 hover:text-gray-900'
+                      ? 'text-slate-400 hover:text-white'
+                      : 'text-gray-600 hover:text-gray-900'
                 }`}
               >
                 📊 Por LO
@@ -256,8 +329,8 @@ export default function ResultsScreen({
                       ? 'bg-slate-700 text-white border-b-2 border-amber-500'
                       : 'bg-white text-gray-900 border-b-2 border-amber-600'
                     : isDarkMode
-                    ? 'text-slate-400 hover:text-white'
-                    : 'text-gray-600 hover:text-gray-900'
+                      ? 'text-slate-400 hover:text-white'
+                      : 'text-gray-600 hover:text-gray-900'
                 }`}
               >
                 ✓ Detalles
@@ -269,32 +342,50 @@ export default function ResultsScreen({
             {activeTab === 'summary' && (
               <div className="space-y-4">
                 <div>
-                  <h3 className={`font-semibold mb-2 ${isDarkMode ? 'text-white' : 'text-gray-900'}`}>Resultado:</h3>
-                  <p className={isDarkMode ? 'text-slate-400' : 'text-gray-600'}>
+                  <h3
+                    className={`font-semibold mb-2 ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
+                  >
+                    Resultado:
+                  </h3>
+                  <p
+                    className={isDarkMode ? 'text-slate-400' : 'text-gray-600'}
+                  >
                     {result.passed ? (
                       <>
-                        ¡Felicitaciones! Has aprobado el simulacro con un puntaje de{' '}
-                        <strong>{result.score}</strong> sobre {result.totalQuestions}, logrando un{' '}
-                        <strong>{result.percentage.toFixed(2)}%</strong> de aciertos. El puntaje mínimo requerido es 26 puntos (65%).
+                        ¡Felicitaciones! Has aprobado el simulacro con un
+                        puntaje de <strong>{result.score}</strong> sobre{' '}
+                        {result.totalQuestions}, logrando un{' '}
+                        <strong>{result.percentage.toFixed(2)}%</strong> de
+                        aciertos. El puntaje mínimo requerido es 26 puntos
+                        (65%).
                       </>
                     ) : (
                       <>
-                        No has alcanzado el puntaje mínimo de aprobación. Obtuviste <strong>{result.score}</strong> puntos sobre{' '}
-                        {result.totalQuestions}, equivalente a un <strong>{result.percentage.toFixed(2)}%</strong>. Se requieren al menos 26 puntos (65%) para aprobar. Te recomendamos revisar las áreas de mejora identificadas y volver a intentarlo.
+                        No has alcanzado el puntaje mínimo de aprobación.
+                        Obtuviste <strong>{result.score}</strong> puntos sobre{' '}
+                        {result.totalQuestions}, equivalente a un{' '}
+                        <strong>{result.percentage.toFixed(2)}%</strong>. Se
+                        requieren al menos 26 puntos (65%) para aprobar. Te
+                        recomendamos revisar las áreas de mejora identificadas y
+                        volver a intentarlo.
                       </>
                     )}
                   </p>
                 </div>
 
                 <div className="grid grid-cols-1 md:grid-cols-2 gap-4 pt-4">
-                  <div className={`p-5 rounded-xl border-2 shadow-sm ${
-                    isDarkMode
-                      ? 'border-green-700 bg-green-900/20'
-                      : 'border-green-200 bg-green-50/50'
-                  }`}>
-                    <h4 className={`font-semibold mb-3 flex items-center gap-2 ${
-                      isDarkMode ? 'text-green-300' : 'text-green-900'
-                    }`}>
+                  <div
+                    className={`p-5 rounded-xl border-2 shadow-sm ${
+                      isDarkMode
+                        ? 'border-green-700 bg-green-900/20'
+                        : 'border-green-200 bg-green-50/50'
+                    }`}
+                  >
+                    <h4
+                      className={`font-semibold mb-3 flex items-center gap-2 ${
+                        isDarkMode ? 'text-green-300' : 'text-green-900'
+                      }`}
+                    >
                       <span className="text-xl">💪</span>
                       Fortalezas Identificadas:
                     </h4>
@@ -303,29 +394,56 @@ export default function ResultsScreen({
                         .filter((lo) => lo.percentage >= 70)
                         .slice(0, 5)
                         .map((lo) => (
-                          <li key={lo.learningObjective} className="flex items-center gap-2">
-                            <span className={isDarkMode ? 'text-green-400' : 'text-green-600'}>✓</span>
-                            <span className={isDarkMode ? 'text-slate-300' : 'text-gray-700'}>
-                              {lo.learningObjective}: <strong>{lo.correctAnswers}/{lo.totalQuestions}</strong> ({lo.percentage.toFixed(0)}%)
+                          <li
+                            key={lo.learningObjective}
+                            className="flex items-center gap-2"
+                          >
+                            <span
+                              className={
+                                isDarkMode ? 'text-green-400' : 'text-green-600'
+                              }
+                            >
+                              ✓
+                            </span>
+                            <span
+                              className={
+                                isDarkMode ? 'text-slate-300' : 'text-gray-700'
+                              }
+                            >
+                              {lo.learningObjective}:{' '}
+                              <strong>
+                                {lo.correctAnswers}/{lo.totalQuestions}
+                              </strong>{' '}
+                              ({lo.percentage.toFixed(0)}%)
                             </span>
                           </li>
                         ))}
-                      {result.learningObjectiveAnalysis.filter((lo) => lo.percentage >= 70).length === 0 && (
-                        <li className={isDarkMode ? 'text-slate-400' : 'text-gray-600'}>
+                      {result.learningObjectiveAnalysis.filter(
+                        (lo) => lo.percentage >= 70
+                      ).length === 0 && (
+                        <li
+                          className={
+                            isDarkMode ? 'text-slate-400' : 'text-gray-600'
+                          }
+                        >
                           Ninguna área con desempeño sobresaliente identificada.
                         </li>
                       )}
                     </ul>
                   </div>
 
-                  <div className={`p-5 rounded-xl border-2 shadow-sm ${
-                    isDarkMode
-                      ? 'border-amber-700 bg-amber-900/20'
-                      : 'border-amber-200 bg-amber-50/50'
-                  }`}>
-                    <h4 className={`font-semibold mb-3 flex items-center gap-2 ${
-                      isDarkMode ? 'text-amber-300' : 'text-amber-900'
-                    }`}>
+                  <div
+                    className={`p-5 rounded-xl border-2 shadow-sm ${
+                      isDarkMode
+                        ? 'border-amber-700 bg-amber-900/20'
+                        : 'border-amber-200 bg-amber-50/50'
+                    }`}
+                  >
+                    <h4
+                      className={`font-semibold mb-3 flex items-center gap-2 ${
+                        isDarkMode ? 'text-amber-300' : 'text-amber-900'
+                      }`}
+                    >
                       <span className="text-xl">📚</span>
                       Áreas de Mejora:
                     </h4>
@@ -334,16 +452,40 @@ export default function ResultsScreen({
                         .filter((lo) => lo.percentage < 70)
                         .slice(0, 5)
                         .map((lo) => (
-                          <li key={lo.learningObjective} className="flex items-center gap-2">
-                            <span className={isDarkMode ? 'text-amber-400' : 'text-amber-600'}>⚠</span>
-                            <span className={isDarkMode ? 'text-slate-300' : 'text-gray-700'}>
-                              {lo.learningObjective}: <strong>{lo.correctAnswers}/{lo.totalQuestions}</strong> ({lo.percentage.toFixed(0)}%)
+                          <li
+                            key={lo.learningObjective}
+                            className="flex items-center gap-2"
+                          >
+                            <span
+                              className={
+                                isDarkMode ? 'text-amber-400' : 'text-amber-600'
+                              }
+                            >
+                              ⚠
+                            </span>
+                            <span
+                              className={
+                                isDarkMode ? 'text-slate-300' : 'text-gray-700'
+                              }
+                            >
+                              {lo.learningObjective}:{' '}
+                              <strong>
+                                {lo.correctAnswers}/{lo.totalQuestions}
+                              </strong>{' '}
+                              ({lo.percentage.toFixed(0)}%)
                             </span>
                           </li>
                         ))}
-                      {result.learningObjectiveAnalysis.filter((lo) => lo.percentage < 70).length === 0 && (
-                        <li className={isDarkMode ? 'text-slate-400' : 'text-gray-600'}>
-                          ¡Excelente! No se identificaron áreas débiles significativas.
+                      {result.learningObjectiveAnalysis.filter(
+                        (lo) => lo.percentage < 70
+                      ).length === 0 && (
+                        <li
+                          className={
+                            isDarkMode ? 'text-slate-400' : 'text-gray-600'
+                          }
+                        >
+                          ¡Excelente! No se identificaron áreas débiles
+                          significativas.
                         </li>
                       )}
                     </ul>
@@ -355,44 +497,77 @@ export default function ResultsScreen({
             {activeTab === 'learning-objectives' && (
               <div className="space-y-4">
                 <div className="mb-4">
-                  <h3 className={`text-lg font-bold flex items-center gap-2 ${isDarkMode ? 'text-white' : 'text-gray-900'}`}>
+                  <h3
+                    className={`text-lg font-bold flex items-center gap-2 ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
+                  >
                     <span className="text-2xl">📊</span>
                     Análisis por Learning Objective
                   </h3>
-                  <p className={`text-sm mt-1 ${isDarkMode ? 'text-slate-400' : 'text-gray-600'}`}>
-                    Desempeño en cada objetivo de aprendizaje del syllabus ISTQB CTFL v4.0
+                  <p
+                    className={`text-sm mt-1 ${isDarkMode ? 'text-slate-400' : 'text-gray-600'}`}
+                  >
+                    Desempeño en cada objetivo de aprendizaje del syllabus ISTQB
+                    CTFL v4.0
                   </p>
                 </div>
                 {result.learningObjectiveAnalysis.map((lo) => (
-                  <div key={lo.learningObjective} className={`p-4 rounded-xl border-2 shadow-sm space-y-2 ${
-                    lo.percentage >= 70
-                      ? isDarkMode ? 'border-green-700 bg-green-900/10' : 'border-green-200 bg-green-50/30'
-                      : lo.percentage >= 50
-                      ? isDarkMode ? 'border-amber-700 bg-amber-900/10' : 'border-amber-200 bg-amber-50/30'
-                      : isDarkMode ? 'border-red-700 bg-red-900/10' : 'border-red-200 bg-red-50/30'
-                  }`}>
+                  <div
+                    key={lo.learningObjective}
+                    className={`p-4 rounded-xl border-2 shadow-sm space-y-2 ${
+                      lo.percentage >= 70
+                        ? isDarkMode
+                          ? 'border-green-700 bg-green-900/10'
+                          : 'border-green-200 bg-green-50/30'
+                        : lo.percentage >= 50
+                          ? isDarkMode
+                            ? 'border-amber-700 bg-amber-900/10'
+                            : 'border-amber-200 bg-amber-50/30'
+                          : isDarkMode
+                            ? 'border-red-700 bg-red-900/10'
+                            : 'border-red-200 bg-red-50/30'
+                    }`}
+                  >
                     <div className="flex justify-between items-center">
-                      <span className={`font-semibold ${isDarkMode ? 'text-slate-100' : 'text-gray-900'}`}>
+                      <span
+                        className={`font-semibold ${isDarkMode ? 'text-slate-100' : 'text-gray-900'}`}
+                      >
                         {lo.learningObjective}
                       </span>
-                      <span className={`text-sm font-bold px-3 py-1 rounded-full ${
-                        lo.percentage >= 70
-                          ? isDarkMode ? 'bg-green-900/40 text-green-300' : 'bg-green-100 text-green-800'
-                          : lo.percentage >= 50
-                          ? isDarkMode ? 'bg-amber-900/40 text-amber-300' : 'bg-amber-100 text-amber-800'
-                          : isDarkMode ? 'bg-red-900/40 text-red-300' : 'bg-red-100 text-red-800'
-                      }`}>
-                        {lo.correctAnswers} / {lo.totalQuestions} ({lo.percentage.toFixed(0)}%)
+                      <span
+                        className={`text-sm font-bold px-3 py-1 rounded-full ${
+                          lo.percentage >= 70
+                            ? isDarkMode
+                              ? 'bg-green-900/40 text-green-300'
+                              : 'bg-green-100 text-green-800'
+                            : lo.percentage >= 50
+                              ? isDarkMode
+                                ? 'bg-amber-900/40 text-amber-300'
+                                : 'bg-amber-100 text-amber-800'
+                              : isDarkMode
+                                ? 'bg-red-900/40 text-red-300'
+                                : 'bg-red-100 text-red-800'
+                        }`}
+                      >
+                        {lo.correctAnswers} / {lo.totalQuestions} (
+                        {lo.percentage.toFixed(0)}%)
                       </span>
                     </div>
-                    <div className={`w-full rounded-full h-3 shadow-inner ${isDarkMode ? 'bg-slate-700' : 'bg-gray-200'}`}>
+                    <div
+                      className={`w-full rounded-full h-3 shadow-inner ${isDarkMode ? 'bg-slate-700' : 'bg-gray-200'}`}
+                    >
                       <div
                         className={`h-3 rounded-full transition-all shadow-sm ${
                           lo.percentage >= 70
-                            ? isDarkMode ? 'bg-green-500' : 'bg-green-600'
+                            ? isDarkMode
+                              ? 'bg-green-500'
+                              : 'bg-green-600'
                             : lo.percentage >= 50
-                            ? isDarkMode ? 'bg-amber-500' : 'bg-amber-600'
-                            : isDarkMode ? 'bg-red-500' : 'bg-red-600'
+                              ? isDarkMode
+                                ? 'bg-amber-500'
+                                : 'bg-amber-600'
+                              : isDarkMode
+                                ? 'bg-red-500'
+                                : 'bg-red-600'
                         }`}
                         style={{ width: `${lo.percentage}%` }}
                       />
@@ -413,48 +588,84 @@ export default function ResultsScreen({
                           ? 'border-green-700 bg-green-900/10'
                           : 'border-green-300 bg-green-50/30'
                         : isDarkMode
-                        ? 'border-red-700 bg-red-900/10'
-                        : 'border-red-300 bg-red-50/30'
+                          ? 'border-red-700 bg-red-900/10'
+                          : 'border-red-300 bg-red-50/30'
                     }`}
                   >
-                    <div className={`p-4 border-b ${isDarkMode ? 'border-slate-700' : 'border-gray-200'}`}>
+                    <div
+                      className={`p-4 border-b ${isDarkMode ? 'border-slate-700' : 'border-gray-200'}`}
+                    >
                       <div className="flex justify-between items-start gap-3">
-                        <h3 className={`text-lg font-bold flex items-center gap-2 ${isDarkMode ? 'text-white' : 'text-gray-900'}`}>
+                        <h3
+                          className={`text-lg font-bold flex items-center gap-2 ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
+                        >
                           Pregunta {index + 1}
                           {answer.isCorrect ? (
-                            <span className={`text-2xl ${isDarkMode ? 'text-green-400' : 'text-green-600'}`}>✓</span>
+                            <span
+                              className={`text-2xl ${isDarkMode ? 'text-green-400' : 'text-green-600'}`}
+                            >
+                              ✓
+                            </span>
                           ) : (
-                            <span className={`text-2xl ${isDarkMode ? 'text-red-400' : 'text-red-600'}`}>✗</span>
+                            <span
+                              className={`text-2xl ${isDarkMode ? 'text-red-400' : 'text-red-600'}`}
+                            >
+                              ✗
+                            </span>
                           )}
                         </h3>
                         <div className="flex gap-2 text-sm flex-shrink-0">
-                          <span className={`px-3 py-1 rounded-full font-medium border ${
-                            isDarkMode
-                              ? 'bg-blue-900/40 text-blue-300 border-blue-700'
-                              : 'bg-blue-100 text-blue-800 border-blue-200'
-                          }`}>
+                          <span
+                            className={`px-3 py-1 rounded-full font-medium border ${
+                              isDarkMode
+                                ? 'bg-blue-900/40 text-blue-300 border-blue-700'
+                                : 'bg-blue-100 text-blue-800 border-blue-200'
+                            }`}
+                          >
                             {answer.learningObjective}
                           </span>
-                          <span className={`px-3 py-1 rounded-full font-semibold border ${
-                            isDarkMode
-                              ? 'bg-amber-900/40 text-amber-300 border-amber-700'
-                              : 'bg-amber-100 text-amber-800 border-amber-200'
-                          }`}>
+                          <span
+                            className={`px-3 py-1 rounded-full font-semibold border ${
+                              isDarkMode
+                                ? 'bg-amber-900/40 text-amber-300 border-amber-700'
+                                : 'bg-amber-100 text-amber-800 border-amber-200'
+                            }`}
+                          >
                             {answer.kLevel}
                           </span>
                         </div>
                       </div>
                     </div>
                     <div className="p-4 space-y-4">
-                      <p className={`text-base ${isDarkMode ? 'text-white' : 'text-gray-900'}`}>{answer.questionText}</p>
+                      <p
+                        className={`text-base ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
+                      >
+                        {answer.questionText}
+                      </p>
 
                       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                         <div>
-                          <h4 className={`font-semibold mb-2 flex items-center gap-2 ${isDarkMode ? 'text-white' : 'text-gray-900'}`}>
+                          <h4
+                            className={`font-semibold mb-2 flex items-center gap-2 ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
+                          >
                             {answer.isCorrect ? (
-                              <span className={isDarkMode ? 'text-green-400' : 'text-green-600'}>✓</span>
+                              <span
+                                className={
+                                  isDarkMode
+                                    ? 'text-green-400'
+                                    : 'text-green-600'
+                                }
+                              >
+                                ✓
+                              </span>
                             ) : (
-                              <span className={isDarkMode ? 'text-red-400' : 'text-red-600'}>✗</span>
+                              <span
+                                className={
+                                  isDarkMode ? 'text-red-400' : 'text-red-600'
+                                }
+                              >
+                                ✗
+                              </span>
                             )}
                             Tu Respuesta:
                           </h4>
@@ -465,8 +676,8 @@ export default function ResultsScreen({
                                   ? 'bg-green-900/30 text-green-300 border-green-700'
                                   : 'bg-green-100 text-green-900 border-green-300'
                                 : isDarkMode
-                                ? 'bg-red-900/30 text-red-300 border-red-700'
-                                : 'bg-red-100 text-red-900 border-red-300'
+                                  ? 'bg-red-900/30 text-red-300 border-red-700'
+                                  : 'bg-red-100 text-red-900 border-red-300'
                             }`}
                           >
                             {answer.userAnswer.join(', ') || 'Sin responder'}
@@ -475,15 +686,27 @@ export default function ResultsScreen({
 
                         {!answer.isCorrect && (
                           <div>
-                            <h4 className={`font-semibold mb-2 flex items-center gap-2 ${isDarkMode ? 'text-white' : 'text-gray-900'}`}>
-                              <span className={isDarkMode ? 'text-green-400' : 'text-green-600'}>✓</span>
+                            <h4
+                              className={`font-semibold mb-2 flex items-center gap-2 ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
+                            >
+                              <span
+                                className={
+                                  isDarkMode
+                                    ? 'text-green-400'
+                                    : 'text-green-600'
+                                }
+                              >
+                                ✓
+                              </span>
                               Respuesta Correcta:
                             </h4>
-                            <p className={`p-3 rounded-lg font-medium border-2 ${
-                              isDarkMode
-                                ? 'bg-green-900/30 text-green-300 border-green-700'
-                                : 'bg-green-100 text-green-900 border-green-300'
-                            }`}>
+                            <p
+                              className={`p-3 rounded-lg font-medium border-2 ${
+                                isDarkMode
+                                  ? 'bg-green-900/30 text-green-300 border-green-700'
+                                  : 'bg-green-100 text-green-900 border-green-300'
+                              }`}
+                            >
                               {answer.correctAnswer.join(', ')}
                             </p>
                           </div>
@@ -492,38 +715,59 @@ export default function ResultsScreen({
 
                       {!answer.isCorrect && (
                         <div className="mt-4">
-                          <h4 className={`font-semibold mb-3 flex items-center gap-2 ${isDarkMode ? 'text-white' : 'text-gray-900'}`}>
+                          <h4
+                            className={`font-semibold mb-3 flex items-center gap-2 ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
+                          >
                             <span className="text-xl">💡</span>
                             Explicación:
                           </h4>
                           <div className="space-y-2 text-sm">
-                            {Object.entries(answer.explanations).map(([label, exp]) => (
-                              <div
-                                key={label}
-                                className={`p-3 rounded-lg border-l-4 ${
-                                  exp.correct
-                                    ? isDarkMode
-                                      ? 'bg-green-900/20 border-green-500'
-                                      : 'bg-green-50 border-green-500'
-                                    : isDarkMode
-                                    ? 'bg-slate-700/50 border-slate-600'
-                                    : 'bg-gray-50 border-gray-300'
-                                }`}
-                              >
-                                <span className={`font-semibold ${
-                                  exp.correct
-                                    ? isDarkMode ? 'text-green-300' : 'text-green-900'
-                                    : isDarkMode ? 'text-slate-200' : 'text-gray-900'
-                                }`}>
-                                  Opción {label}: {exp.correct ? '✓ (Correcta)' : '✗ (Incorrecta)'}
-                                </span>
-                                <p className={`mt-1 ${
-                                  exp.correct
-                                    ? isDarkMode ? 'text-green-200' : 'text-green-800'
-                                    : isDarkMode ? 'text-slate-300' : 'text-gray-700'
-                                }`}>{exp.explanation}</p>
-                              </div>
-                            ))}
+                            {Object.entries(answer.explanations).map(
+                              ([label, exp]) => (
+                                <div
+                                  key={label}
+                                  className={`p-3 rounded-lg border-l-4 ${
+                                    exp.correct
+                                      ? isDarkMode
+                                        ? 'bg-green-900/20 border-green-500'
+                                        : 'bg-green-50 border-green-500'
+                                      : isDarkMode
+                                        ? 'bg-slate-700/50 border-slate-600'
+                                        : 'bg-gray-50 border-gray-300'
+                                  }`}
+                                >
+                                  <span
+                                    className={`font-semibold ${
+                                      exp.correct
+                                        ? isDarkMode
+                                          ? 'text-green-300'
+                                          : 'text-green-900'
+                                        : isDarkMode
+                                          ? 'text-slate-200'
+                                          : 'text-gray-900'
+                                    }`}
+                                  >
+                                    Opción {label}:{' '}
+                                    {exp.correct
+                                      ? '✓ (Correcta)'
+                                      : '✗ (Incorrecta)'}
+                                  </span>
+                                  <p
+                                    className={`mt-1 ${
+                                      exp.correct
+                                        ? isDarkMode
+                                          ? 'text-green-200'
+                                          : 'text-green-800'
+                                        : isDarkMode
+                                          ? 'text-slate-300'
+                                          : 'text-gray-700'
+                                    }`}
+                                  >
+                                    {exp.explanation}
+                                  </p>
+                                </div>
+                              )
+                            )}
                           </div>
                         </div>
                       )}
@@ -534,8 +778,6 @@ export default function ResultsScreen({
             )}
           </div>
         </div>
-
-
       </div>
     </div>
   );

--- a/apps/frontend/src/app/labs/test-app/README.md
+++ b/apps/frontend/src/app/labs/test-app/README.md
@@ -92,21 +92,21 @@ Una vez finalizadas las pruebas, accede al generador de informes:
 
 ## 📋 Rutas Disponibles
 
-| Ruta                             | Descripción                       |
-| -------------------------------- | --------------------------------- |
-| `/labs/test-app`                 | Home (redirige según login)       |
-| `/labs/test-app/login`           | Iniciar sesión                    |
-| `/labs/test-app/register`        | Registrar cuenta nueva            |
-| `/labs/test-app/catalog`         | Catálogo de productos             |
-| `/labs/test-app/product/[id]`    | Detalle de producto               |
-| `/labs/test-app/cart`            | Carrito de compras                |
-| `/labs/test-app/checkout`        | Checkout y pago                   |
-| `/labs/test-app/history`         | Historial de pedidos              |
-| `/labs/test-app/profile`         | Perfil del usuario                |
-| `/labs/test-app/support`         | Crear tickets de soporte          |
-| `/labs/test-app/report`          | Generador de informe técnico      |
-| `/labs/test-app/evidence`        | Exportar audit log                |
-| `/labs/test-app/admin?key=...`   | Panel de administración (oculto)  |
+| Ruta                           | Descripción                      |
+| ------------------------------ | -------------------------------- |
+| `/labs/test-app`               | Home (redirige según login)      |
+| `/labs/test-app/login`         | Iniciar sesión                   |
+| `/labs/test-app/register`      | Registrar cuenta nueva           |
+| `/labs/test-app/catalog`       | Catálogo de productos            |
+| `/labs/test-app/product/[id]`  | Detalle de producto              |
+| `/labs/test-app/cart`          | Carrito de compras               |
+| `/labs/test-app/checkout`      | Checkout y pago                  |
+| `/labs/test-app/history`       | Historial de pedidos             |
+| `/labs/test-app/profile`       | Perfil del usuario               |
+| `/labs/test-app/support`       | Crear tickets de soporte         |
+| `/labs/test-app/report`        | Generador de informe técnico     |
+| `/labs/test-app/evidence`      | Exportar audit log               |
+| `/labs/test-app/admin?key=...` | Panel de administración (oculto) |
 
 ---
 
@@ -117,48 +117,39 @@ La aplicación contiene **10 bugs intencionales**, de los cuales **6-8 estarán 
 ### Bugs Confirmados en el Sistema:
 
 1. **Filtro Inconsistente (Catálogo)**
-
    - Al combinar búsqueda + categoría, el conteo de resultados no coincide con los items mostrados
    - Severidad: **Media**
 
 2. **Ordenamiento Inestable (Catálogo)**
-
    - Al ordenar por precio, productos con el mismo precio saltan de posición al cambiar de página
    - Severidad: **Baja**
 
 3. **Validación de Cantidad Rota (Carrito)**
-
    - Permite ingresar cantidad 0 o mayor al stock si se tipea rápido (onBlur valida tarde)
    - Severidad: **Alta**
 
 4. **Total del Carrito Desfasado (Carrito)**
-
    - Al cambiar cantidades rápido, los impuestos no recalculan hasta recargar página
    - Severidad: **Alta**
 
 5. **Checkout Error 500 Simulado (Checkout)**
-
    - Si el campo "Apartamento/Suite" tiene más de 50 caracteres, muestra error genérico 500 en vez de validación clara
    - Severidad: **Media**
 
 6. **Bug de Zona Horaria (Historial)**
-
    - Guarda timezone "America/Asuncion" en perfil, pero el historial muestra fechas en UTC sin convertir
    - Severidad: **Baja**
 
 7. **Problemas de Accesibilidad (Detalle de Producto)**
-
    - Botón "Agregar al carrito" sin `aria-label` cuando está disabled
    - Label de cantidad sin `htmlFor` apuntando al input
    - Severidad: **Media**
 
 8. **XSS Reflejado Leve (Catálogo)**
-
    - La búsqueda escapa `<script>` pero permite `"><test>` que rompe el placeholder (sin ejecutar JS)
    - Severidad: **Media**
 
 9. **Prioridad de Ticket Mal Asignada (Soporte)**
-
    - Seleccionar prioridad "Alta" puede guardarse como "Media" si se envía de inmediato
    - Severidad: **Baja**
 
@@ -277,7 +268,7 @@ Configura la clave del panel admin (server-only, se verifica en
 
 ```env
 # .env.local
-ADMIN_KEY=aiquaa-test-admin-2024
+TEST_APP_ADMIN_KEY=aiquaa-test-admin-2024
 ```
 
 ---

--- a/apps/frontend/src/app/labs/test-app/admin/page.tsx
+++ b/apps/frontend/src/app/labs/test-app/admin/page.tsx
@@ -124,7 +124,7 @@ export default function AdminPage() {
             Se requiere clave de administrador para acceder.
           </p>
           <p className="text-sm text-gray-500">
-            Accede con: /labs/test-app/admin?key=&lt;ADMIN_KEY&gt;
+            Accede con: /labs/test-app/admin?key=&lt;TEST_APP_ADMIN_KEY&gt;
           </p>
         </div>
       </TestAppLayout>

--- a/apps/frontend/src/app/labs/test-app/report/__tests__/metadata.test.ts
+++ b/apps/frontend/src/app/labs/test-app/report/__tests__/metadata.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import { stripBase64FromBugs } from '../metadata';
+import type { BugReport } from '../types';
+
+describe('test-app report metadata', () => {
+  it('removes base64 image payloads before persisting exam metadata', () => {
+    const bugs: BugReport[] = [
+      {
+        id: 'bug-1',
+        title: 'Checkout error',
+        description: 'Fails on submit',
+        stepsToReproduce: ['Open checkout'],
+        expectedResult: 'Order is created',
+        actualResult: 'Error',
+        severity: 'High',
+        category: 'Checkout',
+        evidence: '',
+        foundAt: new Date('2026-07-10T00:00:00Z'),
+        images: [
+          {
+            id: 'img-1',
+            fileName: 'evidence.png',
+            base64Data: 'data:image/png;base64,abc123',
+            mimeType: 'image/png',
+            size: 123,
+            uploadedAt: new Date('2026-07-10T00:00:00Z'),
+          },
+        ],
+      },
+    ];
+
+    const [bug] = stripBase64FromBugs(bugs);
+
+    expect(bug.images[0]).toMatchObject({
+      id: 'img-1',
+      fileName: 'evidence.png',
+      mimeType: 'image/png',
+      size: 123,
+    });
+    expect(bug.images[0]).not.toHaveProperty('base64Data');
+  });
+});

--- a/apps/frontend/src/app/labs/test-app/report/metadata.ts
+++ b/apps/frontend/src/app/labs/test-app/report/metadata.ts
@@ -1,0 +1,31 @@
+import type { BugReport, ImageEvidence } from './types';
+
+type PersistedImageEvidence = Omit<ImageEvidence, 'base64Data'> & {
+  storageBucket?: string;
+  storagePath?: string;
+  signedUrl?: string;
+  uploadError?: string;
+};
+
+export type PersistedBugReport = Omit<BugReport, 'images'> & {
+  images: PersistedImageEvidence[];
+};
+
+export function stripBase64FromImage(
+  image: ImageEvidence | PersistedImageEvidence
+): PersistedImageEvidence {
+  const metadata = { ...image } as PersistedImageEvidence & {
+    base64Data?: string;
+  };
+  delete metadata.base64Data;
+  return metadata;
+}
+
+export function stripBase64FromBugs(
+  bugs: Array<BugReport | PersistedBugReport>
+): PersistedBugReport[] {
+  return bugs.map((bug) => ({
+    ...bug,
+    images: (bug.images ?? []).map(stripBase64FromImage),
+  }));
+}

--- a/apps/frontend/src/app/labs/test-app/report/page.tsx
+++ b/apps/frontend/src/app/labs/test-app/report/page.tsx
@@ -6,6 +6,7 @@ import { useState, useEffect } from 'react';
 import { useTheme } from '@/contexts/ThemeContext';
 import { useSupabaseAuth } from '@/contexts/SupabaseAuthContext';
 import { getExamUserDefaults } from '@/lib/exam-user-defaults';
+import { createClient } from '@/lib/supabase/client';
 import { getCurrentUser, getSessionStartedAt } from '../lib/storage';
 import { getCandidateId, setCandidateId } from '../lib/prng';
 import type {
@@ -25,6 +26,15 @@ import {
   formatLastSaved,
 } from './utils';
 import { saveExamResultAction } from '@/actions/exams';
+import { stripBase64FromBugs, stripBase64FromImage } from './metadata';
+
+const EVIDENCE_BUCKET = 'test-app-evidence';
+
+function extensionForMimeType(mimeType: string) {
+  if (mimeType === 'image/png') return 'png';
+  if (mimeType === 'image/webp') return 'webp';
+  return 'jpg';
+}
 
 export default function TechnicalReportPage() {
   const { isDarkMode } = useTheme();
@@ -405,6 +415,61 @@ export default function TechnicalReportPage() {
     score: {} as any,
   });
 
+  const uploadEvidenceImages = async (bugsToUpload: BugReport[]) => {
+    if (!user) {
+      return bugsToUpload.map((bug) => ({
+        ...bug,
+        images: (bug.images ?? []).map((image) => ({
+          ...stripBase64FromImage(image),
+          uploadError: 'No autenticado',
+        })),
+      }));
+    }
+
+    const supabase = createClient();
+    const uploadedBugs: BugReport[] = [];
+
+    for (const bug of bugsToUpload) {
+      const uploadedImages = [];
+
+      for (const image of bug.images ?? []) {
+        try {
+          const response = await fetch(image.base64Data);
+          const blob = await response.blob();
+          const extension = extensionForMimeType(image.mimeType);
+          const path = `${user.id}/${bug.id}/${image.id}.${extension}`;
+          const { error } = await supabase.storage
+            .from(EVIDENCE_BUCKET)
+            .upload(path, blob, {
+              contentType: image.mimeType,
+              upsert: true,
+            });
+
+          if (error) throw error;
+
+          uploadedImages.push({
+            ...stripBase64FromImage(image),
+            storageBucket: EVIDENCE_BUCKET,
+            storagePath: path,
+          });
+        } catch (error) {
+          uploadedImages.push({
+            ...stripBase64FromImage(image),
+            uploadError:
+              error instanceof Error ? error.message : 'No se pudo subir',
+          });
+        }
+      }
+
+      uploadedBugs.push({
+        ...bug,
+        images: uploadedImages as unknown as ImageEvidence[],
+      });
+    }
+
+    return stripBase64FromBugs(uploadedBugs);
+  };
+
   const handleSaveToDb = async () => {
     setIsSaving(true);
     setSaveError('');
@@ -418,6 +483,7 @@ export default function TechnicalReportPage() {
     const timeSpentSeconds = sessionStart
       ? Math.max(60, Math.round((Date.now() - sessionStart.getTime()) / 1000))
       : testSession.duration * 60; // fallback if session start was never recorded
+    const bugsForMetadata = await uploadEvidenceImages(bugs);
     const { error } = await saveExamResultAction({
       exam_type: 'test-app',
       exam_mode: 'exam',
@@ -435,7 +501,7 @@ export default function TechnicalReportPage() {
       github_profile: candidateInfo.githubProfile || undefined,
       process_code: processCode.trim().toUpperCase() || undefined,
       metadata: {
-        bugs,
+        bugs: bugsForMetadata,
         exploredSections: testSession.exploredSections,
         bugCount: bugs.length,
         severityCounts: {

--- a/apps/frontend/src/lib/resend.ts
+++ b/apps/frontend/src/lib/resend.ts
@@ -9,8 +9,9 @@ export async function sendEmail(
   const from = process.env.RESEND_FROM_EMAIL ?? 'AIQUAA <noreply@aiquaa.com>';
 
   if (!apiKey) {
-    console.warn('[resend] RESEND_API_KEY not set — email not sent');
-    return { error: null };
+    const error = 'RESEND_API_KEY not set';
+    console.warn(`[resend] ${error} - email not sent`);
+    return { error };
   }
 
   const res = await fetch(RESEND_API_URL, {
@@ -24,7 +25,9 @@ export async function sendEmail(
 
   if (!res.ok) {
     const body = await res.json().catch(() => ({}));
-    return { error: (body as { message?: string }).message ?? `HTTP ${res.status}` };
+    return {
+      error: (body as { message?: string }).message ?? `HTTP ${res.status}`,
+    };
   }
 
   return { error: null };

--- a/supabase/migrations/20260710_000000_fix_reported_bugs_security_guardrails.sql
+++ b/supabase/migrations/20260710_000000_fix_reported_bugs_security_guardrails.sql
@@ -1,0 +1,145 @@
+-- Fix reported bugs/security without changing ranking/top SQL.
+-- This migration intentionally does not alter get_leaderboard, get_xp_ranking,
+-- ranking_candidatos, ordering, scoring, or leaderboard filters.
+
+-- Private bucket for test-app evidence. The app uploads authenticated users'
+-- screenshots here and stores only object references in exam_results.metadata.
+INSERT INTO storage.buckets (id, name, public)
+VALUES ('test-app-evidence', 'test-app-evidence', false)
+ON CONFLICT (id) DO NOTHING;
+
+DROP POLICY IF EXISTS "test_app_evidence_upload_own" ON storage.objects;
+CREATE POLICY "test_app_evidence_upload_own"
+  ON storage.objects
+  FOR INSERT TO authenticated
+  WITH CHECK (
+    bucket_id = 'test-app-evidence'
+    AND (storage.foldername(name))[1] = (SELECT auth.uid())::text
+  );
+
+DROP POLICY IF EXISTS "test_app_evidence_update_own" ON storage.objects;
+CREATE POLICY "test_app_evidence_update_own"
+  ON storage.objects
+  FOR UPDATE TO authenticated
+  USING (
+    bucket_id = 'test-app-evidence'
+    AND (storage.foldername(name))[1] = (SELECT auth.uid())::text
+  )
+  WITH CHECK (
+    bucket_id = 'test-app-evidence'
+    AND (storage.foldername(name))[1] = (SELECT auth.uid())::text
+  );
+
+DROP POLICY IF EXISTS "test_app_evidence_read_own" ON storage.objects;
+CREATE POLICY "test_app_evidence_read_own"
+  ON storage.objects
+  FOR SELECT TO authenticated
+  USING (
+    bucket_id = 'test-app-evidence'
+    AND (storage.foldername(name))[1] = (SELECT auth.uid())::text
+  );
+
+-- Backfill only historical infrastructure-fundamentals attempts that failed to
+-- sync before the CHECK constraint was fixed. Do not call gamification/XP.
+INSERT INTO public.exam_results (
+  user_id,
+  exam_type,
+  exam_mode,
+  score,
+  total_questions,
+  max_possible_score,
+  correct_answers,
+  incorrect_answers,
+  passing_score,
+  passed,
+  percentage,
+  time_spent,
+  section_scores,
+  metadata,
+  created_at
+)
+SELECT
+  aa.user_id,
+  'infrastructure-fundamentals',
+  'exam',
+  COALESCE(aa.total_score, 0),
+  COALESCE(answer_counts.total_answers, 0),
+  aa.max_score,
+  COALESCE(answer_counts.correct_answers, 0),
+  GREATEST(0, COALESCE(answer_counts.total_answers, 0) - COALESCE(answer_counts.correct_answers, 0)),
+  COALESCE((a.metadata->>'passingScore')::integer, 70),
+  COALESCE(aa.passed, false),
+  COALESCE(aa.percentage, 0),
+  GREATEST(60, COALESCE(EXTRACT(EPOCH FROM (COALESCE(aa.submitted_at, aa.updated_at) - aa.started_at))::integer, 60)),
+  COALESCE(section_scores.rows, '[]'::jsonb),
+  jsonb_build_object(
+    'assessment_attempt_id', aa.id,
+    'backfilled', true,
+    'backfilled_at', now(),
+    'source', '20260710_000000_fix_reported_bugs_security_guardrails'
+  ),
+  COALESCE(aa.submitted_at, aa.updated_at, aa.created_at)
+FROM public.assessment_attempts aa
+JOIN public.assessments a ON a.id = aa.assessment_id
+LEFT JOIN LATERAL (
+  SELECT
+    COUNT(*)::integer AS total_answers,
+    COUNT(*) FILTER (WHERE ans.is_correct IS TRUE)::integer AS correct_answers
+  FROM public.assessment_answers ans
+  WHERE ans.attempt_id = aa.id
+) answer_counts ON true
+LEFT JOIN LATERAL (
+  SELECT jsonb_agg(
+    jsonb_build_object(
+      'section', s.title,
+      'correct', sc.score,
+      'total', sc.max_score,
+      'percentage', ROUND((sc.score::numeric / GREATEST(1, sc.max_score)) * 100)
+    )
+    ORDER BY s.order_index
+  ) AS rows
+  FROM public.assessment_scores sc
+  JOIN public.assessment_sections s ON s.id = sc.section_id
+  WHERE sc.attempt_id = aa.id
+) section_scores ON true
+WHERE a.slug = 'infrastructure-fundamentals'
+  AND aa.status = 'graded'
+  AND NOT EXISTS (
+    SELECT 1
+    FROM public.exam_results er
+    WHERE er.exam_type = 'infrastructure-fundamentals'
+      AND er.metadata->>'assessment_attempt_id' = aa.id::text
+  );
+
+-- RLS initplan cleanup for known hot policies. Equivalent behavior, but
+-- auth.uid() is evaluated once. Ranking RPCs/views are not modified.
+DO $$
+BEGIN
+  IF to_regclass('public.user_xp') IS NOT NULL THEN
+    DROP POLICY IF EXISTS "user_xp_select_own" ON public.user_xp;
+    CREATE POLICY "user_xp_select_own" ON public.user_xp
+      FOR SELECT TO authenticated
+      USING ((SELECT auth.uid()) = user_id);
+  END IF;
+
+  IF to_regclass('public.profiles') IS NOT NULL THEN
+    DROP POLICY IF EXISTS "profiles_select_own" ON public.profiles;
+    CREATE POLICY "profiles_select_own" ON public.profiles
+      FOR SELECT TO authenticated
+      USING ((SELECT auth.uid()) = id);
+  END IF;
+
+  IF to_regclass('public.empresa_invitaciones') IS NOT NULL THEN
+    DROP POLICY IF EXISTS "empresa_invitaciones_member_read" ON public.empresa_invitaciones;
+    CREATE POLICY "empresa_invitaciones_member_read"
+      ON public.empresa_invitaciones FOR SELECT TO authenticated
+      USING (
+        EXISTS (
+          SELECT 1 FROM public.empresa_miembros em
+          WHERE em.empresa_id = empresa_invitaciones.empresa_id
+            AND em.user_id = (SELECT auth.uid())
+            AND em.status = 'active'
+        )
+      );
+  END IF;
+END $$;


### PR DESCRIPTION
## Summary

This PR fixes the reported bugs and security issues we could resolve in code without changing ranking behavior.

- hardens legacy exam persistence for `git`, `istqb`, and `performance` by recalculating server-side before saving
- removes base64 evidence blobs from `test-app/report` submissions by uploading screenshots to Supabase Storage and persisting only references
- adds invitation email delivery tracking, resend support, and non-blocking employer notifications when a candidate completes an exam with a `process_code`
- adds an idempotent backfill for missing `infrastructure-fundamentals` history rows plus targeted RLS initplan cleanup
- moves `test-app` admin verification to a server-only env var and stops build logs from printing secrets

## Why

- legacy labs were trusting client-submitted scoring fields and one Git flow was duplicating result writes
- `test-app/report` could exceed the Server Action body limit when screenshots were sent inline as base64
- invitation emails failed without visible delivery state, and employers were not notified when results arrived
- historical `infrastructure-fundamentals` attempts were missing from `exam_results`, so they never appeared in profile history
- Supabase advisors were flagging hot RLS policies that could be made cheaper without widening access

## Ranking Guardrails

- no changes to `get_leaderboard`, `get_xp_ranking`, `ranking_candidatos`, or leaderboard ordering/scoring/filtering logic
- the backfill only inserts missing `infrastructure-fundamentals` rows keyed by `metadata.assessment_attempt_id`
- the backfill does not recalculate XP, achievements, or gamification side effects

## Validation

- `pnpm --filter @aiquaa/frontend type-check`
- `pnpm --filter @aiquaa/frontend lint`
- `pnpm --filter @aiquaa/frontend test -- src/actions/lib/__tests__/legacy-exam-scoring.test.ts src/actions/__tests__/empresa-invitaciones.test.ts src/app/labs/test-app/report/__tests__/metadata.test.ts src/app/labs/istqb/__tests__/utils.test.ts`
- `pnpm --filter @aiquaa/frontend build` with `NODE_OPTIONS=--use-system-ca`

Full `pnpm --filter @aiquaa/frontend test` still has pre-existing auth/mock failures unrelated to this diff.

## Linked Issues

Closes #128
Closes #160
Closes #177
Closes #201
Closes #226
Closes #246
Closes #262

Refs #151
Refs #197
Refs #213
Refs #225
