### PR TITLE
fix(labs): mostrar Playwright — Fundamentos en el catálogo de /labs

### DIFF
--- a/apps/frontend/src/lib/labsCatalog.ts
+++ b/apps/frontend/src/lib/labsCatalog.ts
@@ -70,6 +70,17 @@ export const toolCategories: LabCategory[] = [
         implementedDate: 'Jul 2026',
       },
       {
+        id: 'playwright-fundamentals',
+        name: 'Playwright — Fundamentos',
+        description:
+          'Prueba técnica teórica sobre Test CLI, locators web-first, assertions con auto-retry y fixtures/hooks/debugging, con snippets reales de código — auto-corregido, 100 pts',
+        icon: '🎬',
+        color: 'from-fuchsia-500 to-purple-700',
+        href: '/assessments/playwright-fundamentals',
+        featured: true,
+        implementedDate: 'Jul 2026',
+      },
+      {
         id: 'performance',
         name: 'Examen de Performance Testing',
         description:


### PR DESCRIPTION
## Summary
- Sigue a #287 (ya mergeado). `playwright-fundamentals` existe en `/assessments` y ya está integrado a ranking/perfil, pero nunca se agregó a `labsCatalog.ts` — el catálogo que alimenta la página `/labs` y el contador de herramientas del home — a diferencia de las demás pruebas `-fundamentals` (`database-fundamentals`, `infrastructure-fundamentals`, `api-developer-fundamentals`) que ya estaban ahí.
- Se agrega la entrada faltante en la categoría "🎓 Formación y Certificación", junto a "Prueba Práctica de Playwright", apuntando a `/assessments/playwright-fundamentals`.
- Ningún cambio en `labs/page.tsx`: renderiza `toolCategories` sin filtrar por prefijo de URL, así que basta con la entrada en el catálogo.

## Test plan
- [x] `pnpm --filter @aiquaa/frontend type-check` — limpio.
- [x] `pnpm --filter @aiquaa/frontend lint` (solo el archivo tocado) — limpio.
- [ ] Manual: abrir `/labs`, confirmar la card "Playwright — Fundamentos" en "Formación y Certificación" con link a `/assessments/playwright-fundamentals`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01QvaiVQgRxC3RVEnd1SHFsC)_