### PR TITLE
fix: sync student and admin event-progress exam calculations

### DIFF
--- a/apps/frontend/src/actions/candidate-events.ts
+++ b/apps/frontend/src/actions/candidate-events.ts
@@ -1,12 +1,7 @@
 'use server';
 
 import { createClient } from '@/lib/supabase/server';
-
-const ASSESSMENT_SLUGS = [
-  'database-fundamentals',
-  'database-practice',
-  'infrastructure-fundamentals',
-];
+import { PROCESS_ASSESSMENT_SLUGS } from './lib/assessment-slugs';
 
 export interface MyEventResult {
   examType: string;
@@ -58,16 +53,15 @@ export async function getMyEventProgressAction(): Promise<{
         .not('process_code', 'is', null),
       supabase
         .from('assessment_attempts')
-        .select(
-          'percentage, passed, metadata, assessments!inner(slug)'
-        )
+        .select('percentage, passed, metadata, assessments!inner(slug)')
         .eq('user_id', user.id)
         .eq('status', 'graded')
-        .in('assessments.slug', ASSESSMENT_SLUGS),
+        .in('assessments.slug', PROCESS_ASSESSMENT_SLUGS),
     ]);
 
   if (examResultsError) return { error: examResultsError.message, data: null };
-  if (assessmentRes.error) return { error: assessmentRes.error.message, data: null };
+  if (assessmentRes.error)
+    return { error: assessmentRes.error.message, data: null };
 
   type MyResultRow = {
     examType: string;
@@ -108,9 +102,7 @@ export async function getMyEventProgressAction(): Promise<{
   if (touchedError) return { error: touchedError.message, data: null };
 
   const groupIds = [
-    ...new Set(
-      (touchedProcesses ?? []).map((p) => p.group_id as string)
-    ),
+    ...new Set((touchedProcesses ?? []).map((p) => p.group_id as string)),
   ];
   if (groupIds.length === 0) return { data: [], error: null };
 

--- a/apps/frontend/src/actions/employer.ts
+++ b/apps/frontend/src/actions/employer.ts
@@ -1,6 +1,7 @@
 'use server';
 
 import { createClient } from '@/lib/supabase/server';
+import { PROCESS_ASSESSMENT_SLUGS } from './lib/assessment-slugs';
 
 export interface HiringProcess {
   id: string;
@@ -357,13 +358,6 @@ function getAttemptTimeSpentSeconds(row: {
 
   return Math.max(0, Math.round((submitted - started) / 1000));
 }
-
-const PROCESS_ASSESSMENT_SLUGS = [
-  'database-fundamentals',
-  'database-practice',
-  'infrastructure-fundamentals',
-  'api-developer-fundamentals',
-];
 
 async function fetchAssessmentAttemptsForProcessCodes(
   supabase: ReturnType<typeof createClient>,

--- a/apps/frontend/src/actions/lib/assessment-slugs.ts
+++ b/apps/frontend/src/actions/lib/assessment-slugs.ts
@@ -1,0 +1,12 @@
+/**
+ * Assessment slugs (from `assessments.slug`) counted as part of a hiring
+ * process's exam requirements. Shared between the candidate-facing
+ * (`candidate-events.ts`) and empresa-facing (`employer.ts`) progress
+ * queries so the two views can't drift out of sync with each other.
+ */
+export const PROCESS_ASSESSMENT_SLUGS = [
+  'database-fundamentals',
+  'database-practice',
+  'infrastructure-fundamentals',
+  'api-developer-fundamentals',
+];

--- a/supabase/migrations/20260714_060000_candidate_read_own_event_processes.sql
+++ b/supabase/migrations/20260714_060000_candidate_read_own_event_processes.sql
@@ -1,0 +1,40 @@
+-- Let a candidate read the hiring_processes rows (code, exam_types) that
+-- belong to an event (hiring_process_group) they've already rendered at
+-- least one exam in — mirrors candidates_select_own_event_groups
+-- (20260703_050000), which only granted read on the *group* itself.
+--
+-- Without this, getMyEventProgressAction's queries against
+-- hiring_processes (to build the "required exam types" union and the set of
+-- process codes belonging to the event) only had the
+-- hiring_processes_empresa_access policy available, which is scoped to
+-- empresa owners/members — so a plain candidate session could see none, or
+-- only some, of the event's other processes/exam_types. That desynced the
+-- student-facing progress card from the empresa "Eventos" view, which reads
+-- the same tables under an empresa member's broader RLS visibility: a
+-- candidate could see fewer required exam types and have already-graded
+-- results excluded because the process they belong to fell outside what
+-- their own query could see.
+
+DROP POLICY IF EXISTS "candidates_select_own_event_processes" ON public.hiring_processes;
+
+CREATE POLICY "candidates_select_own_event_processes" ON public.hiring_processes
+  FOR SELECT
+  TO authenticated
+  USING (
+    group_id IS NOT NULL
+    AND EXISTS (
+      SELECT 1
+      FROM public.hiring_processes hp_touched
+      WHERE hp_touched.group_id = hiring_processes.group_id
+        AND (
+          EXISTS (
+            SELECT 1 FROM public.exam_results er
+            WHERE er.process_code = hp_touched.code AND er.user_id = auth.uid()
+          )
+          OR EXISTS (
+            SELECT 1 FROM public.assessment_attempts aa
+            WHERE aa.metadata->>'processCode' = hp_touched.code AND aa.user_id = auth.uid()
+          )
+        )
+    )
+  );


### PR DESCRIPTION
## Summary

Students saw already-graded exams (e.g. ISTQB, API Testing — Fundamentos) listed as pending ("TE FALTA RENDIR") on their own `/perfil` progress card, while the admin `empresa/eventos/[id]` view correctly showed the same student had completed them for the same event.

Both views compute exam progress independently by querying `exam_results` / `assessment_attempts` / `hiring_processes` directly from Next.js Server Actions (this repo has no separate backend for these flows), which let two bugs creep in:

- **`apps/frontend/src/actions/candidate-events.ts` (`getMyEventProgressAction`, student view) vs `apps/frontend/src/actions/employer.ts` (`getEventStatsAction`, admin view)** each hardcoded their own list of assessment slugs counted toward an event's exams. The student-facing list was missing `api-developer-fundamentals`, so any graded attempt of that assessment was silently excluded from a student's own progress even though the admin view counted it. Both now import a single shared `PROCESS_ASSESSMENT_SLUGS` constant from `apps/frontend/src/actions/lib/assessment-slugs.ts`.
- `getMyEventProgressAction` queries `hiring_processes` (to build the "required exam types" union and the process-code set used to match a student's own results to an event) under the student's own authenticated RLS context. Only the `hiring_processes_empresa_access` policy (empresa owner/member scoped) existed for that table, so a plain candidate session could see fewer processes/exam types than an empresa member querying the same event — undercounting the denominator and dropping already-graded exams from the student's own list. Added `candidates_select_own_event_processes`, mirroring the existing `candidates_select_own_event_groups` policy (`20260703_050000`): a candidate can now `SELECT` any `hiring_processes` row belonging to an event group where they already have a result in at least one process of that group.

## Test plan

- [x] `pnpm --filter @aiquaa/frontend type-check` passes
- [x] `eslint` clean on the changed files
- [ ] Apply migration `20260714_060000_candidate_read_own_event_processes.sql` to the target Supabase project (migrations don't auto-apply from this repo)
- [ ] After applying, verify `katteryne0055@gmail.com`'s `/perfil` progress card for "Bootcamp CLT 2026" shows 10/10 matching the admin `/empresa/eventos/[id]` view


---
_Generated by [Claude Code](https://claude.ai/code/session_013Dba4DnRXW6YL6E92nWmvM)_