### PR TITLE
feat(labs): prueba técnica práctica de Playwright (/labs/playwright-practico)

### DIFF
--- a/apps/frontend/src/actions/exams.ts
+++ b/apps/frontend/src/actions/exams.ts
@@ -21,7 +21,8 @@ interface SaveExamResultPayload {
     | 'database-fundamentals'
     | 'database-practice'
     | 'infrastructure-fundamentals'
-    | 'api-developer-fundamentals';
+    | 'api-developer-fundamentals'
+    | 'playwright-practico';
   exam_mode: 'exam' | 'training';
   participant_name?: string;
   participant_email?: string;
@@ -61,7 +62,10 @@ interface SaveExamResultPayload {
 // Exámenes cuyo score automático es heurístico (conteo/keywords, no validación
 // real del contenido) y por eso arrancan marcados como pendientes de
 // corrección manual hasta que un evaluador los revise.
-const NEEDS_MANUAL_CORRECTION_EXAM_TYPES = new Set(['test-app']);
+const NEEDS_MANUAL_CORRECTION_EXAM_TYPES = new Set([
+  'test-app',
+  'playwright-practico',
+]);
 
 export async function saveExamResultAction(payload: SaveExamResultPayload) {
   const normalizedPayload = recalculateLegacyExamPayload(payload);

--- a/apps/frontend/src/app/api/labs/playwright-practico/verify/route.ts
+++ b/apps/frontend/src/app/api/labs/playwright-practico/verify/route.ts
@@ -1,0 +1,272 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { Octokit } from '@octokit/rest';
+import { createClient } from '@/lib/supabase/server';
+import { validateProcessCodeAction } from '@/actions/employer';
+import { saveExamResultAction } from '@/actions/exams';
+import {
+  parseRepoSlug,
+  parseIssueOrPrNumber,
+  hasFolderUpload,
+} from '@/lib/labs/gitPractico';
+import {
+  FOLDER_PREFIX,
+  MIN_SPEC_FILES,
+  MAX_PR_FILES,
+  MAX_SPEC_FILES_TO_FETCH,
+  MAX_SPEC_FILE_BYTES,
+  PASSING_SCORE,
+  findPlaywrightConfig,
+  listSpecFiles,
+  usesWebFirstLocators,
+  targetsTestApp,
+  detectScenarios,
+  scoreChecks,
+  type CheckResult,
+} from '@/lib/labs/playwrightPractico';
+
+/**
+ * Verifica la prueba práctica de Playwright contra el repo del proceso de
+ * contratación. La verificación es estática: lista los archivos del PR y lee
+ * el contenido de los specs vía GitHub API (no ejecuta los tests); las
+ * heurísticas se complementan con revisión manual (review_status pendiente).
+ *
+ * Env requerida:
+ * - GITHUB_TOKEN: token con permiso de lectura sobre el repo destino (evita
+ *   rate limits; sin token el límite anónimo de 60 req/h hace inviable el lab).
+ */
+
+const getOctokit = () =>
+  new Octokit(
+    process.env.GITHUB_TOKEN ? { auth: process.env.GITHUB_TOKEN } : {}
+  );
+
+const eqLogin = (a?: string | null, b?: string | null) =>
+  Boolean(a && b && a.toLowerCase() === b.toLowerCase());
+
+export async function POST(request: NextRequest) {
+  try {
+    // 1. Auth
+    const supabase = createClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+    if (!user) {
+      return NextResponse.json({ error: 'No autenticado' }, { status: 401 });
+    }
+
+    const body = await request.json().catch(() => null);
+    const processCode: string = body?.process_code?.trim() ?? '';
+    const candidateGithub: string = body?.candidate_github?.trim() ?? '';
+    const prUrl: string = body?.pr_url?.trim() ?? '';
+
+    if (!processCode || !candidateGithub || !prUrl) {
+      return NextResponse.json(
+        { error: 'Faltan campos obligatorios' },
+        { status: 400 }
+      );
+    }
+
+    // 2. Resolver proceso por código
+    const { valid, process, reason } =
+      await validateProcessCodeAction(processCode);
+    if (!valid || !process) {
+      return NextResponse.json(
+        {
+          error:
+            reason === 'expired'
+              ? 'El proceso está vencido'
+              : 'Código de proceso inválido',
+        },
+        { status: 403 }
+      );
+    }
+    if (!(process.exam_types ?? []).includes('playwright-practico')) {
+      return NextResponse.json(
+        { error: 'Este proceso no incluye la prueba práctica de Playwright' },
+        { status: 403 }
+      );
+    }
+
+    const slug = process.repository_url
+      ? parseRepoSlug(process.repository_url)
+      : null;
+    if (!slug) {
+      return NextResponse.json(
+        { error: 'El proceso no tiene un repositorio válido configurado' },
+        { status: 422 }
+      );
+    }
+
+    // 3. Parsear link del PR
+    const prNumber = parseIssueOrPrNumber(prUrl);
+    if (!prNumber) {
+      return NextResponse.json(
+        { error: 'El link del Pull Request no es válido' },
+        { status: 400 }
+      );
+    }
+
+    // 4. Chequeos con GitHub API
+    const octokit = getOctokit();
+    const { owner, repo } = slug;
+
+    const pr = await octokit.pulls
+      .get({ owner, repo, pull_number: prNumber })
+      .then((r) => r.data)
+      .catch(() => null);
+
+    // Paginado con tope: un candidato que commitea node_modules/ puede superar
+    // por mucho los 100 archivos de la primera página.
+    const filenames: string[] = [];
+    if (pr) {
+      try {
+        await octokit.paginate(
+          octokit.pulls.listFiles,
+          { owner, repo, pull_number: prNumber, per_page: 100 },
+          (response, done) => {
+            for (const f of response.data) filenames.push(f.filename);
+            if (filenames.length >= MAX_PR_FILES) done();
+            return response.data;
+          }
+        );
+      } catch {
+        /* seguimos con lo que se haya podido listar */
+      }
+    }
+
+    const folder = hasFolderUpload(filenames, FOLDER_PREFIX);
+    const configPath = findPlaywrightConfig(filenames, folder.folder);
+    const specFiles = listSpecFiles(filenames, folder.folder);
+
+    // Contenido de los specs en el head del PR. `refs/pull/N/head` existe en el
+    // repo base también cuando el PR viene de un fork.
+    const contents: string[] = [];
+    for (const path of specFiles.slice(0, MAX_SPEC_FILES_TO_FETCH)) {
+      const data = await octokit.repos
+        .getContent({ owner, repo, path, ref: `refs/pull/${prNumber}/head` })
+        .then((r) => r.data)
+        .catch(() => null);
+      if (
+        data &&
+        !Array.isArray(data) &&
+        data.type === 'file' &&
+        typeof data.content === 'string' &&
+        data.size <= MAX_SPEC_FILE_BYTES
+      ) {
+        contents.push(Buffer.from(data.content, 'base64').toString('utf-8'));
+      }
+    }
+
+    const scenarios = detectScenarios(contents);
+
+    const checks: CheckResult[] = [
+      {
+        id: 'pr',
+        label: 'Pull Request abierto por el candidato',
+        passed: Boolean(pr && eqLogin(pr.user?.login, candidateGithub)),
+        detail: pr ? undefined : 'No se encontró el PR',
+      },
+      {
+        id: 'folder',
+        label: `Carpeta subida (${FOLDER_PREFIX}*)`,
+        passed: folder.ok,
+        detail:
+          folder.folder ??
+          (filenames.length >= MAX_PR_FILES
+            ? `PR con demasiados archivos (>${MAX_PR_FILES}); ¿subiste node_modules?`
+            : undefined),
+      },
+      {
+        id: 'config',
+        label: 'playwright.config incluido en la carpeta',
+        passed: Boolean(configPath),
+        detail: configPath ?? undefined,
+      },
+      {
+        id: 'specs',
+        label: `Al menos ${MIN_SPEC_FILES} archivos *.spec/*.test`,
+        passed: specFiles.length >= MIN_SPEC_FILES,
+        detail: `${specFiles.length} archivo(s) de test`,
+      },
+      {
+        id: 'locators',
+        label: 'Locators web-first (getByRole, getByLabel, ...)',
+        passed: usesWebFirstLocators(contents),
+      },
+      {
+        id: 'target',
+        label: 'Los tests apuntan a /labs/test-app',
+        passed: targetsTestApp(contents),
+      },
+      {
+        id: 'esc_login',
+        label: 'Escenario: login (válido e inválido)',
+        passed: scenarios.login,
+      },
+      {
+        id: 'esc_catalogo',
+        label: 'Escenario: búsqueda en catálogo',
+        passed: scenarios.catalog,
+      },
+      {
+        id: 'esc_carrito',
+        label: 'Escenario: carrito y total',
+        passed: scenarios.cart,
+      },
+      {
+        id: 'esc_checkout',
+        label: 'Escenario: validación de checkout',
+        passed: scenarios.checkout,
+      },
+    ];
+
+    const { score, maxScore, passed } = scoreChecks(checks);
+    const percentage = Math.round((score / maxScore) * 100);
+    const correct = checks.filter((c) => c.passed).length;
+
+    // 5. Guardar resultado (aparece en el dashboard del proceso vía process_code)
+    await saveExamResultAction({
+      exam_type: 'playwright-practico',
+      exam_mode: 'exam',
+      score,
+      total_questions: checks.length,
+      max_possible_score: maxScore,
+      correct_answers: correct,
+      incorrect_answers: checks.length - correct,
+      passing_score: PASSING_SCORE,
+      passed,
+      percentage,
+      time_spent: 0,
+      github_profile: candidateGithub,
+      company_name: process.company_name ?? undefined,
+      process_code: process.code,
+      metadata: {
+        repository: `${owner}/${repo}`,
+        pr_url: prUrl,
+        folder: folder.folder,
+        config_path: configPath,
+        spec_files: specFiles,
+        checks,
+      },
+    });
+
+    return NextResponse.json(
+      { score, maxScore, percentage, passed, checks },
+      { status: 200 }
+    );
+  } catch (error) {
+    console.error('playwright-practico verify error:', error);
+    return NextResponse.json(
+      {
+        error:
+          error instanceof Error
+            ? error.message
+            : 'Error inesperado al verificar',
+      },
+      { status: 500 }
+    );
+  }
+}
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';

--- a/apps/frontend/src/app/dashboard/page.tsx
+++ b/apps/frontend/src/app/dashboard/page.tsx
@@ -83,6 +83,7 @@ export default function DashboardPage() {
     'database-practice',
     'infrastructure-fundamentals',
     'api-developer-fundamentals',
+    'playwright-practico',
   ];
   const recommended = allTypes.find((t) => !passedTypes.has(t)) ?? null;
   const allPassed = allTypes.every((t) => passedTypes.has(t));

--- a/apps/frontend/src/app/employer/nuevo/page.tsx
+++ b/apps/frontend/src/app/employer/nuevo/page.tsx
@@ -15,6 +15,10 @@ const EXAM_OPTIONS = [
   { value: 'istqb', label: 'ISTQB Foundation Level' },
   { value: 'git', label: 'Git' },
   { value: 'git-practico', label: 'Git — Prueba práctica (GitHub)' },
+  {
+    value: 'playwright-practico',
+    label: 'Playwright — Prueba práctica (E2E)',
+  },
   { value: 'performance', label: 'Rendimiento / Performance' },
   { value: 'api-testing-fundamentals', label: 'API Testing Fundamentals' },
   { value: 'api-banking', label: 'API Testing - Challenge practico' },

--- a/apps/frontend/src/app/empresa/buscar-candidatos/page.tsx
+++ b/apps/frontend/src/app/empresa/buscar-candidatos/page.tsx
@@ -27,6 +27,7 @@ const EXAM_LABELS: Record<string, string> = {
   istqb: 'ISTQB CTFL',
   git: 'Git',
   'git-practico': 'Git Practica',
+  'playwright-practico': 'Playwright Práctica',
   performance: 'Performance',
   'api-testing-fundamentals': 'API Testing Fundamentals',
   'api-banking': 'API Testing Challenge',

--- a/apps/frontend/src/app/empresa/candidatos/page.tsx
+++ b/apps/frontend/src/app/empresa/candidatos/page.tsx
@@ -63,6 +63,7 @@ const EXAM_LABELS: Record<string, string> = {
   istqb: 'ISTQB CTFL',
   git: 'Git',
   'git-practico': 'Git Práctica',
+  'playwright-practico': 'Playwright Práctica',
   performance: 'Performance',
   'test-app': 'Test App — Bug Hunt',
   'api-testing-fundamentals': 'API Testing Fundamentals',

--- a/apps/frontend/src/app/empresa/procesos/[id]/page.tsx
+++ b/apps/frontend/src/app/empresa/procesos/[id]/page.tsx
@@ -116,6 +116,7 @@ const EXAM_LABELS: Record<string, string> = {
   istqb: 'ISTQB CTFL',
   git: 'Git',
   'git-practico': 'Git — Prueba práctica',
+  'playwright-practico': 'Playwright — Prueba práctica',
   performance: 'Performance',
   'test-app': 'Test App — Bug Hunt',
   'api-testing-fundamentals': 'API Testing Fundamentals',

--- a/apps/frontend/src/app/empresa/procesos/nuevo/page.tsx
+++ b/apps/frontend/src/app/empresa/procesos/nuevo/page.tsx
@@ -30,6 +30,12 @@ const EXAM_OPTIONS = [
       'Flujo real en un repo: crear issue, rama, subir carpeta y abrir un PR que cierre el issue — verificación automática vía GitHub API',
   },
   {
+    id: 'playwright-practico',
+    label: 'Playwright — Prueba práctica (E2E)',
+    description:
+      'Automatización real: specs de Playwright para login, catálogo, carrito y checkout de la Test App, entregados por PR — verificación automática vía GitHub API',
+  },
+  {
     id: 'performance',
     label: 'Performance Testing — Pruebas de carga',
     description:

--- a/apps/frontend/src/app/invitaciones/[token]/page.tsx
+++ b/apps/frontend/src/app/invitaciones/[token]/page.tsx
@@ -7,6 +7,7 @@ const EXAM_LABELS: Record<string, string> = {
   istqb: 'ISTQB CTFL',
   git: 'Git',
   'git-practico': 'Git Práctica',
+  'playwright-practico': 'Playwright Práctica',
   performance: 'Performance Testing',
   'api-testing-fundamentals': 'API Testing Fundamentals',
   'api-banking': 'API Testing Challenge',

--- a/apps/frontend/src/app/labs/playwright-practico/PlaywrightPracticoClient.tsx
+++ b/apps/frontend/src/app/labs/playwright-practico/PlaywrightPracticoClient.tsx
@@ -1,0 +1,398 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useTheme } from '@/contexts/ThemeContext';
+import { useToolUsage } from '@/hooks/useToolUsage';
+import { validateProcessCodeAction } from '@/actions/employer';
+
+const STORAGE_KEY = 'playwright-practico-last';
+const TEST_APP_PATH = '/labs/test-app';
+
+interface CheckResult {
+  id: string;
+  label: string;
+  passed: boolean;
+  detail?: string;
+}
+
+interface VerifyResponse {
+  score: number;
+  maxScore: number;
+  percentage: number;
+  passed: boolean;
+  checks: CheckResult[];
+}
+
+interface ResolvedProcess {
+  code: string;
+  position_name: string;
+  company_name: string;
+  repository_url: string | null;
+}
+
+export default function PlaywrightPracticoClient() {
+  const { isDarkMode } = useTheme();
+  const { logUsage, logError } = useToolUsage('playwright-practico');
+
+  const [code, setCode] = useState('');
+  const [validating, setValidating] = useState(false);
+  const [process, setProcess] = useState<ResolvedProcess | null>(null);
+  const [gateError, setGateError] = useState<string | null>(null);
+
+  const [github, setGithub] = useState('');
+  const [prUrl, setPrUrl] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [formError, setFormError] = useState<string | null>(null);
+  const [result, setResult] = useState<VerifyResponse | null>(null);
+  const [testAppUrl, setTestAppUrl] = useState(
+    `https://aiquaa.com${TEST_APP_PATH}`
+  );
+
+  useEffect(() => {
+    setTestAppUrl(`${window.location.origin}${TEST_APP_PATH}`);
+    try {
+      const stored = localStorage.getItem(STORAGE_KEY);
+      if (stored) {
+        const p = JSON.parse(stored);
+        setGithub(p.github ?? '');
+      }
+    } catch {
+      /* ignore */
+    }
+  }, []);
+
+  const repoSlug = process?.repository_url
+    ? process.repository_url.replace('https://github.com/', '')
+    : '';
+  const folderName = github
+    ? `prueba_tecnica_playwright_${github}`
+    : 'prueba_tecnica_playwright_<usuario>';
+
+  const handleValidate = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!code.trim()) return;
+    setValidating(true);
+    setGateError(null);
+    try {
+      const {
+        valid,
+        process: p,
+        reason,
+      } = await validateProcessCodeAction(code.trim());
+      if (!valid || !p) {
+        setGateError(
+          reason === 'expired'
+            ? 'El proceso está vencido.'
+            : 'Código inválido. Revisá el código que te dio la empresa.'
+        );
+        return;
+      }
+      if (!(p.exam_types ?? []).includes('playwright-practico')) {
+        setGateError('Este código no incluye la prueba práctica de Playwright.');
+        return;
+      }
+      setProcess({
+        code: p.code,
+        position_name: p.position_name,
+        company_name: p.company_name,
+        repository_url: p.repository_url ?? null,
+      });
+      void logUsage('start');
+    } catch (err) {
+      setGateError('No se pudo validar el código. Intentá de nuevo.');
+      void logError(err, 'validate');
+    } finally {
+      setValidating(false);
+    }
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!process) return;
+    setSubmitting(true);
+    setFormError(null);
+    setResult(null);
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify({ github }));
+      const res = await fetch('/api/labs/playwright-practico/verify', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          process_code: process.code,
+          candidate_github: github.trim(),
+          pr_url: prUrl.trim(),
+        }),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        setFormError(data?.error ?? 'No se pudo verificar.');
+        return;
+      }
+      setResult(data as VerifyResponse);
+      void logUsage('verify');
+    } catch (err) {
+      setFormError('Error de red al verificar.');
+      void logError(err, 'verify');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const inputClass = `w-full rounded-lg border px-3 py-2 text-sm outline-none transition-colors focus:ring-2 focus:ring-indigo-500 ${
+    isDarkMode
+      ? 'bg-slate-700 border-slate-600 text-white placeholder-slate-400'
+      : 'bg-white border-gray-300 text-gray-900 placeholder-gray-400'
+  }`;
+  const labelClass = `block text-sm font-medium mb-1.5 ${isDarkMode ? 'text-slate-300' : 'text-gray-700'}`;
+  const cardClass = `rounded-xl border p-6 ${isDarkMode ? 'bg-dark-secondary border-slate-700' : 'bg-white border-gray-200'}`;
+
+  return (
+    <div
+      className={`min-h-screen transition-colors duration-300 ${isDarkMode ? 'bg-dark-bg' : 'bg-gray-50'}`}
+    >
+      <div className="max-w-2xl mx-auto px-4 sm:px-6 lg:px-8 py-12 space-y-6">
+        <header>
+          <h1
+            className={`text-2xl font-bold ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
+          >
+            🎭 Prueba práctica de Playwright
+          </h1>
+          <p
+            className={`text-sm mt-1 ${isDarkMode ? 'text-slate-400' : 'text-gray-500'}`}
+          >
+            Automatizá 4 escenarios E2E contra la Test App (login, catálogo,
+            carrito y checkout) y entregalos por Pull Request. La corrección es
+            automática.
+          </p>
+        </header>
+
+        {/* Step 0 — gate por código */}
+        {!process && (
+          <form onSubmit={handleValidate} className={`${cardClass} space-y-4`}>
+            <div>
+              <label className={labelClass}>Código del proceso *</label>
+              <input
+                type="text"
+                className={`${inputClass} font-mono tracking-wider`}
+                placeholder="ej. AIQUAA-2026-X7K"
+                value={code}
+                onChange={(e) => setCode(e.target.value.toUpperCase())}
+                required
+              />
+              <p
+                className={`text-xs mt-1 ${isDarkMode ? 'text-slate-500' : 'text-gray-400'}`}
+              >
+                Es el código que te compartió la empresa para esta prueba.
+              </p>
+            </div>
+            {gateError && (
+              <div className="rounded-lg border border-red-300 bg-red-50 text-red-700 px-4 py-3 text-sm dark:border-red-700/50 dark:bg-red-900/20 dark:text-red-300">
+                {gateError}
+              </div>
+            )}
+            <button
+              type="submit"
+              disabled={validating || !code.trim()}
+              className="w-full py-2.5 rounded-lg text-sm font-semibold bg-indigo-600 text-white hover:bg-indigo-700 disabled:opacity-50 transition-colors"
+            >
+              {validating ? 'Validando...' : 'Continuar'}
+            </button>
+          </form>
+        )}
+
+        {/* Instrucciones + form */}
+        {process && (
+          <>
+            <div className={cardClass}>
+              <p
+                className={`text-xs font-semibold uppercase tracking-widest mb-1 ${isDarkMode ? 'text-indigo-400' : 'text-indigo-500'}`}
+              >
+                {process.company_name} · {process.position_name}
+              </p>
+              <a
+                href={process.repository_url ?? '#'}
+                target="_blank"
+                rel="noopener noreferrer"
+                className={`text-lg font-semibold inline-flex items-center gap-2 ${isDarkMode ? 'text-white hover:text-indigo-300' : 'text-gray-900 hover:text-indigo-600'}`}
+              >
+                🔗 {repoSlug}
+              </a>
+
+              <ol
+                className={`mt-4 space-y-2 text-sm list-decimal list-inside ${isDarkMode ? 'text-slate-300' : 'text-gray-700'}`}
+              >
+                <li>
+                  Cloná el repositorio y creá una <strong>rama</strong> nueva a
+                  partir de <code>main</code>.
+                </li>
+                <li>
+                  En la carpeta <code>{folderName}/</code> inicializá un
+                  proyecto de Playwright (<code>npm init playwright@latest</code>
+                  ). Incluí tu <code>playwright.config.ts</code> y la carpeta{' '}
+                  <code>tests/</code>. <strong>No subas</strong>{' '}
+                  <code>node_modules/</code> ni <code>test-results/</code>{' '}
+                  (agregá un <code>.gitignore</code>).
+                </li>
+                <li>
+                  Sistema bajo prueba:{' '}
+                  <a
+                    href={testAppUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-indigo-500 hover:underline"
+                  >
+                    {testAppUrl}
+                  </a>{' '}
+                  (usala como <code>baseURL</code>). Credenciales demo:{' '}
+                  <code>tester@aiquaa.com</code> / <code>Test1234!</code>.
+                </li>
+                <li>
+                  Automatizá estos <strong>4 escenarios</strong> (mínimo 3
+                  archivos <code>.spec.ts</code>):
+                  <ul className="list-disc list-inside ml-4 mt-1 space-y-1">
+                    <li>
+                      <strong>Login:</strong> con credenciales válidas llegás al
+                      catálogo; con contraseña incorrecta se muestra un error
+                      (usá aserciones web-first como <code>toHaveURL</code> y{' '}
+                      <code>toBeVisible</code>).
+                    </li>
+                    <li>
+                      <strong>Búsqueda en catálogo:</strong> buscá un término y
+                      verificá que los resultados corresponden.
+                    </li>
+                    <li>
+                      <strong>Carrito:</strong> agregá un producto, verificá que
+                      aparece y que el total es coherente (precio × cantidad).
+                    </li>
+                    <li>
+                      <strong>Validación de checkout:</strong> confirmá con
+                      campos vacíos o inválidos y verificá los mensajes.
+                    </li>
+                  </ul>
+                </li>
+                <li>
+                  Se valora: <code>beforeEach</code>, un Page Object simple y
+                  locators <code>getByRole</code>/<code>getByLabel</code>/
+                  <code>getByPlaceholder</code> (evitá{' '}
+                  <code>waitForTimeout</code> y selectores CSS frágiles).
+                </li>
+                <li>
+                  Abrí un <strong>Pull Request</strong> hacia <code>main</code>{' '}
+                  y pegá abajo tu usuario y el link del PR.
+                </li>
+              </ol>
+
+              <p
+                className={`mt-4 text-xs rounded-lg px-3 py-2 ${isDarkMode ? 'bg-amber-900/20 text-amber-300' : 'bg-amber-50 text-amber-700'}`}
+              >
+                ⚠️ La Test App tiene <strong>bugs intencionales</strong>: si un
+                test tuyo falla por un comportamiento raro de la app, puede ser
+                un bug real. Documentalo en la descripción del PR — suma en la
+                evaluación.
+              </p>
+            </div>
+
+            <form onSubmit={handleSubmit} className={`${cardClass} space-y-4`}>
+              <div>
+                <label className={labelClass}>Tu usuario de GitHub *</label>
+                <input
+                  type="text"
+                  className={inputClass}
+                  placeholder="ej. stevenayal"
+                  value={github}
+                  onChange={(e) => setGithub(e.target.value)}
+                  required
+                />
+              </div>
+              <div>
+                <label className={labelClass}>Link del Pull Request *</label>
+                <input
+                  type="url"
+                  className={inputClass}
+                  placeholder={`https://github.com/${repoSlug || 'owner/repo'}/pull/2`}
+                  value={prUrl}
+                  onChange={(e) => setPrUrl(e.target.value)}
+                  required
+                />
+              </div>
+              {formError && (
+                <div className="rounded-lg border border-red-300 bg-red-50 text-red-700 px-4 py-3 text-sm dark:border-red-700/50 dark:bg-red-900/20 dark:text-red-300">
+                  {formError}
+                </div>
+              )}
+              <div className="flex gap-3">
+                <button
+                  type="submit"
+                  disabled={submitting}
+                  className="flex-1 py-2.5 rounded-lg text-sm font-semibold bg-indigo-600 text-white hover:bg-indigo-700 disabled:opacity-50 transition-colors"
+                >
+                  {submitting ? 'Verificando...' : 'Verificar mi entrega'}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => {
+                    setProcess(null);
+                    setResult(null);
+                    setCode('');
+                  }}
+                  className={`px-4 py-2.5 rounded-lg text-sm font-medium transition-colors ${isDarkMode ? 'text-slate-300 hover:bg-slate-700' : 'text-gray-700 hover:bg-gray-100'}`}
+                >
+                  Cambiar código
+                </button>
+              </div>
+            </form>
+
+            {/* Resultado */}
+            {result && (
+              <div className={cardClass}>
+                <div className="flex items-center justify-between mb-4">
+                  <span
+                    className={`text-sm font-medium ${isDarkMode ? 'text-slate-300' : 'text-gray-700'}`}
+                  >
+                    Resultado
+                  </span>
+                  <span
+                    className={`text-sm font-bold px-3 py-1 rounded-full ${
+                      result.passed
+                        ? 'bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-300'
+                        : 'bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300'
+                    }`}
+                  >
+                    {result.passed ? '✅ Aprobado' : '❌ No aprobado'} ·{' '}
+                    {result.score}/{result.maxScore} ({result.percentage}%)
+                  </span>
+                </div>
+                <ul className="space-y-2">
+                  {result.checks.map((c) => (
+                    <li
+                      key={c.id}
+                      className={`flex items-start gap-2 text-sm ${isDarkMode ? 'text-slate-300' : 'text-gray-700'}`}
+                    >
+                      <span>{c.passed ? '✅' : '❌'}</span>
+                      <span>
+                        {c.label}
+                        {c.detail && (
+                          <span
+                            className={`ml-1 text-xs ${isDarkMode ? 'text-slate-500' : 'text-gray-400'}`}
+                          >
+                            ({c.detail})
+                          </span>
+                        )}
+                      </span>
+                    </li>
+                  ))}
+                </ul>
+                <p
+                  className={`mt-4 text-xs ${isDarkMode ? 'text-slate-500' : 'text-gray-400'}`}
+                >
+                  La verificación automática es estática (no ejecuta tus tests).
+                  Un evaluador revisará además la calidad del código en tu PR.
+                </p>
+              </div>
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/src/app/labs/playwright-practico/page.tsx
+++ b/apps/frontend/src/app/labs/playwright-practico/page.tsx
@@ -1,0 +1,52 @@
+import { Metadata } from 'next';
+import PlaywrightPracticoClient from './PlaywrightPracticoClient';
+
+export const metadata: Metadata = {
+  title: 'Prueba práctica de Playwright | AIQUAA Labs',
+  description:
+    'Prueba técnica práctica de Playwright: automatizá login, catálogo, carrito y checkout de la Test App y entregá tus specs por Pull Request. Verificación automática vía GitHub API.',
+  keywords: [
+    'prueba técnica Playwright',
+    'playwright práctico',
+    'automatización E2E',
+    'test automation',
+    'pull request',
+    'QA',
+    'AIQUAA',
+    'evaluación técnica',
+  ],
+  openGraph: {
+    title: 'Prueba práctica de Playwright | AIQUAA',
+    description:
+      'Automatizá 4 escenarios E2E contra la Test App y entregalos por PR. Corrección automática.',
+    url: 'https://aiquaa.com/labs/playwright-practico',
+    siteName: 'AIQUAA',
+    type: 'website',
+    locale: 'es_PY',
+    images: [
+      {
+        url: '/api/og?title=Prueba%20pr%C3%A1ctica%20de%20Playwright&subtitle=Login%20%E2%86%92%20cat%C3%A1logo%20%E2%86%92%20carrito%20%E2%86%92%20checkout&section=Labs',
+        width: 1200,
+        height: 630,
+        alt: 'Prueba práctica de Playwright - AIQUAA',
+      },
+    ],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Prueba práctica de Playwright | AIQUAA',
+    description:
+      'Automatizá 4 escenarios E2E contra la Test App y entregalos por PR. Corrección automática.',
+    images: [
+      '/api/og?title=Prueba%20pr%C3%A1ctica%20de%20Playwright&subtitle=Login%20%E2%86%92%20cat%C3%A1logo%20%E2%86%92%20carrito%20%E2%86%92%20checkout&section=Labs',
+    ],
+    creator: '@stevenayal',
+  },
+  alternates: {
+    canonical: 'https://aiquaa.com/labs/playwright-practico',
+  },
+};
+
+export default function PlaywrightPracticoPage() {
+  return <PlaywrightPracticoClient />;
+}

--- a/apps/frontend/src/app/perfil/page.tsx
+++ b/apps/frontend/src/app/perfil/page.tsx
@@ -48,7 +48,8 @@ interface ExamResultRow {
     | 'database-fundamentals'
     | 'database-practice'
     | 'infrastructure-fundamentals'
-    | 'api-developer-fundamentals';
+    | 'api-developer-fundamentals'
+    | 'playwright-practico';
   exam_mode: 'exam' | 'training';
   score: number;
   total_questions: number;

--- a/apps/frontend/src/app/talento/[id]/page.tsx
+++ b/apps/frontend/src/app/talento/[id]/page.tsx
@@ -5,6 +5,7 @@ const EXAM_LABELS: Record<string, string> = {
   istqb: 'ISTQB CTFL',
   git: 'Git',
   'git-practico': 'Git Práctica',
+  'playwright-practico': 'Playwright Práctica',
   performance: 'Performance',
   'api-testing-fundamentals': 'API Testing Fundamentals',
   'api-banking': 'API Testing Challenge',

--- a/apps/frontend/src/components/labs/LabsAuthGate.tsx
+++ b/apps/frontend/src/components/labs/LabsAuthGate.tsx
@@ -17,6 +17,7 @@ const PROTECTED_LABS_ROUTES = [
   '/labs/istqb',
   '/labs/git',
   '/labs/git-practico',
+  '/labs/playwright-practico',
   '/labs/api-testing-fundamentals',
   '/labs/allpairs',
   '/labs/data-generator',

--- a/apps/frontend/src/lib/exams.ts
+++ b/apps/frontend/src/lib/exams.ts
@@ -13,7 +13,8 @@ export type ExamType =
   | 'database-fundamentals'
   | 'database-practice'
   | 'infrastructure-fundamentals'
-  | 'api-developer-fundamentals';
+  | 'api-developer-fundamentals'
+  | 'playwright-practico';
 
 export interface ExamMeta {
   emoji: string;
@@ -69,6 +70,11 @@ export const EXAM_META: Record<ExamType, ExamMeta> = {
     label: 'APIs para Desarrolladores — Fundamentos',
     href: '/assessments/api-developer-fundamentals',
   },
+  'playwright-practico': {
+    emoji: '🎭',
+    label: 'Playwright — Prueba práctica',
+    href: '/labs/playwright-practico',
+  },
 };
 
 export const EXAM_TYPES = Object.keys(EXAM_META) as ExamType[];
@@ -82,6 +88,7 @@ export const POINTS_BASED_TYPES = new Set<ExamType>([
   'database-practice',
   'infrastructure-fundamentals',
   'api-developer-fundamentals',
+  'playwright-practico',
 ]);
 
 export interface ExamScoreFields {

--- a/apps/frontend/src/lib/labs/__tests__/playwrightPractico.test.ts
+++ b/apps/frontend/src/lib/labs/__tests__/playwrightPractico.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect } from 'vitest';
+import {
+  findPlaywrightConfig,
+  listSpecFiles,
+  usesWebFirstLocators,
+  targetsTestApp,
+  detectScenarios,
+  scoreChecks,
+  FOLDER_PREFIX,
+  type CheckResult,
+} from '../playwrightPractico';
+import { hasFolderUpload } from '../gitPractico';
+
+const FOLDER = 'prueba_tecnica_playwright_steven';
+
+describe('FOLDER_PREFIX + hasFolderUpload (reused from gitPractico)', () => {
+  it('detects the playwright folder with the explicit prefix', () => {
+    const r = hasFolderUpload(
+      [`${FOLDER}/playwright.config.ts`, 'README.md'],
+      FOLDER_PREFIX
+    );
+    expect(r.ok).toBe(true);
+    expect(r.folder).toBe(FOLDER);
+  });
+
+  it('rejects the generic prueba_tecnica_* folder of git-practico', () => {
+    expect(
+      hasFolderUpload(['prueba_tecnica_steven/x.json'], FOLDER_PREFIX).ok
+    ).toBe(false);
+  });
+});
+
+describe('findPlaywrightConfig', () => {
+  it('finds a ts config inside the folder', () => {
+    expect(
+      findPlaywrightConfig(
+        [`${FOLDER}/playwright.config.ts`, `${FOLDER}/tests/login.spec.ts`],
+        FOLDER
+      )
+    ).toBe(`${FOLDER}/playwright.config.ts`);
+  });
+
+  it('finds a js config in a subfolder', () => {
+    expect(
+      findPlaywrightConfig([`${FOLDER}/e2e/playwright.config.js`], FOLDER)
+    ).toBe(`${FOLDER}/e2e/playwright.config.js`);
+  });
+
+  it('ignores configs outside the folder and returns null without folder', () => {
+    expect(findPlaywrightConfig(['playwright.config.ts'], FOLDER)).toBeNull();
+    expect(findPlaywrightConfig(['playwright.config.ts'], null)).toBeNull();
+  });
+});
+
+describe('listSpecFiles', () => {
+  it('lists spec and test files inside the folder only', () => {
+    const files = [
+      `${FOLDER}/tests/login.spec.ts`,
+      `${FOLDER}/tests/cart.test.js`,
+      `${FOLDER}/playwright.config.ts`,
+      'e2e/other.spec.ts',
+    ];
+    expect(listSpecFiles(files, FOLDER)).toEqual([
+      `${FOLDER}/tests/login.spec.ts`,
+      `${FOLDER}/tests/cart.test.js`,
+    ]);
+  });
+
+  it('returns empty without folder', () => {
+    expect(listSpecFiles(['a.spec.ts'], null)).toEqual([]);
+  });
+});
+
+describe('usesWebFirstLocators', () => {
+  it('detects getByRole / getByLabel', () => {
+    expect(
+      usesWebFirstLocators(["page.getByRole('button', { name: 'Entrar' })"])
+    ).toBe(true);
+    expect(usesWebFirstLocators(["page.getByLabel('Email')"])).toBe(true);
+  });
+
+  it('rejects css-only locators', () => {
+    expect(
+      usesWebFirstLocators(["page.locator('#login')", "page.click('.btn')"])
+    ).toBe(false);
+  });
+});
+
+describe('targetsTestApp', () => {
+  it('detects the test-app base url', () => {
+    expect(
+      targetsTestApp(["await page.goto('https://aiquaa.com/labs/test-app');"])
+    ).toBe(true);
+    expect(targetsTestApp(["await page.goto('https://example.com');"])).toBe(
+      false
+    );
+  });
+});
+
+describe('detectScenarios', () => {
+  it('detects each scenario from minimal specs', () => {
+    const r = detectScenarios([
+      "await page.goto('/labs/test-app/login'); await page.fill('input', password);",
+      "await page.goto('/labs/test-app/catalog'); await search.fill('mouse');",
+      "await addToCart.click(); await expect(page.getByText('Total')).toBeVisible();",
+      "await page.goto('/labs/test-app/checkout'); await expect(error).toContainText('obligatorio');",
+    ]);
+    expect(r).toEqual({
+      login: true,
+      catalog: true,
+      cart: true,
+      checkout: true,
+    });
+  });
+
+  it('requires both signals per scenario', () => {
+    const r = detectScenarios(["await page.goto('/labs/test-app/login');"]);
+    expect(r.login).toBe(false);
+    expect(r.catalog).toBe(false);
+    expect(r.cart).toBe(false);
+    expect(r.checkout).toBe(false);
+  });
+
+  it('is case-insensitive', () => {
+    const r = detectScenarios([
+      "await page.goto('/labs/test-app/LOGIN'); // PASSWORD check",
+    ]);
+    expect(r.login).toBe(true);
+  });
+});
+
+describe('scoreChecks', () => {
+  const mk = (passed: boolean[]): CheckResult[] =>
+    passed.map((p, i) => ({ id: `c${i}`, label: `c${i}`, passed: p }));
+
+  it('scores 10 points per passing check', () => {
+    const r = scoreChecks(mk(Array(10).fill(true)));
+    expect(r).toEqual({ score: 100, maxScore: 100, passed: true });
+  });
+
+  it('passes at 7 of 10 (70)', () => {
+    const r = scoreChecks(mk([...Array(7).fill(true), ...Array(3).fill(false)]));
+    expect(r.score).toBe(70);
+    expect(r.passed).toBe(true);
+  });
+
+  it('fails below 70', () => {
+    const r = scoreChecks(mk([...Array(6).fill(true), ...Array(4).fill(false)]));
+    expect(r.score).toBe(60);
+    expect(r.passed).toBe(false);
+  });
+});

--- a/apps/frontend/src/lib/labs/playwrightPractico.ts
+++ b/apps/frontend/src/lib/labs/playwrightPractico.ts
@@ -1,0 +1,91 @@
+// Pure helpers for the Playwright practical lab (`playwright-practico`).
+// No Octokit/Supabase here so they can be unit-tested in isolation.
+// URL/PR parsing and folder detection are reused from ./gitPractico.
+
+import type { CheckResult } from './gitPractico';
+
+export type { CheckResult };
+
+export const FOLDER_PREFIX = 'prueba_tecnica_playwright_';
+export const MIN_SPEC_FILES = 3;
+export const POINTS_PER_CHECK = 10;
+export const PASSING_SCORE = 70; // at least 7 of 10 checks
+export const MAX_PR_FILES = 300; // stop paginating listFiles beyond this
+export const MAX_SPEC_FILES_TO_FETCH = 12; // cap getContent requests
+export const MAX_SPEC_FILE_BYTES = 200_000; // skip suspiciously large files
+
+const CONFIG_RE = /^playwright\.config\.(ts|js|mts|mjs|cts|cjs)$/i;
+const SPEC_RE = /\.(spec|test)\.(ts|js|mts|mjs|tsx|jsx)$/i;
+
+const inFolder = (filename: string, folder: string) =>
+  filename.toLowerCase().startsWith(`${folder.toLowerCase()}/`);
+
+/** Path of a playwright.config.* inside the candidate folder, or null. */
+export function findPlaywrightConfig(
+  filenames: string[],
+  folder: string | null
+): string | null {
+  if (!folder) return null;
+  for (const name of filenames) {
+    if (!inFolder(name, folder)) continue;
+    const base = name.split('/').pop() ?? '';
+    if (CONFIG_RE.test(base)) return name;
+  }
+  return null;
+}
+
+/** `*.spec.*` / `*.test.*` files inside the candidate folder. */
+export function listSpecFiles(
+  filenames: string[],
+  folder: string | null
+): string[] {
+  if (!folder) return [];
+  return filenames.filter(
+    (name) => inFolder(name, folder) && SPEC_RE.test(name)
+  );
+}
+
+/** True if the specs use web-first locators (getByRole, getByLabel, ...). */
+export function usesWebFirstLocators(contents: string[]): boolean {
+  return /getBy(Role|Label|Placeholder|Text|TestId|Title|AltText)\s*\(/.test(
+    contents.join('\n')
+  );
+}
+
+/** True if the specs target the system under test (`/labs/test-app`). */
+export function targetsTestApp(contents: string[]): boolean {
+  return contents.join('\n').includes('/labs/test-app');
+}
+
+export interface ScenarioCoverage {
+  login: boolean;
+  catalog: boolean;
+  cart: boolean;
+  checkout: boolean;
+}
+
+// Keyword heuristics over the combined spec contents. They are signals, not
+// proof of a working test — the 70-point threshold plus the human rubric in
+// docs/tools/playwright-practico.md absorb false negatives.
+export function detectScenarios(contents: string[]): ScenarioCoverage {
+  const all = contents.join('\n').toLowerCase();
+  return {
+    login: /\/login/.test(all) && /(password|contraseñ)/.test(all),
+    catalog: /\/catalog/.test(all) && /(search|buscar|filter|filtr)/.test(all),
+    cart:
+      /(\/cart|carrito|add.?to.?cart|agregar)/.test(all) && /total/.test(all),
+    checkout:
+      /\/checkout/.test(all) &&
+      /(required|obligatorio|error|valid|inváli)/.test(all),
+  };
+}
+
+export function scoreChecks(checks: CheckResult[]): {
+  score: number;
+  maxScore: number;
+  passed: boolean;
+} {
+  const maxScore = checks.length * POINTS_PER_CHECK;
+  const score = checks.filter((c) => c.passed).length * POINTS_PER_CHECK;
+  return { score, maxScore, passed: score >= PASSING_SCORE };
+}

--- a/apps/frontend/src/lib/labsCatalog.ts
+++ b/apps/frontend/src/lib/labsCatalog.ts
@@ -60,6 +60,16 @@ export const toolCategories: LabCategory[] = [
         implementedDate: 'Jun 2026',
       },
       {
+        id: 'playwright-practico',
+        name: 'Prueba Práctica de Playwright',
+        description:
+          'Automatizá 4 escenarios E2E contra la Test App (login, catálogo, carrito, checkout) y entregalos por PR — verificación automática vía GitHub API',
+        icon: '🎭',
+        color: 'from-emerald-600 to-teal-700',
+        href: '/labs/playwright-practico',
+        implementedDate: 'Jul 2026',
+      },
+      {
         id: 'performance',
         name: 'Examen de Performance Testing',
         description:

--- a/docs/tools/playwright-practico.md
+++ b/docs/tools/playwright-practico.md
@@ -1,0 +1,155 @@
+# Prueba Práctica de Playwright (`/labs/playwright-practico`)
+
+Prueba técnica **práctica** de automatización E2E con Playwright para candidatos QA (nivel básico-intermedio). El candidato automatiza 4 escenarios contra la **Test App** de AIQUAA (e-commerce mock con bugs intencionales) y entrega su proyecto por Pull Request. La verificación inicial es automática vía GitHub API y se complementa con una rúbrica de revisión humana.
+
+> La parte **teórica** de Playwright se implementará por separado como assessment (`assessments/_shared`). Este lab cubre solo la práctica.
+
+---
+
+## 🎯 Resumen
+
+- **Modalidad:** práctica, contra app real desplegada (`/labs/test-app`)
+- **Duración estimada:** 60–90 minutos
+- **Puntuación automática:** 100 puntos (10 checks × 10 pts), aprueba con **≥ 70**
+- **Entrega:** Pull Request al repositorio del proceso de contratación
+- **Gate:** código de proceso (igual que `git-practico`); el proceso debe incluir `playwright-practico` en `exam_types` y tener `repository_url` configurado
+- **Revisión:** el resultado queda `pending_correction` hasta que un evaluador lo revise (el score automático es heurístico)
+
+---
+
+## 📋 Consigna para el candidato
+
+### Preparación
+
+1. Cloná el repositorio del proceso y creá una **rama** nueva a partir de `main`.
+2. Dentro de la carpeta `prueba_tecnica_playwright_<tu_usuario>/`, inicializá un proyecto de Playwright:
+
+   ```bash
+   mkdir prueba_tecnica_playwright_<tu_usuario>
+   cd prueba_tecnica_playwright_<tu_usuario>
+   npm init playwright@latest
+   ```
+
+3. Incluí tu `playwright.config.ts` y la carpeta `tests/`. **No subas `node_modules/` ni `test-results/`** — agregá un `.gitignore`:
+
+   ```gitignore
+   node_modules/
+   test-results/
+   playwright-report/
+   ```
+
+4. Configurá la `baseURL` apuntando a la Test App desplegada:
+
+   ```ts
+   // playwright.config.ts
+   use: {
+     baseURL: 'https://aiquaa.com/labs/test-app',
+   },
+   ```
+
+5. Credenciales demo: `tester@aiquaa.com` / `Test1234!`.
+
+### Escenarios a automatizar (mínimo 3 archivos `.spec.ts`)
+
+| # | Escenario | Criterios de aceptación |
+|---|-----------|------------------------|
+| 1 | **Login** | a) Con credenciales válidas, verificás que llegás al catálogo (`toHaveURL`). b) Con contraseña incorrecta, verificás que se muestra un mensaje de error (`toBeVisible`). |
+| 2 | **Búsqueda en catálogo** | Buscás un término y verificás que los resultados visibles corresponden a la búsqueda (cantidad de tarjetas o texto de los productos). |
+| 3 | **Carrito** | Agregás un producto desde el catálogo o el detalle, vas al carrito y verificás que el producto aparece y que el **total** es coherente con precio × cantidad. |
+| 4 | **Validación de checkout** | Intentás confirmar la compra con campos obligatorios vacíos o inválidos y verificás los mensajes de validación. |
+
+### Se valora (nivel intermedio, opcional)
+
+- Un `beforeEach` para navegar o loguearte.
+- Un Page Object simple (por ejemplo `LoginPage`).
+- Locators web-first: `getByRole`, `getByLabel`, `getByPlaceholder` (la Test App **no** tiene `data-testid`).
+- Evitar `waitForTimeout` y selectores CSS/XPath frágiles.
+- Tests independientes entre sí (cada uno arranca desde un estado conocido).
+
+### ⚠️ Sobre los bugs intencionales
+
+La Test App contiene **bugs intencionales** (ver `apps/frontend/src/app/labs/test-app/README.md`). Si un assert honesto tuyo falla por un comportamiento raro de la app, probablemente encontraste uno. **Documentalo en la descripción del PR** (pasos, esperado vs. real): no te penaliza en la verificación automática (que es estática) y suma en la evaluación humana.
+
+### Entrega
+
+1. Commit en tu rama y **Pull Request** hacia `main` del repo del proceso.
+2. En `/labs/playwright-practico`, ingresá el código del proceso, tu usuario de GitHub y el link del PR, y presioná **Verificar mi entrega**.
+
+---
+
+## ✅ Verificación automática (10 checks × 10 pts, aprueba ≥ 70)
+
+La verificación es **estática**: lista los archivos del PR y lee el contenido de los specs vía GitHub API. **No ejecuta los tests.**
+
+| # | Check | Qué valida |
+|---|-------|-----------|
+| 1 | `pr` | El PR fue abierto por el usuario de GitHub declarado |
+| 2 | `folder` | Existe la carpeta `prueba_tecnica_playwright_<usuario>/` |
+| 3 | `config` | Hay un `playwright.config.(ts\|js)` dentro de la carpeta |
+| 4 | `specs` | Al menos 3 archivos `*.spec.*` / `*.test.*` |
+| 5 | `locators` | Usa locators web-first (`getByRole`, `getByLabel`, …) |
+| 6 | `target` | Los tests apuntan a `/labs/test-app` |
+| 7 | `esc_login` | Cubre el escenario de login |
+| 8 | `esc_catalogo` | Cubre la búsqueda en catálogo |
+| 9 | `esc_carrito` | Cubre carrito y total |
+| 10 | `esc_checkout` | Cubre la validación de checkout |
+
+Los checks 7–10 son heurísticas por palabras clave sobre el contenido de los specs: son **señales, no prueba de un test funcionando**. El umbral de 70 tolera hasta 3 falsos negativos; la revisión humana define la nota final.
+
+---
+
+## 🧑‍⚖️ Rúbrica de evaluación humana (complementaria)
+
+El resultado queda marcado como **pendiente de corrección** (`review_status: pending_correction`). El evaluador revisa el PR y puntúa:
+
+| Dimensión | Puntos | Qué mirar |
+|-----------|--------|-----------|
+| **Calidad de código** | 0–10 | Nombres descriptivos, sin duplicación, `beforeEach`/fixtures bien usados, Page Object si aplica, estructura clara del proyecto |
+| **Robustez / anti-flakiness** | 0–10 | Aserciones web-first con auto-wait, sin `waitForTimeout`, sin selectores CSS/XPath frágiles, tests independientes entre sí |
+| **Calidad de asserts** | 0–10 | Asertan comportamiento observable (URL, textos, totales calculados), no solo "el elemento existe"; el caso negativo del login está bien cubierto |
+| **Bonus** | +5 | Documentó bugs intencionales de la Test App encontrados por sus propios tests (pasos, esperado vs. real, en la descripción del PR) |
+
+### Guía del evaluador
+
+1. **Ver el resultado automático:** el intento aparece en el dashboard del proceso (`/empresa/procesos/[id]`) vía `process_code`; el detalle de checks está en `metadata.checks` del registro en `exam_results`.
+2. **Correr los tests localmente:**
+
+   ```bash
+   git fetch origin pull/<N>/head:candidato && git checkout candidato
+   cd prueba_tecnica_playwright_<usuario>
+   npm install && npx playwright install chromium
+   npx playwright test
+   ```
+
+3. **Importante:** la Test App tiene bugs intencionales por diseño — algunos asserts "correctos" pueden fallar legítimamente (por ejemplo el total del carrito con cambios rápidos de cantidad). Un test que falla exponiendo un bug real es una **señal positiva**, no un error del candidato.
+4. Cargar la corrección manual desde el flujo de revisión de exámenes.
+
+---
+
+## ⚙️ Requisitos de operación
+
+- **`GITHUB_TOKEN`** (env del backend/Vercel): token con permiso de lectura sobre el repositorio del proceso. Sin token, el rate limit anónimo de GitHub (60 req/h) hace inviable la verificación. Es el mismo token que usa `git-practico`.
+- El proceso de contratación debe tener:
+  - `playwright-practico` dentro de `exam_types` (se selecciona al crear el proceso en `/empresa/procesos/nuevo`).
+  - `repository_url` apuntando al repo donde los candidatos suben su carpeta.
+- Migración requerida: `supabase/migrations/20260714_000000_playwright_practico.sql` (amplía el CHECK de `exam_results.exam_type` — solo redefine la restricción, **no toca datos existentes**).
+
+---
+
+## 🧩 Arquitectura
+
+Clona el patrón de `git-practico`:
+
+| Pieza | Ubicación |
+|-------|-----------|
+| Página del lab | `apps/frontend/src/app/labs/playwright-practico/{page.tsx,PlaywrightPracticoClient.tsx}` |
+| API de verificación | `apps/frontend/src/app/api/labs/playwright-practico/verify/route.ts` |
+| Helpers puros (testeados) | `apps/frontend/src/lib/labs/playwrightPractico.ts` |
+| Tests unitarios | `apps/frontend/src/lib/labs/__tests__/playwrightPractico.test.ts` |
+| Sistema bajo prueba | `apps/frontend/src/app/labs/test-app/` |
+| Migración | `supabase/migrations/20260714_000000_playwright_practico.sql` |
+
+```bash
+# Correr los tests unitarios de los helpers
+pnpm --filter @aiquaa/frontend test -- --run src/lib/labs/__tests__/playwrightPractico.test.ts
+```

--- a/supabase/migrations/20260714_000000_playwright_practico.sql
+++ b/supabase/migrations/20260714_000000_playwright_practico.sql
@@ -1,0 +1,27 @@
+-- Prueba técnica práctica de Playwright (lab `playwright-practico`):
+-- amplía el CHECK de exam_results.exam_type con `playwright-practico`
+-- (sin esto los inserts fallan en silencio).
+
+ALTER TABLE public.exam_results
+  DROP CONSTRAINT IF EXISTS exam_results_exam_type_check;
+
+ALTER TABLE public.exam_results
+  ADD CONSTRAINT exam_results_exam_type_check
+  CHECK (
+    exam_type = ANY (
+      ARRAY[
+        'git'::text,
+        'git-practico'::text,
+        'istqb'::text,
+        'performance'::text,
+        'test-app'::text,
+        'api-testing-fundamentals'::text,
+        'api-banking'::text,
+        'database-fundamentals'::text,
+        'database-practice'::text,
+        'infrastructure-fundamentals'::text,
+        'api-developer-fundamentals'::text,
+        'playwright-practico'::text
+      ]
+    )
+  );


### PR DESCRIPTION
## Qué agrega

Nuevo lab **`/labs/playwright-practico`**: prueba técnica **práctica** de Playwright para candidatos QA (nivel básico-intermedio), clonando el patrón probado de `git-practico`. La parte teórica vendrá después como assessment separado.

### Flujo del candidato

1. Valida el **código del proceso** de contratación (requiere `playwright-practico` en `exam_types` y `repository_url` configurado).
2. Automatiza **4 escenarios E2E** contra la Test App desplegada (`/labs/test-app`): login (OK/KO), búsqueda en catálogo, carrito + total, validación de checkout.
3. Sube su proyecto Playwright en `prueba_tecnica_playwright_<usuario>/` y abre un **PR** al repo del proceso.
4. Envía usuario de GitHub + link del PR → **verificación automática** vía GitHub API.

### Verificación automática (estática, no ejecuta tests)

10 checks × 10 pts, aprueba con **≥ 70**: PR propio, carpeta, `playwright.config`, ≥3 specs, locators web-first, target `/labs/test-app` y 4 heurísticas de cobertura de escenarios. El resultado se guarda en `exam_results` como `playwright-practico`, marcado `pending_correction` para revisión humana con rúbrica documentada.

## Archivos

- **Nuevo**: `lib/labs/playwrightPractico.ts` (helpers puros + 16 unit tests), `api/labs/playwright-practico/verify/route.ts`, `labs/playwright-practico/{page,PlaywrightPracticoClient}.tsx`, `docs/tools/playwright-practico.md` (consigna + rúbrica del evaluador), migración `20260714_000000_playwright_practico.sql`.
- **Registries**: catálogo de labs, `LabsAuthGate`, union de `exam_type` (`actions/exams.ts`, `lib/exams.ts`, perfil), labels de empresa/talento/invitaciones, opciones de proceso nuevo, dashboard.

## Base de datos

La migración **solo redefine el CHECK** de `exam_results.exam_type` para permitir el nuevo tipo — **no toca filas ni borra datos** (los resultados existentes de estudiantes quedan intactos).

## Verificación

- ✅ `pnpm --filter @aiquaa/frontend test -- --run src/lib/labs` → 31/31 tests (gitPractico + playwrightPractico).
- ✅ `pnpm lint` → 0 errores (warnings preexistentes).
- ✅ `pnpm build` → OK; rutas `/labs/playwright-practico` y `/api/labs/playwright-practico/verify` generadas.
- Los tests unitarios que fallan en la suite completa (auth/forum/health) fallan igual en `main` — preexistentes, no relacionados.

## Requisitos de operación

- `GITHUB_TOKEN` con lectura del repo del proceso (mismo token que `git-practico`).
- Aplicar la migración de Supabase antes de usar el lab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JktzUrCDjsqYEMCCpDAMzA

---
_Generated by [Claude Code](https://claude.ai/code/session_01JktzUrCDjsqYEMCCpDAMzA)_