### PR TITLE
feat(assessments): examen conceptual Playwright Fundamentals + ranking

### DIFF
--- a/apps/frontend/src/actions/exams.ts
+++ b/apps/frontend/src/actions/exams.ts
@@ -22,7 +22,8 @@ interface SaveExamResultPayload {
     | 'database-practice'
     | 'infrastructure-fundamentals'
     | 'api-developer-fundamentals'
-    | 'playwright-practico';
+    | 'playwright-practico'
+    | 'playwright-fundamentals';
   exam_mode: 'exam' | 'training';
   participant_name?: string;
   participant_email?: string;
@@ -188,7 +189,9 @@ export async function getLeaderboardAction(
     | 'database-fundamentals'
     | 'database-practice'
     | 'infrastructure-fundamentals'
-    | 'api-developer-fundamentals',
+    | 'api-developer-fundamentals'
+    | 'playwright-practico'
+    | 'playwright-fundamentals',
   limit = 20
 ) {
   const supabase = createClient();

--- a/apps/frontend/src/app/assessments/_shared/components/AssessmentSectionScreen.tsx
+++ b/apps/frontend/src/app/assessments/_shared/components/AssessmentSectionScreen.tsx
@@ -13,6 +13,7 @@ import ApiDocCard from './ApiDocCard';
 import AssessmentProgress from './AssessmentProgress';
 import AssessmentTimer from './AssessmentTimer';
 import MultipleChoiceQuestion from './MultipleChoiceQuestion';
+import PlaywrightCodeBlock from './PlaywrightCodeBlock';
 import RequestResponseBlock from './RequestResponseBlock';
 import SectionNavigator from './SectionNavigator';
 import SectionSummaryCard from './SectionSummaryCard';
@@ -23,6 +24,7 @@ import TrueFalseQuestion from './TrueFalseQuestion';
 import type {
   ApiDocScenario,
   AssessmentSectionPayload,
+  PlaywrightCodeScenario,
   SqlQueryScenario,
   SqlSchemaScenario,
 } from '../types';
@@ -269,6 +271,9 @@ export default function AssessmentSectionScreen({
             const sqlScenario = question.metadata?.sqlScenario as
               | SqlQueryScenario
               | undefined;
+            const codeScenario = question.metadata?.codeScenario as
+              | PlaywrightCodeScenario
+              | undefined;
 
             return (
               <div
@@ -303,6 +308,12 @@ export default function AssessmentSectionScreen({
                 {sqlScenario ? (
                   <div className="mt-5">
                     <SqlScenarioBlock scenario={sqlScenario} />
+                  </div>
+                ) : null}
+
+                {codeScenario ? (
+                  <div className="mt-5">
+                    <PlaywrightCodeBlock scenario={codeScenario} />
                   </div>
                 ) : null}
 

--- a/apps/frontend/src/app/assessments/_shared/components/AssessmentWelcome.tsx
+++ b/apps/frontend/src/app/assessments/_shared/components/AssessmentWelcome.tsx
@@ -10,12 +10,15 @@ export default function AssessmentWelcome({
   evaluatesCopy = 'Fundamentos de API, criterio QA, diseño de casos, validación de respuestas y bug reporting.',
   scoringCopy = 'Automático en niveles 1, 2 y 4. Heurístico en niveles 3 y 5.',
   resultCopy = 'Score total, score por nivel, fortalezas, debilidades y temas a reforzar.',
+  referenceLinks,
 }: {
   overview: AssessmentOverview;
   startHref?: string;
   evaluatesCopy?: string;
   scoringCopy?: string;
   resultCopy?: string;
+  /** Links a documentación oficial recomendados antes de empezar (opcional). */
+  referenceLinks?: Array<{ label: string; href: string }>;
 }) {
   const { isDarkMode } = useTheme();
 
@@ -92,6 +95,31 @@ export default function AssessmentWelcome({
               <p className="mt-2 text-sm text-slate-200">{resultCopy}</p>
             </div>
           </div>
+
+          {referenceLinks && referenceLinks.length > 0 ? (
+            <div className="mt-8 rounded-3xl border border-slate-800 bg-slate-950/70 p-6">
+              <p className="text-xs uppercase tracking-[0.18em] text-slate-400">
+                Documentación de referencia
+              </p>
+              <p className="mt-2 text-sm text-slate-300">
+                Te recomendamos repasar estos recursos oficiales antes de
+                empezar.
+              </p>
+              <div className="mt-4 flex flex-wrap gap-3">
+                {referenceLinks.map((link) => (
+                  <a
+                    key={link.href}
+                    href={link.href}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="inline-flex items-center rounded-full border border-cyan-400/30 bg-cyan-400/10 px-4 py-2 text-sm font-medium text-cyan-200 transition hover:bg-cyan-400/20"
+                  >
+                    {link.label} ↗
+                  </a>
+                ))}
+              </div>
+            </div>
+          ) : null}
 
           <div className="mt-8 flex flex-col gap-3 sm:flex-row">
             <Link

--- a/apps/frontend/src/app/assessments/_shared/components/PlaywrightCodeBlock.tsx
+++ b/apps/frontend/src/app/assessments/_shared/components/PlaywrightCodeBlock.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import type { PlaywrightCodeScenario } from '../types';
+
+export default function PlaywrightCodeBlock({
+  scenario,
+}: {
+  scenario: PlaywrightCodeScenario;
+}) {
+  return (
+    <div className="rounded-3xl border border-slate-800 bg-slate-950/70 p-5">
+      {scenario.note ? (
+        <div className="mb-4 rounded-2xl border border-amber-400/30 bg-amber-400/10 px-4 py-3 text-sm text-amber-100">
+          {scenario.note}
+        </div>
+      ) : null}
+
+      <div className="rounded-2xl border border-slate-800 bg-slate-900/80 p-4">
+        <p className="text-xs font-semibold uppercase tracking-[0.18em] text-cyan-300">
+          {scenario.title ??
+            `Código Playwright (${scenario.language ?? 'typescript'})`}
+        </p>
+        <pre className="mt-3 overflow-x-auto rounded-2xl bg-slate-950 p-4 text-xs text-cyan-100">
+          {scenario.code}
+        </pre>
+      </div>
+
+      {scenario.expectedOutput ? (
+        <div className="mt-4 rounded-2xl border border-slate-800 bg-slate-900/80 p-4">
+          <p className="text-xs font-semibold uppercase tracking-[0.18em] text-emerald-300">
+            Salida del CLI
+          </p>
+          <pre className="mt-3 overflow-x-auto rounded-2xl bg-slate-950 p-4 text-xs text-emerald-100">
+            {scenario.expectedOutput}
+          </pre>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/frontend/src/app/assessments/_shared/registry.ts
+++ b/apps/frontend/src/app/assessments/_shared/registry.ts
@@ -43,6 +43,15 @@ import {
   buildInfrastructureFundamentalsGamificationEvents,
 } from '../infrastructure-fundamentals/lib/gamification';
 import { ensureInfrastructureFundamentalsSeeded } from '../infrastructure-fundamentals/lib/seed';
+import {
+  PLAYWRIGHT_FUNDAMENTALS_SEED_VERSION,
+  PLAYWRIGHT_FUNDAMENTALS_SLUG,
+} from '../playwright-fundamentals/data/assessment-definition';
+import {
+  PLAYWRIGHT_FUNDAMENTALS_GAMIFICATION_RULES,
+  buildPlaywrightFundamentalsGamificationEvents,
+} from '../playwright-fundamentals/lib/gamification';
+import { ensurePlaywrightFundamentalsSeeded } from '../playwright-fundamentals/lib/seed';
 import type {
   AssessmentGamificationEvent,
   AssessmentGamificationRule,
@@ -53,7 +62,8 @@ export type AssessmentExamType =
   | 'api-testing-fundamentals'
   | 'database-fundamentals'
   | 'database-practice'
-  | 'infrastructure-fundamentals';
+  | 'infrastructure-fundamentals'
+  | 'playwright-fundamentals';
 
 export interface AssessmentGamificationEventInput {
   attemptId: string;
@@ -123,5 +133,14 @@ export const ASSESSMENT_REGISTRY: Record<string, AssessmentRegistryEntry> = {
     gamificationSource: 'INFRASTRUCTURE_FUNDAMENTALS',
     gamificationRules: INFRASTRUCTURE_FUNDAMENTALS_GAMIFICATION_RULES,
     buildGamificationEvents: buildInfrastructureFundamentalsGamificationEvents,
+  },
+  [PLAYWRIGHT_FUNDAMENTALS_SLUG]: {
+    slug: PLAYWRIGHT_FUNDAMENTALS_SLUG,
+    seedVersion: PLAYWRIGHT_FUNDAMENTALS_SEED_VERSION,
+    ensureSeeded: ensurePlaywrightFundamentalsSeeded,
+    examType: 'playwright-fundamentals',
+    gamificationSource: 'PLAYWRIGHT_FUNDAMENTALS',
+    gamificationRules: PLAYWRIGHT_FUNDAMENTALS_GAMIFICATION_RULES,
+    buildGamificationEvents: buildPlaywrightFundamentalsGamificationEvents,
   },
 };

--- a/apps/frontend/src/app/assessments/_shared/types.ts
+++ b/apps/frontend/src/app/assessments/_shared/types.ts
@@ -166,6 +166,14 @@ export interface SqlQueryScenario {
   note?: string;
 }
 
+export interface PlaywrightCodeScenario {
+  title?: string;
+  code: string;
+  language?: string;
+  expectedOutput?: string;
+  note?: string;
+}
+
 export interface ScoringRule {
   type: AssessmentScoringMode;
   checks: string[];

--- a/apps/frontend/src/app/assessments/page.tsx
+++ b/apps/frontend/src/app/assessments/page.tsx
@@ -4,6 +4,7 @@ import { apiTestingFundamentalsDefinition } from './api-testing-fundamentals/dat
 import { databaseFundamentalsDefinition } from './database-fundamentals/data/assessment-definition';
 import { databasePracticeDefinition } from './database-practice/data/assessment-definition';
 import { infrastructureFundamentalsDefinition } from './infrastructure-fundamentals/data/assessment-definition';
+import { playwrightFundamentalsDefinition } from './playwright-fundamentals/data/assessment-definition';
 
 export default function AssessmentsIndexPage() {
   const overview = apiTestingFundamentalsDefinition;
@@ -35,6 +36,13 @@ export default function AssessmentsIndexPage() {
       badgeColor: 'text-amber-300',
       accentColor: 'text-indigo-200',
       buttonClass: 'bg-indigo-500 hover:bg-indigo-400',
+    },
+    {
+      definition: playwrightFundamentalsDefinition,
+      badge: 'Examen teórico · Auto-corregido · Playwright',
+      badgeColor: 'text-amber-300',
+      accentColor: 'text-fuchsia-200',
+      buttonClass: 'bg-fuchsia-500 hover:bg-fuchsia-400',
     },
   ];
 

--- a/apps/frontend/src/app/assessments/playwright-fundamentals/__tests__/definition.test.ts
+++ b/apps/frontend/src/app/assessments/playwright-fundamentals/__tests__/definition.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { assertAssessmentDefinitionConsistency } from '../../_shared/testing/assessment-definition-checks';
+import {
+  PLAYWRIGHT_FUNDAMENTALS_SEED_VERSION,
+  PLAYWRIGHT_FUNDAMENTALS_SLUG,
+  playwrightFundamentalsDefinition,
+} from '../data/assessment-definition';
+import { ASSESSMENT_REGISTRY } from '../../_shared/registry';
+
+describe('playwright-fundamentals definition', () => {
+  it('mantiene presupuestos de puntos y answer keys consistentes', () => {
+    assertAssessmentDefinitionConsistency(playwrightFundamentalsDefinition);
+  });
+
+  it('define 4 niveles teóricos sobre 100 puntos', () => {
+    expect(playwrightFundamentalsDefinition.sections).toHaveLength(4);
+    expect(playwrightFundamentalsDefinition.total_score).toBe(100);
+    expect(playwrightFundamentalsDefinition.slug).toBe(
+      PLAYWRIGHT_FUNDAMENTALS_SLUG
+    );
+  });
+
+  it('está registrado con el seedVersion correcto', () => {
+    const entry = ASSESSMENT_REGISTRY[PLAYWRIGHT_FUNDAMENTALS_SLUG];
+    expect(entry).toBeDefined();
+    expect(entry.seedVersion).toBe(PLAYWRIGHT_FUNDAMENTALS_SEED_VERSION);
+    expect(entry.examType).toBe('playwright-fundamentals');
+  });
+});

--- a/apps/frontend/src/app/assessments/playwright-fundamentals/data/assessment-definition.ts
+++ b/apps/frontend/src/app/assessments/playwright-fundamentals/data/assessment-definition.ts
@@ -1,0 +1,596 @@
+import type { AssessmentSeedDefinition } from '../../_shared/types';
+
+export const PLAYWRIGHT_FUNDAMENTALS_SLUG = 'playwright-fundamentals';
+
+// Bumpear cuando cambie la definición (secciones/preguntas) para forzar re-seed.
+export const PLAYWRIGHT_FUNDAMENTALS_SEED_VERSION = 1;
+
+export const playwrightFundamentalsDefinition: AssessmentSeedDefinition = {
+  slug: PLAYWRIGHT_FUNDAMENTALS_SLUG,
+  title: 'Playwright — Fundamentos',
+  description:
+    'Evaluación teórica basada en código real de Playwright y en su documentación oficial: CLI y configuración, locators web-first, assertions con auto-retry, y fixtures/hooks/debugging.',
+  level: 'Junior a Semi Senior',
+  type: 'QA Automatización Web',
+  duration_minutes: 30,
+  total_score: 100,
+  is_active: true,
+  metadata: {
+    moduleName: 'AIQUAA Assessments / Playwright Fundamentals',
+    passingScore: 60,
+    candidateBands: [
+      { min: 0, max: 39, label: 'Inicial' },
+      { min: 40, max: 59, label: 'Junior en formación' },
+      { min: 60, max: 74, label: 'Junior' },
+      { min: 75, max: 89, label: 'Junior avanzado / Semi Senior inicial' },
+      { min: 90, max: 100, label: 'Semi Senior' },
+    ],
+  },
+  sections: [
+    {
+      slug: 'nivel-1-cli-configuracion',
+      title: 'Nivel 1: Test CLI & Configuración',
+      description:
+        'Comandos del Playwright Test CLI y estructura básica de playwright.config.ts (proyectos, reporters).',
+      order_index: 1,
+      max_score: 25,
+      metadata: {
+        instructions:
+          'Preguntas basadas en la documentación oficial: https://playwright.dev/docs/test-cli',
+        suggestedMinutes: 7,
+      },
+      questions: [
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            '¿Qué comando de la CLI ejecuta la suite de tests de Playwright?',
+          options: [
+            { label: 'npx playwright test', value: 'a' },
+            { label: 'npm run playwright', value: 'b' },
+            { label: 'playwright run', value: 'c' },
+            { label: 'npx playwright start', value: 'd' },
+          ],
+          correct_answer: { value: 'a' },
+          explanation:
+            '`npx playwright test` es el comando estándar del Test CLI para correr los tests (con o sin filtros adicionales).',
+          points: 5,
+          order_index: 1,
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            'Dado este fragmento de playwright.config.ts y el comando ejecutado, ¿qué hace el flag --project?',
+          metadata: {
+            codeScenario: {
+              title: 'playwright.config.ts (fragmento)',
+              language: 'typescript',
+              code: `export default defineConfig({
+  projects: [
+    { name: 'chromium', use: { ...devices['Desktop Chrome'] } },
+    { name: 'firefox', use: { ...devices['Desktop Firefox'] } },
+    { name: 'webkit', use: { ...devices['Desktop Safari'] } },
+  ],
+});`,
+              expectedOutput: '$ npx playwright test --project=firefox',
+            },
+          },
+          options: [
+            {
+              label:
+                'Ejecuta solo los tests contra el proyecto llamado "firefox" definido en la config, ignorando los demás',
+              value: 'a',
+            },
+            {
+              label: 'Instala el navegador Firefox si no está presente',
+              value: 'b',
+            },
+            {
+              label: 'Ejecuta todos los proyectos, pero reporta solo Firefox',
+              value: 'c',
+            },
+            {
+              label: 'Cambia el navegador por defecto para todos los tests',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'a' },
+          explanation:
+            '--project filtra la corrida a los proyectos indicados por --name en playwright.config.ts; el resto de los proyectos configurados no se ejecutan.',
+          points: 5,
+          order_index: 2,
+        },
+        {
+          question_type: 'true_false',
+          prompt:
+            'El flag --headed ejecuta los tests mostrando el navegador en pantalla en vez de en modo headless.',
+          correct_answer: { value: true },
+          explanation:
+            'Por defecto Playwright corre en modo headless; --headed fuerza a que el navegador sea visible, útil para depurar visualmente.',
+          points: 5,
+          order_index: 3,
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt: '¿Qué hace el comando "npx playwright test --debug"?',
+          options: [
+            {
+              label:
+                'Abre el Playwright Inspector para pausar la ejecución y avanzar paso a paso por el test',
+              value: 'a',
+            },
+            {
+              label: 'Genera automáticamente un reporte de cobertura',
+              value: 'b',
+            },
+            {
+              label: 'Ejecuta los tests en paralelo con más workers',
+              value: 'c',
+            },
+            {
+              label: 'Solo valida la sintaxis de los tests sin ejecutarlos',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'a' },
+          explanation:
+            '--debug abre el Playwright Inspector: permite pausar, avanzar acción por acción e inspeccionar selectores mientras corre el test.',
+          points: 5,
+          order_index: 4,
+        },
+        {
+          question_type: 'short_text',
+          prompt:
+            '¿Qué comando de la CLI abre el reporte HTML generado por la última corrida de tests?',
+          expected_keywords: ['show-report'],
+          explanation:
+            '`npx playwright show-report` abre en el navegador el último reporte HTML generado por el reporter "html".',
+          scoring_rules: {
+            type: 'automatic',
+            requiredKeywords: ['show-report'],
+          },
+          points: 5,
+          order_index: 5,
+        },
+      ],
+    },
+    {
+      slug: 'nivel-2-locators-acciones',
+      title: 'Nivel 2: Locators & Acciones (Web-First)',
+      description:
+        'Locators web-first (getByRole, getByLabel, getByTestId) y su comportamiento de auto-waiting antes de actuar.',
+      order_index: 2,
+      max_score: 25,
+      metadata: {
+        instructions:
+          'Preguntas basadas en la documentación oficial de locators: https://playwright.dev/docs/locators',
+        suggestedMinutes: 8,
+      },
+      questions: [
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            '¿Por qué Playwright recomienda getByRole como locator principal en vez de selectores CSS/XPath genéricos?',
+          metadata: {
+            codeScenario: {
+              title: 'Ejemplo de test',
+              language: 'typescript',
+              code: `await page.getByRole('button', { name: 'Enviar' }).click();`,
+            },
+          },
+          options: [
+            {
+              label:
+                'Porque refleja cómo perciben la página los usuarios y las tecnologías asistivas, en vez de depender de la estructura interna del DOM',
+              value: 'a',
+            },
+            {
+              label: 'Porque es más corto de escribir que un selector CSS',
+              value: 'b',
+            },
+            {
+              label: 'Porque no requiere que la página tenga HTML semántico',
+              value: 'c',
+            },
+            {
+              label: 'Porque solo funciona en Chromium',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'a' },
+          explanation:
+            'Los locators por rol/accesibilidad son más resilientes a cambios de implementación (clases, estructura) y validan que la UI sea accesible, algo que un selector CSS frágil no garantiza.',
+          points: 5,
+          order_index: 1,
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            '¿Cuál es la diferencia principal entre getByLabel() y getByTestId()?',
+          options: [
+            {
+              label:
+                'getByLabel() ubica un control de formulario por su <label> asociado; getByTestId() ubica un elemento por su atributo data-testid, sin depender de texto ni accesibilidad',
+              value: 'a',
+            },
+            {
+              label: 'Son sinónimos, hacen exactamente lo mismo',
+              value: 'b',
+            },
+            {
+              label: 'getByTestId() solo funciona con elementos <button>',
+              value: 'c',
+            },
+            {
+              label: 'getByLabel() ignora el idioma del contenido de la página',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'a' },
+          explanation:
+            'getByLabel() busca inputs/controles asociados a un <label>; getByTestId() usa un atributo dedicado (por defecto data-testid) como último recurso cuando no hay un rol o texto estable.',
+          points: 5,
+          order_index: 2,
+        },
+        {
+          question_type: 'true_false',
+          prompt:
+            'page.locator(\'#submit\') es equivalente a un locator "web-first" semántico como getByRole, ya que ambos generan el mismo tipo de selector.',
+          metadata: {
+            codeScenario: {
+              title: 'Ejemplo de test',
+              language: 'typescript',
+              code: `await page.locator('#submit').click();`,
+            },
+          },
+          correct_answer: { value: false },
+          explanation:
+            "page.locator('#submit') es un selector CSS genérico, frágil ante cambios de markup. getByRole/getByLabel/getByTestId son locators semánticos recomendados por sobre CSS/XPath cuando es posible.",
+          points: 5,
+          order_index: 3,
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            '¿Qué hacen los locators web-first de Playwright automáticamente antes de ejecutar una acción como .click()?',
+          options: [
+            {
+              label:
+                'Auto-esperan (auto-waiting) a que el elemento esté adjunto al DOM, visible, habilitado y estable, reintentando hasta el timeout configurado',
+              value: 'a',
+            },
+            {
+              label: 'Recargan la página automáticamente',
+              value: 'b',
+            },
+            {
+              label:
+                'Ejecutan la acción inmediatamente sin ninguna espera adicional',
+              value: 'c',
+            },
+            {
+              label: 'Toman una captura de pantalla antes de cada acción',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'a' },
+          explanation:
+            'El auto-waiting es central en Playwright: los locators reintentan la búsqueda del elemento y validan condiciones de "actionability" antes de interactuar, sin necesidad de sleeps manuales.',
+          points: 5,
+          order_index: 4,
+        },
+        {
+          question_type: 'short_text',
+          prompt:
+            '¿Qué atributo HTML usa por defecto getByTestId() para ubicar un elemento?',
+          expected_keywords: ['data-testid'],
+          explanation:
+            'Por defecto getByTestId() busca el atributo data-testid; puede reconfigurarse con testIdAttribute en playwright.config.ts.',
+          scoring_rules: {
+            type: 'automatic',
+            requiredKeywords: ['data-testid'],
+          },
+          points: 5,
+          order_index: 5,
+        },
+      ],
+    },
+    {
+      slug: 'nivel-3-assertions',
+      title: 'Nivel 3: Assertions & Auto-waiting',
+      description:
+        'Aserciones auto-retrying de Playwright (expect(locator)...) frente a aserciones genéricas sobre valores ya resueltos.',
+      order_index: 3,
+      max_score: 25,
+      metadata: {
+        instructions:
+          'Preguntas basadas en la documentación oficial de assertions: https://playwright.dev/docs/test-assertions',
+        suggestedMinutes: 8,
+      },
+      questions: [
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            'En este código, si el texto "Bienvenido" todavía no apareció en el DOM cuando corre la línea, ¿qué hace Playwright?',
+          metadata: {
+            codeScenario: {
+              title: 'Ejemplo de test',
+              language: 'typescript',
+              code: `await expect(page.getByText('Bienvenido')).toBeVisible();`,
+            },
+          },
+          options: [
+            {
+              label:
+                'Reintenta automáticamente la aserción hasta que el texto sea visible o se cumpla el timeout, en vez de fallar de inmediato',
+              value: 'a',
+            },
+            {
+              label: 'Falla inmediatamente sin reintentar',
+              value: 'b',
+            },
+            {
+              label: 'Recarga la página y vuelve a intentar desde cero',
+              value: 'c',
+            },
+            {
+              label: 'Ignora la aserción si el elemento no existe todavía',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'a' },
+          explanation:
+            'toBeVisible() (como la mayoría de los matchers de expect(locator)) es auto-retrying: reintenta hasta cumplirse la condición o vencer el timeout, evitando falsos negativos por timing.',
+          points: 5,
+          order_index: 1,
+        },
+        {
+          question_type: 'true_false',
+          prompt:
+            "expect(locator).toHaveText('foo') es una aserción auto-retrying: reintenta hasta que el contenido coincida o venza el timeout.",
+          correct_answer: { value: true },
+          explanation:
+            'Los matchers que reciben un Locator (toHaveText, toBeVisible, toHaveValue, etc.) son auto-retrying por diseño.',
+          points: 5,
+          order_index: 2,
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            '¿Por qué esta aserción NO es auto-retrying aunque use expect()?',
+          metadata: {
+            codeScenario: {
+              title: 'Ejemplo de test',
+              language: 'typescript',
+              code: `const items = await page.getByRole('listitem').all();
+expect(items.length).toBe(3);`,
+            },
+          },
+          options: [
+            {
+              label:
+                'Porque expect() recibe un número ya resuelto por .all(), no un Locator: expect(valor).toBe() es una aserción genérica sin reintentos automáticos',
+              value: 'a',
+            },
+            {
+              label: 'Porque toBe() nunca existe en Playwright',
+              value: 'b',
+            },
+            {
+              label: 'Porque getByRole no soporta listitem',
+              value: 'c',
+            },
+            {
+              label: 'Porque .all() lanza una excepción si hay 3 elementos',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'a' },
+          explanation:
+            '.all() resuelve la lista de elementos en ese instante; a partir de ahí expect(items.length).toBe(3) es una aserción "de valor" común de Jest/Vitest, no una aserción de Playwright sobre un Locator.',
+          points: 5,
+          order_index: 3,
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            '¿Cuál es la forma recomendada de esperar a que un elemento desaparezca de la pantalla?',
+          options: [
+            {
+              label:
+                'await expect(locator).toBeHidden() (o toBeVisible con negación), en vez de un sleep/wait manual con tiempo fijo',
+              value: 'a',
+            },
+            {
+              label: 'await page.waitForTimeout(5000)',
+              value: 'b',
+            },
+            {
+              label: 'Recargar la página hasta que el elemento no aparezca',
+              value: 'c',
+            },
+            {
+              label: 'No hay forma de esperar eso en Playwright',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'a' },
+          explanation:
+            'toBeHidden()/not.toBeVisible() son auto-retrying y evitan sleeps arbitrarios, que son frágiles y hacen los tests más lentos o flaky.',
+          points: 5,
+          order_index: 4,
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            '¿Qué helper de Playwright permite reintentar un bloque de código arbitrario (no solo una aserción sobre un Locator) hasta que no lance error o venza el timeout?',
+          metadata: {
+            codeScenario: {
+              title: 'Ejemplo de test',
+              language: 'typescript',
+              code: `await expect(async () => {
+  const response = await page.request.get('/api/status');
+  expect(response.status()).toBe(200);
+}).toPass();`,
+            },
+          },
+          options: [
+            {
+              label:
+                'Envolver el bloque en una función async y encadenar .toPass() sobre expect(fn)',
+              value: 'a',
+            },
+            { label: 'page.retry(fn)', value: 'b' },
+            { label: 'test.repeat(fn)', value: 'c' },
+            { label: 'No existe ese mecanismo en Playwright', value: 'd' },
+          ],
+          correct_answer: { value: 'a' },
+          explanation:
+            'expect(async () => { ... }).toPass() reintenta todo el bloque hasta que no lance ninguna excepción o se agote el timeout, útil para lógica de reintento que no depende de un Locator.',
+          points: 5,
+          order_index: 5,
+        },
+      ],
+    },
+    {
+      slug: 'nivel-4-fixtures-hooks-debugging',
+      title: 'Nivel 4: Fixtures, Hooks & Debugging',
+      description:
+        'Fixtures built-in y custom, hooks de test.beforeEach/afterEach y herramientas de debugging (Inspector, Trace Viewer, UI mode).',
+      order_index: 4,
+      max_score: 25,
+      metadata: {
+        instructions:
+          'Preguntas basadas en la documentación oficial de fixtures: https://playwright.dev/docs/test-fixtures',
+        suggestedMinutes: 7,
+      },
+      questions: [
+        {
+          question_type: 'multiple_choice',
+          prompt: '¿Qué hace test.beforeEach en este ejemplo?',
+          metadata: {
+            codeScenario: {
+              title: 'Ejemplo de test',
+              language: 'typescript',
+              code: `test.beforeEach(async ({ page }) => {
+  await page.goto('https://example.com');
+});
+
+test('el título es correcto', async ({ page }) => {
+  await expect(page).toHaveTitle(/Example/);
+});`,
+            },
+          },
+          options: [
+            {
+              label:
+                'Se ejecuta antes de cada test del archivo (o describe), recibiendo fixtures como page para preparar el estado inicial',
+              value: 'a',
+            },
+            {
+              label:
+                'Se ejecuta una sola vez antes de todos los archivos de test',
+              value: 'b',
+            },
+            {
+              label: 'Reemplaza al test y nunca corre el bloque test()',
+              value: 'c',
+            },
+            {
+              label: 'Solo corre si el test anterior falló',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'a' },
+          explanation:
+            'test.beforeEach corre antes de cada test dentro de su mismo archivo o describe, y puede recibir fixtures (como page) igual que un test.',
+          points: 5,
+          order_index: 1,
+        },
+        {
+          question_type: 'true_false',
+          prompt:
+            'Las fixtures built-in como page, context y browser se crean automáticamente para cada test y se limpian al finalizar, sin que el test tenga que gestionarlas manualmente.',
+          correct_answer: { value: true },
+          explanation:
+            'Playwright Test gestiona el ciclo de vida de las fixtures built-in: las crea antes del test y las libera después, aislando cada test.',
+          points: 5,
+          order_index: 2,
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            '¿Qué representa la llamada a use(page) dentro de esta fixture custom?',
+          metadata: {
+            codeScenario: {
+              title: 'Fixture custom',
+              language: 'typescript',
+              code: `export const test = base.extend({
+  loggedInPage: async ({ page }, use) => {
+    await page.goto('/login');
+    await page.getByLabel('Usuario').fill('demo');
+    await page.getByRole('button', { name: 'Ingresar' }).click();
+    await use(page);
+    // (opcional) código de teardown después de esta línea
+  },
+});`,
+            },
+          },
+          options: [
+            {
+              label:
+                'Es el punto donde se entrega el valor de la fixture al test; la ejecución se pausa ahí hasta que el test termina, y luego continúa el código de teardown posterior',
+              value: 'a',
+            },
+            {
+              label: 'Finaliza la fixture inmediatamente y no ejecuta el test',
+              value: 'b',
+            },
+            {
+              label: 'Solo sirve para loguear mensajes en consola',
+              value: 'c',
+            },
+            {
+              label: 'Es obligatorio pero no tiene ningún efecto en el test',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'a' },
+          explanation:
+            'use() entrega el valor de la fixture (en este caso, la page ya logueada) al test que la solicitó; cualquier código después de use() corre como teardown una vez que el test terminó.',
+          points: 5,
+          order_index: 3,
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            '¿Qué comando de la CLI abre el Trace Viewer para inspeccionar una corrida fallida?',
+          options: [
+            { label: 'npx playwright show-trace trace.zip', value: 'a' },
+            { label: 'npx playwright open-trace', value: 'b' },
+            { label: 'npx playwright test --trace-only', value: 'c' },
+            { label: 'npx playwright inspect trace.zip', value: 'd' },
+          ],
+          correct_answer: { value: 'a' },
+          explanation:
+            'npx playwright show-trace trace.zip abre el Trace Viewer, con la línea de tiempo, DOM snapshots, red y consola de esa corrida.',
+          points: 5,
+          order_index: 4,
+        },
+        {
+          question_type: 'short_text',
+          prompt:
+            '¿Qué flag de la CLI abre el modo interactivo (UI mode) para ver y depurar los tests con una línea de tiempo visual?',
+          expected_keywords: ['--ui'],
+          explanation:
+            'npx playwright test --ui abre el UI mode: una interfaz gráfica para explorar, correr y depurar tests con timeline y watch mode.',
+          scoring_rules: {
+            type: 'automatic',
+            requiredKeywords: ['--ui'],
+          },
+          points: 5,
+          order_index: 5,
+        },
+      ],
+    },
+  ],
+};

--- a/apps/frontend/src/app/assessments/playwright-fundamentals/lib/gamification.ts
+++ b/apps/frontend/src/app/assessments/playwright-fundamentals/lib/gamification.ts
@@ -1,0 +1,15 @@
+import { createAssessmentGamification } from '../../_shared/lib/gamification';
+
+const gamification = createAssessmentGamification({
+  prefix: 'PLAYWRIGHT_FUNDAMENTALS',
+  descriptions: {
+    completed: 'Completar el assessment Playwright Fundamentals',
+    passed: 'Aprobar el assessment Playwright Fundamentals (score >= 60)',
+    highScore: 'Score sobresaliente en Playwright Fundamentals (>= 90)',
+  },
+});
+
+export const PLAYWRIGHT_FUNDAMENTALS_GAMIFICATION_RULES = gamification.rules;
+
+export const buildPlaywrightFundamentalsGamificationEvents =
+  gamification.buildEvents;

--- a/apps/frontend/src/app/assessments/playwright-fundamentals/lib/seed.ts
+++ b/apps/frontend/src/app/assessments/playwright-fundamentals/lib/seed.ts
@@ -1,0 +1,12 @@
+import { ensureAssessmentSeeded } from '../../_shared/lib/seed';
+import {
+  PLAYWRIGHT_FUNDAMENTALS_SEED_VERSION,
+  playwrightFundamentalsDefinition,
+} from '../data/assessment-definition';
+
+export async function ensurePlaywrightFundamentalsSeeded() {
+  return ensureAssessmentSeeded(
+    playwrightFundamentalsDefinition,
+    PLAYWRIGHT_FUNDAMENTALS_SEED_VERSION
+  );
+}

--- a/apps/frontend/src/app/assessments/playwright-fundamentals/page.tsx
+++ b/apps/frontend/src/app/assessments/playwright-fundamentals/page.tsx
@@ -1,0 +1,102 @@
+import { Metadata } from 'next';
+import { playwrightFundamentalsDefinition } from './data/assessment-definition';
+import AssessmentWelcome from '../_shared/components/AssessmentWelcome';
+
+export const metadata: Metadata = {
+  title: 'Playwright — Fundamentos | AIQUAA',
+  description:
+    'Prueba técnica teórica sobre Playwright: Test CLI y configuración, locators web-first, assertions con auto-retry, y fixtures/hooks/debugging.',
+  keywords: [
+    'Playwright',
+    'automatización',
+    'testing E2E',
+    'locators',
+    'assertions',
+    'fixtures',
+    'QA',
+    'testing',
+    'AIQUAA',
+    'evaluación técnica',
+  ],
+  openGraph: {
+    title: 'Playwright — Fundamentos | AIQUAA',
+    description:
+      'Prueba técnica teórica sobre Playwright: CLI, locators, assertions y fixtures.',
+    url: 'https://aiquaa.com/assessments/playwright-fundamentals',
+    siteName: 'AIQUAA',
+    type: 'website',
+    locale: 'es_PY',
+    images: [
+      {
+        url: '/api/og?title=Playwright%20-%20Fundamentos&subtitle=CLI%2C%20Locators%20y%20Assertions&section=Assessments',
+        width: 1200,
+        height: 630,
+        alt: 'Playwright Fundamentos - AIQUAA',
+      },
+    ],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Playwright — Fundamentos | AIQUAA',
+    description:
+      'Prueba técnica sobre CLI, locators, assertions y fixtures de Playwright.',
+    images: [
+      '/api/og?title=Playwright%20-%20Fundamentos&subtitle=CLI%2C%20Locators%20y%20Assertions&section=Assessments',
+    ],
+    creator: '@stevenayal',
+  },
+  alternates: {
+    canonical: 'https://aiquaa.com/assessments/playwright-fundamentals',
+  },
+};
+
+export default function PlaywrightFundamentalsPage() {
+  const overview = {
+    assessment: {
+      id: 'static-playwright-fundamentals',
+      slug: playwrightFundamentalsDefinition.slug,
+      title: playwrightFundamentalsDefinition.title,
+      description: playwrightFundamentalsDefinition.description,
+      level: playwrightFundamentalsDefinition.level,
+      type: playwrightFundamentalsDefinition.type,
+      duration_minutes: playwrightFundamentalsDefinition.duration_minutes,
+      total_score: playwrightFundamentalsDefinition.total_score,
+      is_active: playwrightFundamentalsDefinition.is_active,
+      metadata: playwrightFundamentalsDefinition.metadata,
+    },
+    sections: playwrightFundamentalsDefinition.sections.map(
+      (section, index) => ({
+        id: `static-section-${index + 1}`,
+        assessment_id: 'static-playwright-fundamentals',
+        slug: section.slug,
+        title: section.title,
+        description: section.description,
+        order_index: section.order_index,
+        max_score: section.max_score,
+        metadata: section.metadata,
+      })
+    ),
+  };
+
+  return (
+    <AssessmentWelcome
+      overview={overview}
+      startHref="/assessments/playwright-fundamentals/start"
+      evaluatesCopy="Test CLI y playwright.config.ts; locators web-first (getByRole, getByLabel, getByTestId) y auto-waiting; assertions auto-retrying; fixtures built-in/custom, hooks y herramientas de debugging (Inspector, Trace Viewer, UI mode)."
+      scoringCopy="Automático en los 4 niveles: selección múltiple, verdadero/falso y respuesta corta sobre snippets reales de código Playwright."
+      resultCopy="Score total, score por nivel, fortalezas, debilidades y temas a reforzar."
+      referenceLinks={[
+        { label: 'Test CLI', href: 'https://playwright.dev/docs/test-cli' },
+        { label: 'Locators', href: 'https://playwright.dev/docs/locators' },
+        {
+          label: 'Assertions',
+          href: 'https://playwright.dev/docs/test-assertions',
+        },
+        {
+          label: 'Fixtures',
+          href: 'https://playwright.dev/docs/test-fixtures',
+        },
+      ]}
+    />
+  );
+}

--- a/apps/frontend/src/app/assessments/playwright-fundamentals/result/page.tsx
+++ b/apps/frontend/src/app/assessments/playwright-fundamentals/result/page.tsx
@@ -1,0 +1,19 @@
+import { Suspense } from 'react';
+import AssessmentResultClient from '../../_shared/components/AssessmentResultClient';
+
+export default function PlaywrightFundamentalsResultPage() {
+  return (
+    <Suspense
+      fallback={
+        <div className="min-h-screen flex items-center justify-center bg-slate-950">
+          <div className="h-10 w-10 animate-spin rounded-full border-t-2 border-cyan-400" />
+        </div>
+      }
+    >
+      <AssessmentResultClient
+        startHref="/assessments/playwright-fundamentals/start"
+        fallbackRecommendation="Repasá la documentación oficial de Playwright: Test CLI, locators, assertions y fixtures (https://playwright.dev/docs)."
+      />
+    </Suspense>
+  );
+}

--- a/apps/frontend/src/app/assessments/playwright-fundamentals/section/[sectionId]/page.tsx
+++ b/apps/frontend/src/app/assessments/playwright-fundamentals/section/[sectionId]/page.tsx
@@ -1,0 +1,9 @@
+'use client';
+
+import AssessmentSectionScreen from '../../../_shared/components/AssessmentSectionScreen';
+
+export default function PlaywrightFundamentalsSectionPage() {
+  return (
+    <AssessmentSectionScreen basePath="/assessments/playwright-fundamentals" />
+  );
+}

--- a/apps/frontend/src/app/assessments/playwright-fundamentals/start/page.tsx
+++ b/apps/frontend/src/app/assessments/playwright-fundamentals/start/page.tsx
@@ -1,0 +1,133 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { useTheme } from '@/contexts/ThemeContext';
+import { startAssessmentAttemptAction } from '@/actions/assessments';
+import ProcessCodeInput from '@/components/labs/ProcessCodeInput';
+import { PLAYWRIGHT_FUNDAMENTALS_SLUG } from '../data/assessment-definition';
+
+export default function StartPlaywrightFundamentalsPage() {
+  const router = useRouter();
+  const { isDarkMode } = useTheme();
+  const [processCode, setProcessCode] = useState('');
+  const [error, setError] = useState('');
+  const [isStarting, setIsStarting] = useState(false);
+
+  // Pre-fill desde ?code= (links de invitaciones/procesos de empresa)
+  useEffect(() => {
+    const codeParam = new URLSearchParams(window.location.search).get('code');
+    if (codeParam) setProcessCode(codeParam);
+  }, []);
+
+  async function handleStart() {
+    setError('');
+    setIsStarting(true);
+
+    try {
+      const result = await startAssessmentAttemptAction({
+        slug: PLAYWRIGHT_FUNDAMENTALS_SLUG,
+        processCode,
+      });
+
+      if ('error' in result) {
+        setIsStarting(false);
+        setError(result.error);
+        return;
+      }
+
+      const { attempt, sectionSlug } = result;
+
+      if (!sectionSlug) {
+        setIsStarting(false);
+        setError('No se encontró la primera sección del assessment.');
+        return;
+      }
+
+      setIsStarting(false);
+      router.push(
+        `/assessments/playwright-fundamentals/section/${sectionSlug}?attempt=${attempt.id}`
+      );
+    } catch (startError) {
+      setIsStarting(false);
+      setError(
+        startError instanceof Error
+          ? startError.message
+          : 'No se pudo iniciar el assessment.'
+      );
+    }
+  }
+
+  return (
+    <div
+      className={`min-h-screen px-4 py-12 ${
+        isDarkMode ? 'bg-slate-950 text-white' : 'bg-slate-50 text-slate-900'
+      }`}
+    >
+      <div className="mx-auto max-w-3xl rounded-3xl border border-slate-800 bg-slate-900/80 p-8 text-slate-50 shadow-2xl shadow-cyan-950/20">
+        <p className="text-sm font-semibold uppercase tracking-[0.18em] text-cyan-200">
+          Preparación del intento
+        </p>
+        <h1 className="mt-3 text-3xl font-bold">Playwright — Fundamentos</h1>
+        <p className="mt-3 text-slate-300">
+          Vas a completar 4 niveles teóricos con autosave, scoring por sección y
+          resultado final consolidado.
+        </p>
+
+        <div className="mt-8 grid gap-4 rounded-2xl border border-slate-800 bg-slate-950/70 p-5 md:grid-cols-3">
+          <div>
+            <p className="text-xs uppercase tracking-[0.18em] text-slate-400">
+              Duración sugerida
+            </p>
+            <p className="mt-2 text-lg font-semibold">~30 minutos</p>
+          </div>
+          <div>
+            <p className="text-xs uppercase tracking-[0.18em] text-slate-400">
+              Modalidad
+            </p>
+            <p className="mt-2 text-lg font-semibold">Conceptual</p>
+          </div>
+          <div>
+            <p className="text-xs uppercase tracking-[0.18em] text-slate-400">
+              Resultado
+            </p>
+            <p className="mt-2 text-lg font-semibold">Score total sobre 100</p>
+          </div>
+        </div>
+
+        <div className="mt-8">
+          <ProcessCodeInput
+            value={processCode}
+            onChange={setProcessCode}
+            onNormalizedCode={setProcessCode}
+            autoValidate
+          />
+        </div>
+
+        {error ? (
+          <div className="mt-6 rounded-2xl border border-red-500/30 bg-red-500/10 px-4 py-3 text-sm text-red-200">
+            {error}
+          </div>
+        ) : null}
+
+        <div className="mt-8 flex flex-col gap-3 sm:flex-row">
+          <button
+            type="button"
+            onClick={handleStart}
+            disabled={isStarting}
+            className="inline-flex items-center justify-center rounded-2xl bg-cyan-400 px-5 py-3 text-sm font-semibold text-slate-950 transition hover:bg-cyan-300 disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {isStarting ? 'Preparando intento...' : 'Iniciar o reanudar'}
+          </button>
+          <button
+            type="button"
+            onClick={() => router.push('/assessments/playwright-fundamentals')}
+            className="inline-flex items-center justify-center rounded-2xl border border-slate-700 px-5 py-3 text-sm font-semibold text-slate-200 transition hover:bg-slate-800"
+          >
+            Volver al overview
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/src/app/ranking/page.tsx
+++ b/apps/frontend/src/app/ranking/page.tsx
@@ -58,7 +58,9 @@ type ExamSlug =
   | 'database-fundamentals'
   | 'database-practice'
   | 'infrastructure-fundamentals'
-  | 'api-developer-fundamentals';
+  | 'api-developer-fundamentals'
+  | 'playwright-fundamentals'
+  | 'playwright-practico';
 
 const EXAM_SLUGS: ExamSlug[] = [
   'git',
@@ -71,6 +73,8 @@ const EXAM_SLUGS: ExamSlug[] = [
   'database-practice',
   'infrastructure-fundamentals',
   'api-developer-fundamentals',
+  'playwright-fundamentals',
+  'playwright-practico',
 ];
 
 interface Category {
@@ -140,6 +144,14 @@ const CATEGORIES: Category[] = [
     teorico: 'api-developer-fundamentals',
   },
   {
+    key: 'playwright',
+    label: 'Playwright',
+    emoji: '🎭',
+    color: 'from-fuchsia-500 to-purple-600',
+    teorico: 'playwright-fundamentals',
+    practico: 'playwright-practico',
+  },
+  {
     key: 'comunidad',
     label: 'Comunidad',
     emoji: '🚀',
@@ -161,6 +173,8 @@ const EXAM_TAB_URLS: Record<string, string> = {
   'database-practice': '/assessments/database-practice',
   'infrastructure-fundamentals': '/assessments/infrastructure-fundamentals',
   'api-developer-fundamentals': '/assessments/api-developer-fundamentals',
+  'playwright-fundamentals': '/assessments/playwright-fundamentals',
+  'playwright-practico': '/labs/playwright-practico',
 };
 
 const MEDAL = ['🥇', '🥈', '🥉'];

--- a/apps/frontend/src/lib/exams.ts
+++ b/apps/frontend/src/lib/exams.ts
@@ -14,7 +14,8 @@ export type ExamType =
   | 'database-practice'
   | 'infrastructure-fundamentals'
   | 'api-developer-fundamentals'
-  | 'playwright-practico';
+  | 'playwright-practico'
+  | 'playwright-fundamentals';
 
 export interface ExamMeta {
   emoji: string;
@@ -75,6 +76,11 @@ export const EXAM_META: Record<ExamType, ExamMeta> = {
     label: 'Playwright — Prueba práctica',
     href: '/labs/playwright-practico',
   },
+  'playwright-fundamentals': {
+    emoji: '🎬',
+    label: 'Playwright — Fundamentos',
+    href: '/assessments/playwright-fundamentals',
+  },
 };
 
 export const EXAM_TYPES = Object.keys(EXAM_META) as ExamType[];
@@ -89,6 +95,7 @@ export const POINTS_BASED_TYPES = new Set<ExamType>([
   'infrastructure-fundamentals',
   'api-developer-fundamentals',
   'playwright-practico',
+  'playwright-fundamentals',
 ]);
 
 export interface ExamScoreFields {

--- a/apps/frontend/src/lib/ranking-achievements.ts
+++ b/apps/frontend/src/lib/ranking-achievements.ts
@@ -48,6 +48,8 @@ const RANKED_EXAM_TYPES: ExamType[] = [
   'database-practice',
   'infrastructure-fundamentals',
   'api-developer-fundamentals',
+  'playwright-practico',
+  'playwright-fundamentals',
 ];
 
 const ASSESSMENT_RANKING_TYPES = new Set<ExamType>([
@@ -55,6 +57,7 @@ const ASSESSMENT_RANKING_TYPES = new Set<ExamType>([
   'database-practice',
   'infrastructure-fundamentals',
   'api-developer-fundamentals',
+  'playwright-fundamentals',
 ]);
 
 function isMissingAchievementsTableError(error: { code?: string } | null) {

--- a/supabase/migrations/20260715_000000_playwright_fundamentals.sql
+++ b/supabase/migrations/20260715_000000_playwright_fundamentals.sql
@@ -1,0 +1,44 @@
+-- Habilita el assessment conceptual "Playwright — Fundamentos" en el
+-- ecosistema de resultados/ranking:
+-- 1. Amplía el CHECK de exam_results.exam_type con playwright-fundamentals
+--    (sin esto los inserts fallan en silencio).
+-- 2. Reglas XP para el assessment (espejo de api-developer-fundamentals).
+
+-- 1. exam_results.exam_type
+ALTER TABLE public.exam_results
+  DROP CONSTRAINT IF EXISTS exam_results_exam_type_check;
+
+ALTER TABLE public.exam_results
+  ADD CONSTRAINT exam_results_exam_type_check
+  CHECK (
+    exam_type = ANY (
+      ARRAY[
+        'git'::text,
+        'git-practico'::text,
+        'istqb'::text,
+        'performance'::text,
+        'test-app'::text,
+        'api-testing-fundamentals'::text,
+        'api-banking'::text,
+        'database-fundamentals'::text,
+        'database-practice'::text,
+        'infrastructure-fundamentals'::text,
+        'api-developer-fundamentals'::text,
+        'playwright-practico'::text,
+        'playwright-fundamentals'::text
+      ]
+    )
+  );
+
+-- 2. Reglas XP para el assessment Playwright Fundamentals
+INSERT INTO public.xp_rules (event_type, xp_amount, description, daily_limit, is_active)
+VALUES
+  ('PLAYWRIGHT_FUNDAMENTALS_COMPLETED', 70, 'Completar el assessment Playwright Fundamentals', 3, true),
+  ('PLAYWRIGHT_FUNDAMENTALS_PASSED', 120, 'Aprobar el assessment Playwright Fundamentals (score >= 60)', 3, true),
+  ('PLAYWRIGHT_FUNDAMENTALS_HIGH_SCORE', 160, 'Score sobresaliente en Playwright Fundamentals (>= 90)', 3, true)
+ON CONFLICT (event_type) DO UPDATE SET
+  xp_amount = EXCLUDED.xp_amount,
+  description = EXCLUDED.description,
+  daily_limit = EXCLUDED.daily_limit,
+  is_active = EXCLUDED.is_active,
+  updated_at = now();


### PR DESCRIPTION
## Summary
- Nueva prueba técnica conceptual **Playwright — Fundamentos** (`/assessments/playwright-fundamentals`): 4 niveles (Test CLI & Configuración, Locators & Acciones, Assertions & Auto-waiting, Fixtures/Hooks & Debugging), 20 preguntas auto-corregidas (100 pts) basadas en snippets reales de código Playwright y en la documentación oficial (playwright.dev). Antes de empezar, la pantalla de bienvenida enlaza a la documentación oficial recomendada (Test CLI, Locators, Assertions, Fixtures) vía un nuevo prop opcional `referenceLinks` en `AssessmentWelcome`.
- Nuevo bloque reutilizable `PlaywrightCodeBlock` (calcado de `SqlScenarioBlock`) para mostrar snippets de código Playwright en las preguntas, integrado de forma aditiva en `AssessmentSectionScreen`.
- **Fix de ranking/perfil**: ni `playwright-fundamentals` (nuevo) ni `playwright-practico` (ya existente) aparecían en `/ranking` ni generaban medallas Top-3 en `/perfil`, porque faltaban en los registros hardcodeados de `lib/exams.ts`, `actions/exams.ts`, `app/ranking/page.tsx` y `lib/ranking-achievements.ts`. Ambas pruebas de Playwright quedan ahora integradas al ranking (nueva categoría "Playwright" teórico+práctico) y a los logros de perfil.
- Migración Supabase: amplía el CHECK de `exam_results.exam_type` con `playwright-fundamentals` y siembra sus reglas de XP.

## Test plan
- [x] `pnpm --filter @aiquaa/frontend test` — pasan los 3 tests nuevos de `playwright-fundamentals/__tests__/definition.test.ts` y los 59 tests de assessments/ranking sin regresiones.
- [x] `pnpm --filter @aiquaa/frontend type-check` — limpio.
- [x] `pnpm --filter @aiquaa/frontend lint` — 0 errores (solo warnings preexistentes no relacionados).
- [ ] Manual: completar un intento de `/assessments/playwright-fundamentals` y verificar que aparece en `/perfil` y `/ranking` (pestaña "Playwright").


---
_Generated by [Claude Code](https://claude.ai/code/session_01QvaiVQgRxC3RVEnd1SHFsC)_