### PR TITLE
Átomo del logo: bolita independiente por órbita y visible en responsive

### DIFF
--- a/apps/frontend/src/app/page.tsx
+++ b/apps/frontend/src/app/page.tsx
@@ -224,12 +224,12 @@ export default function HomePage() {
               </div>
 
               {/* Right Column — Circular LogoMark */}
-              <div className="hidden lg:flex justify-center items-center">
+              <div className="flex justify-center items-center mt-12 lg:mt-0">
                 <div className="relative">
                   <div className="absolute inset-0 bg-gradient-to-r from-indigo-500/30 to-purple-500/30 rounded-full blur-3xl" />
 
                   <div
-                    className={`relative w-[340px] h-[340px] rounded-full grid place-items-center backdrop-blur-sm shadow-2xl border ${
+                    className={`relative w-[220px] h-[220px] sm:w-[280px] sm:h-[280px] lg:w-[340px] lg:h-[340px] rounded-full grid place-items-center backdrop-blur-sm shadow-2xl border ${
                       isDarkMode
                         ? 'bg-slate-800/60 border-slate-600/50'
                         : 'bg-white/80 border-indigo-100'
@@ -237,17 +237,18 @@ export default function HomePage() {
                   >
                     <LogoMark
                       size={240}
+                      className="w-[155px] h-[155px] sm:w-[195px] sm:h-[195px] lg:w-[240px] lg:h-[240px]"
                       color={isDarkMode ? '#ffffff' : '#0f172a'}
                       animated
                       wordmark
                     />
 
-                    <div className="absolute -top-2 -right-2 flex items-center gap-1.5 bg-gradient-to-r from-green-500 to-emerald-500 text-white px-4 py-2 rounded-full text-sm font-bold shadow-lg animate-bounce">
+                    <div className="absolute -top-2 -right-2 flex items-center gap-1 sm:gap-1.5 bg-gradient-to-r from-green-500 to-emerald-500 text-white px-2.5 py-1.5 sm:px-4 sm:py-2 rounded-full text-xs sm:text-sm font-bold shadow-lg animate-bounce">
                       <LineIcon name="cap" size={14} />
                       ISTQB Ready
                     </div>
                     <div
-                      className="absolute -bottom-2 -left-2 flex items-center gap-1.5 bg-gradient-to-r from-blue-500 to-cyan-500 text-white px-4 py-2 rounded-full text-sm font-bold shadow-lg animate-bounce"
+                      className="absolute -bottom-2 -left-2 flex items-center gap-1 sm:gap-1.5 bg-gradient-to-r from-blue-500 to-cyan-500 text-white px-2.5 py-1.5 sm:px-4 sm:py-2 rounded-full text-xs sm:text-sm font-bold shadow-lg animate-bounce"
                       style={{ animationDelay: '0.5s' }}
                     >
                       <LineIcon name="target" size={14} />

--- a/apps/frontend/src/components/LogoMark.tsx
+++ b/apps/frontend/src/components/LogoMark.tsx
@@ -17,49 +17,48 @@ const ORBIT_PATH_D = 'M 190 80 A 70 28 0 1 1 50 80 A 70 28 0 1 1 190 80';
 // keyTimes 0/0.5 = costados (profundidad media), 0.25 = frente
 // (más grande/opaco), 0.75 = fondo (más chico/tenue) — simula 3D.
 const DEPTH_KEY_TIMES = '0;0.25;0.5;0.75;1';
-const DEPTH_R_VALUES = '5;6.5;5;2.8;5';
-const DEPTH_OPACITY_VALUES = '0.8;1;0.8;0.35;0.8';
+const DEPTH_R_VALUES = '6;8;6;3.5;6';
+const DEPTH_OPACITY_VALUES = '0.85;1;0.85;0.4;0.85';
 
-function OrbitElectrons({
+function OrbitElectron({
   pathId,
   color,
   duration,
+  begin = 0,
 }: {
   pathId: string;
   color: string;
   duration: number;
+  begin?: number;
 }) {
-  const offset = -(duration / 2);
   return (
     <>
       <path id={pathId} d={ORBIT_PATH_D} fill="none" stroke="none" />
-      {[0, offset].map((begin) => (
-        <circle key={begin} r="5" fill={color} stroke="none">
-          <animateMotion
-            dur={`${duration}s`}
-            begin={`${begin}s`}
-            repeatCount="indefinite"
-          >
-            <mpath href={`#${pathId}`} />
-          </animateMotion>
-          <animate
-            attributeName="r"
-            values={DEPTH_R_VALUES}
-            keyTimes={DEPTH_KEY_TIMES}
-            dur={`${duration}s`}
-            begin={`${begin}s`}
-            repeatCount="indefinite"
-          />
-          <animate
-            attributeName="opacity"
-            values={DEPTH_OPACITY_VALUES}
-            keyTimes={DEPTH_KEY_TIMES}
-            dur={`${duration}s`}
-            begin={`${begin}s`}
-            repeatCount="indefinite"
-          />
-        </circle>
-      ))}
+      <circle r="6" fill={color} stroke="#000" strokeWidth="2">
+        <animateMotion
+          dur={`${duration}s`}
+          begin={`${begin}s`}
+          repeatCount="indefinite"
+        >
+          <mpath href={`#${pathId}`} />
+        </animateMotion>
+        <animate
+          attributeName="r"
+          values={DEPTH_R_VALUES}
+          keyTimes={DEPTH_KEY_TIMES}
+          dur={`${duration}s`}
+          begin={`${begin}s`}
+          repeatCount="indefinite"
+        />
+        <animate
+          attributeName="opacity"
+          values={DEPTH_OPACITY_VALUES}
+          keyTimes={DEPTH_KEY_TIMES}
+          dur={`${duration}s`}
+          begin={`${begin}s`}
+          repeatCount="indefinite"
+        />
+      </circle>
     </>
   );
 }
@@ -98,21 +97,41 @@ export default function LogoMark({
       <g stroke={color} strokeWidth="6" fill="none" strokeLinecap="round">
         <g className={animated ? 'lm-orbit lm-orbit-1' : undefined}>
           <ellipse cx="120" cy="80" rx="70" ry="28" />
+          {electronsOrbit ? (
+            <OrbitElectron
+              pathId={`lm-orbit-path-1-${uid}`}
+              color={color}
+              duration={4.5}
+            />
+          ) : (
+            <circle
+              cx="56.6"
+              cy="68.2"
+              r="6"
+              fill={color}
+              stroke="#000"
+              strokeWidth="2"
+            />
+          )}
         </g>
         <g className={animated ? 'lm-orbit lm-orbit-2' : undefined}>
           <g transform="rotate(60 120 80)">
             <ellipse cx="120" cy="80" rx="70" ry="28" />
             {electronsOrbit ? (
-              <OrbitElectrons
+              <OrbitElectron
                 pathId={`lm-orbit-path-2-${uid}`}
                 color={color}
-                duration={5}
+                duration={6}
               />
             ) : (
-              <>
-                <circle cx="71.9" cy="127.3" r="5" fill={color} stroke="none" />
-                <circle cx="136.9" cy="14.7" r="5" fill={color} stroke="none" />
-              </>
+              <circle
+                cx="71.9"
+                cy="127.3"
+                r="6"
+                fill={color}
+                stroke="#000"
+                strokeWidth="2"
+              />
             )}
           </g>
         </g>
@@ -120,16 +139,20 @@ export default function LogoMark({
           <g transform="rotate(120 120 80)">
             <ellipse cx="120" cy="80" rx="70" ry="28" />
             {electronsOrbit ? (
-              <OrbitElectrons
+              <OrbitElectron
                 pathId={`lm-orbit-path-3-${uid}`}
                 color={color}
-                duration={6.5}
+                duration={7.5}
               />
             ) : (
-              <>
-                <circle cx="178.9" cy="106" r="5" fill={color} stroke="none" />
-                <circle cx="126.9" cy="16" r="5" fill={color} stroke="none" />
-              </>
+              <circle
+                cx="178.9"
+                cy="106"
+                r="6"
+                fill={color}
+                stroke="#000"
+                strokeWidth="2"
+              />
             )}
           </g>
         </g>


### PR DESCRIPTION
## Summary

Continúa el trabajo del PR #289 (ya mergeado) sobre la animación del átomo del logo en el hero del inicio:

- Cada una de las 3 órbitas del átomo ahora tiene su propia bolita (electrón) independiente viajando por su borde, en vez de solo 2 de las 3 compartiendo un par. Se agranda el radio base y se agrega un borde negro de 2px a cada bolita para que se distinga claramente de la línea de la órbita, tanto en modo claro como oscuro (`LogoMark.tsx`).
- El círculo animado del átomo en el hero estaba oculto en mobile/tablet (`hidden lg:flex`). Ahora es visible en todos los breakpoints: se apila debajo del texto en pantallas chicas y escala de 220px (mobile) → 280px (sm) → 340px (lg). Los badges flotantes "ISTQB Ready" / "JMeter Pro" también reducen tamaño de fuente/padding en mobile (`page.tsx`).

## Test plan

- [x] `pnpm exec eslint` sobre los archivos modificados — sin errores
- [x] `tsc --noEmit` (pre-push hook) — sin errores
- [x] Verificación visual con `next dev` + Playwright: átomo animado en desktop, tablet (768px) y mobile (390px), modo claro y oscuro, logo estático del header sin cambios
- [ ] Revisión visual final por el usuario en preview de Vercel

🤖 Generado con [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01T85rp76hFUEEKWeKoKiPTg)_