### PR TITLE
fix: resolve RLS infinite recursion in candidate event-processes policy

### DIFF
--- a/supabase/migrations/20260714233905_candidate_read_own_event_processes.sql
+++ b/supabase/migrations/20260714233905_candidate_read_own_event_processes.sql
@@ -3,17 +3,13 @@
 -- least one exam in — mirrors candidates_select_own_event_groups
 -- (20260703_050000), which only granted read on the *group* itself.
 --
--- Without this, getMyEventProgressAction's queries against
--- hiring_processes (to build the "required exam types" union and the set of
--- process codes belonging to the event) only had the
--- hiring_processes_empresa_access policy available, which is scoped to
--- empresa owners/members — so a plain candidate session could see none, or
--- only some, of the event's other processes/exam_types. That desynced the
--- student-facing progress card from the empresa "Eventos" view, which reads
--- the same tables under an empresa member's broader RLS visibility: a
--- candidate could see fewer required exam types and have already-graded
--- results excluded because the process they belong to fell outside what
--- their own query could see.
+-- SUPERSEDED by 20260714234547_candidate_read_own_event_processes_fixed.sql:
+-- this version's USING clause does its exam_results / assessment_attempts
+-- checks directly, which triggers "infinite recursion detected in policy
+-- for relation exam_results" the moment it's evaluated, because those
+-- tables' own RLS policies reference hiring_processes back. It was live in
+-- production for a few minutes before being replaced — kept here only so
+-- the migration history matches what was actually applied.
 
 DROP POLICY IF EXISTS "candidates_select_own_event_processes" ON public.hiring_processes;
 

--- a/supabase/migrations/20260714234547_candidate_read_own_event_processes_fixed.sql
+++ b/supabase/migrations/20260714234547_candidate_read_own_event_processes_fixed.sql
@@ -1,0 +1,49 @@
+-- Fixes the infinite-recursion bug introduced by
+-- 20260714233905_candidate_read_own_event_processes.sql: RLS policies on
+-- hiring_processes must not do their exam_results / assessment_attempts
+-- checks directly in a USING clause, because those tables have their own
+-- policies that reference hiring_processes back (e.g. empresa read-access
+-- policies) — that creates "infinite recursion detected in policy for
+-- relation exam_results/hiring_processes" the moment the policy runs,
+-- which broke every query against hiring_processes (including the ones
+-- behind /perfil's "Mi progreso en eventos" and /empresa/eventos/[id]).
+--
+-- Routing the check through a SECURITY DEFINER function (owned by a role
+-- with BYPASSRLS, so its internal queries skip RLS entirely) breaks the
+-- cycle — same pattern already used by is_active_empresa_member().
+
+DROP POLICY IF EXISTS "candidates_select_own_event_processes" ON public.hiring_processes;
+DROP FUNCTION IF EXISTS public.candidate_has_result_for_process(text);
+
+CREATE OR REPLACE FUNCTION public.candidate_touched_event_group(p_group_id uuid)
+RETURNS boolean
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = public
+STABLE
+AS $$
+  SELECT EXISTS (
+    SELECT 1 FROM public.hiring_processes hp
+    WHERE hp.group_id = p_group_id
+      AND (
+        EXISTS (
+          SELECT 1 FROM public.exam_results er
+          WHERE er.process_code = hp.code AND er.user_id = auth.uid()
+        )
+        OR EXISTS (
+          SELECT 1 FROM public.assessment_attempts aa
+          WHERE aa.metadata->>'processCode' = hp.code AND aa.user_id = auth.uid()
+        )
+      )
+  );
+$$;
+
+GRANT EXECUTE ON FUNCTION public.candidate_touched_event_group(uuid) TO authenticated;
+
+CREATE POLICY "candidates_select_own_event_processes" ON public.hiring_processes
+  FOR SELECT
+  TO authenticated
+  USING (
+    group_id IS NOT NULL
+    AND public.candidate_touched_event_group(group_id)
+  );


### PR DESCRIPTION
## Summary

PR #285 added `candidates_select_own_event_processes`, an RLS SELECT policy on `hiring_processes` meant to let a candidate see every process (and its `exam_types`) in an event they've participated in — fixing the student vs. admin event-progress mismatch reported for `katteryne0055@gmail.com`.

That policy's `USING` clause checked `exam_results` / `assessment_attempts` directly. Those two tables have their own RLS policies that reference `hiring_processes` back (empresa read-access checks), so evaluating the new policy triggered `infinite recursion detected in policy for relation exam_results` (and `hiring_processes`) — which broke **every** query against `hiring_processes`, including the ones behind `/perfil`'s "Mi progreso en eventos" and `/empresa/eventos/[id]`. This is why after merging #285, the student's profile stopped showing any event data at all.

## Fix

Route the check through `candidate_touched_event_group(p_group_id uuid)`, a `SECURITY DEFINER` function whose internal queries bypass RLS entirely — the same pattern already used by `is_active_empresa_member()` elsewhere in this schema. This breaks the recursive cycle while keeping the same access semantics (a candidate can see any `hiring_processes` row in a group where they already have a result in some process of that group).

- Renamed the original migration to its actual applied timestamp (`20260714233905`) and documented that it's superseded, so migration history matches what was actually run.
- Added `20260714234547_candidate_read_own_event_processes_fixed.sql` with the corrected policy + function.

## Verification

Both migrations were already applied directly to the production Supabase project to restore service immediately (the recursion bug broke live traffic). Confirmed via SQL, impersonating `katteryne0055@gmail.com`'s session:

- `select code, group_id, exam_types, status from hiring_processes where group_id = '<event id>'` now returns all 10 processes (including the previously-hidden `status = 'closed'` ones) with **no recursion error**.
- Baseline queries (`hiring_process_groups`, `exam_results`) still work with no new recursion introduced.

This PR brings the repo's migration history back in sync with what's live in Supabase.

## Test plan

- [x] `pnpm --filter @aiquaa/frontend type-check` passes (pre-push hook)
- [x] Verified against production Supabase via impersonated-session SQL (no recursion, correct row visibility)
- [ ] Confirm `katteryne0055@gmail.com`'s `/perfil` progress card shows event data again and matches the admin `/empresa/eventos/[id]` view (10/10)


---
_Generated by [Claude Code](https://claude.ai/code/session_013Dba4DnRXW6YL6E92nWmvM)_