### PR TITLE
feat(assessments): prueba técnica Gherkin y BDD — Fundamentos

### DIFF
--- a/apps/frontend/src/actions/exams.ts
+++ b/apps/frontend/src/actions/exams.ts
@@ -23,7 +23,8 @@ interface SaveExamResultPayload {
     | 'infrastructure-fundamentals'
     | 'api-developer-fundamentals'
     | 'playwright-practico'
-    | 'playwright-fundamentals';
+    | 'playwright-fundamentals'
+    | 'gherkin-fundamentals';
   exam_mode: 'exam' | 'training';
   participant_name?: string;
   participant_email?: string;
@@ -191,7 +192,8 @@ export async function getLeaderboardAction(
     | 'infrastructure-fundamentals'
     | 'api-developer-fundamentals'
     | 'playwright-practico'
-    | 'playwright-fundamentals',
+    | 'playwright-fundamentals'
+    | 'gherkin-fundamentals',
   limit = 20
 ) {
   const supabase = createClient();

--- a/apps/frontend/src/actions/lib/assessment-slugs.ts
+++ b/apps/frontend/src/actions/lib/assessment-slugs.ts
@@ -9,4 +9,5 @@ export const PROCESS_ASSESSMENT_SLUGS = [
   'database-practice',
   'infrastructure-fundamentals',
   'api-developer-fundamentals',
+  'gherkin-fundamentals',
 ];

--- a/apps/frontend/src/app/assessments/_shared/registry.ts
+++ b/apps/frontend/src/app/assessments/_shared/registry.ts
@@ -35,6 +35,15 @@ import {
 } from '../database-practice/lib/gamification';
 import { ensureDatabasePracticeSeeded } from '../database-practice/lib/seed';
 import {
+  GHERKIN_FUNDAMENTALS_SEED_VERSION,
+  GHERKIN_FUNDAMENTALS_SLUG,
+} from '../gherkin-fundamentals/data/assessment-definition';
+import {
+  GHERKIN_FUNDAMENTALS_GAMIFICATION_RULES,
+  buildGherkinFundamentalsGamificationEvents,
+} from '../gherkin-fundamentals/lib/gamification';
+import { ensureGherkinFundamentalsSeeded } from '../gherkin-fundamentals/lib/seed';
+import {
   INFRASTRUCTURE_FUNDAMENTALS_SEED_VERSION,
   INFRASTRUCTURE_FUNDAMENTALS_SLUG,
 } from '../infrastructure-fundamentals/data/assessment-definition';
@@ -62,6 +71,7 @@ export type AssessmentExamType =
   | 'api-testing-fundamentals'
   | 'database-fundamentals'
   | 'database-practice'
+  | 'gherkin-fundamentals'
   | 'infrastructure-fundamentals'
   | 'playwright-fundamentals';
 
@@ -124,6 +134,15 @@ export const ASSESSMENT_REGISTRY: Record<string, AssessmentRegistryEntry> = {
     gamificationSource: 'DATABASE_PRACTICE',
     gamificationRules: DATABASE_PRACTICE_GAMIFICATION_RULES,
     buildGamificationEvents: buildDatabasePracticeGamificationEvents,
+  },
+  [GHERKIN_FUNDAMENTALS_SLUG]: {
+    slug: GHERKIN_FUNDAMENTALS_SLUG,
+    seedVersion: GHERKIN_FUNDAMENTALS_SEED_VERSION,
+    ensureSeeded: ensureGherkinFundamentalsSeeded,
+    examType: 'gherkin-fundamentals',
+    gamificationSource: 'GHERKIN_FUNDAMENTALS',
+    gamificationRules: GHERKIN_FUNDAMENTALS_GAMIFICATION_RULES,
+    buildGamificationEvents: buildGherkinFundamentalsGamificationEvents,
   },
   [INFRASTRUCTURE_FUNDAMENTALS_SLUG]: {
     slug: INFRASTRUCTURE_FUNDAMENTALS_SLUG,

--- a/apps/frontend/src/app/assessments/gherkin-fundamentals/__tests__/definition.test.ts
+++ b/apps/frontend/src/app/assessments/gherkin-fundamentals/__tests__/definition.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { assertAssessmentDefinitionConsistency } from '../../_shared/testing/assessment-definition-checks';
+import {
+  GHERKIN_FUNDAMENTALS_SEED_VERSION,
+  GHERKIN_FUNDAMENTALS_SLUG,
+  gherkinFundamentalsDefinition,
+} from '../data/assessment-definition';
+import { ASSESSMENT_REGISTRY } from '../../_shared/registry';
+
+describe('gherkin-fundamentals definition', () => {
+  it('mantiene presupuestos de puntos y answer keys consistentes', () => {
+    assertAssessmentDefinitionConsistency(gherkinFundamentalsDefinition);
+  });
+
+  it('define 3 niveles teóricos sobre 100 puntos', () => {
+    expect(gherkinFundamentalsDefinition.sections).toHaveLength(3);
+    expect(gherkinFundamentalsDefinition.total_score).toBe(100);
+    expect(gherkinFundamentalsDefinition.slug).toBe(GHERKIN_FUNDAMENTALS_SLUG);
+  });
+
+  it('está registrado con el seedVersion correcto', () => {
+    const entry = ASSESSMENT_REGISTRY[GHERKIN_FUNDAMENTALS_SLUG];
+    expect(entry).toBeDefined();
+    expect(entry.seedVersion).toBe(GHERKIN_FUNDAMENTALS_SEED_VERSION);
+    expect(entry.examType).toBe('gherkin-fundamentals');
+  });
+});

--- a/apps/frontend/src/app/assessments/gherkin-fundamentals/data/assessment-definition.ts
+++ b/apps/frontend/src/app/assessments/gherkin-fundamentals/data/assessment-definition.ts
@@ -1,0 +1,724 @@
+import type { AssessmentSeedDefinition } from '../../_shared/types';
+
+export const GHERKIN_FUNDAMENTALS_SLUG = 'gherkin-fundamentals';
+
+// Bumpear cuando cambie la definición (secciones/preguntas) para forzar re-seed.
+export const GHERKIN_FUNDAMENTALS_SEED_VERSION = 1;
+
+export const gherkinFundamentalsDefinition: AssessmentSeedDefinition = {
+  slug: GHERKIN_FUNDAMENTALS_SLUG,
+  title: 'Gherkin y BDD — Fundamentos',
+  description:
+    'Evaluación teórica de Gherkin y BDD para QA: fundamentos de Behavior-Driven Development (los 3 amigos, discovery y documentación viva), sintaxis Gherkin (Dado/Cuando/Entonces, Antecedentes) y escenarios avanzados con Scenario Outline, tags y buenas prácticas aplicadas al testing.',
+  level: 'Junior a Semi Senior',
+  type: 'QA BDD',
+  duration_minutes: 35,
+  total_score: 100,
+  is_active: true,
+  metadata: {
+    moduleName: 'AIQUAA Assessments / Gherkin Fundamentals',
+    passingScore: 70,
+    candidateBands: [
+      { min: 0, max: 39, label: 'Inicial' },
+      { min: 40, max: 69, label: 'Junior en formación' },
+      { min: 70, max: 79, label: 'Junior' },
+      { min: 80, max: 89, label: 'Junior avanzado' },
+      { min: 90, max: 100, label: 'Semi Senior' },
+    ],
+  },
+  sections: [
+    {
+      slug: 'nivel-1-fundamentos-bdd',
+      title: 'Nivel 1: Fundamentos de BDD',
+      description:
+        'Validá tu comprensión de Behavior-Driven Development: qué es, los 3 amigos, las fases discovery/formulation/automation, la relación con TDD y la documentación viva.',
+      order_index: 1,
+      max_score: 36,
+      metadata: {
+        instructions:
+          'Combinación de selección múltiple y verdadero/falso basada en la documentación oficial de Cucumber y la práctica BDD.',
+        suggestedMinutes: 12,
+      },
+      questions: [
+        {
+          question_type: 'multiple_choice',
+          prompt: '¿Qué describe mejor a BDD (Behavior-Driven Development)?',
+          options: [
+            {
+              label:
+                'Una práctica colaborativa donde negocio, desarrollo y testing definen el comportamiento esperado mediante ejemplos concretos en lenguaje natural',
+              value: 'a',
+            },
+            {
+              label:
+                'Una herramienta para ejecutar tests unitarios más rápido en el pipeline de CI',
+              value: 'b',
+            },
+            {
+              label:
+                'Un framework de automatización de UI que reemplaza a Selenium y Playwright',
+              value: 'c',
+            },
+            {
+              label:
+                'Una metodología de gestión de proyectos que reemplaza a Scrum',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'a' },
+          explanation:
+            'BDD es ante todo una práctica de colaboración: el equipo describe el comportamiento del sistema con ejemplos concretos y compartidos antes de implementarlo. La automatización es una consecuencia, no el punto de partida.',
+          points: 4,
+          order_index: 1,
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            'En BDD, ¿quiénes son los "3 amigos" (three amigos) que participan en las conversaciones de descubrimiento?',
+          options: [
+            {
+              label: 'El tester, el diseñador UX y el gerente de proyecto',
+              value: 'a',
+            },
+            {
+              label:
+                'La perspectiva de negocio (PO/BA), la de desarrollo y la de testing/QA',
+              value: 'b',
+            },
+            {
+              label: 'El cliente final, el CEO y el equipo de soporte',
+              value: 'c',
+            },
+            {
+              label: 'Tres desarrolladores que revisan el código entre sí',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'b' },
+          explanation:
+            'Los 3 amigos representan tres perspectivas: negocio (qué problema resolver), desarrollo (cómo construirlo) y testing (qué podría salir mal). Juntas producen ejemplos más completos que cualquiera por separado.',
+          points: 4,
+          order_index: 2,
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            '¿Cuáles son las tres fases del ciclo BDD según la documentación de Cucumber?',
+          options: [
+            {
+              label: 'Planificación, ejecución y reporte',
+              value: 'a',
+            },
+            {
+              label: 'Análisis, codificación y despliegue',
+              value: 'b',
+            },
+            {
+              label:
+                'Discovery (descubrir con ejemplos), Formulation (formular en Gherkin) y Automation (automatizar los escenarios)',
+              value: 'c',
+            },
+            {
+              label: 'Red, Green y Refactor',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'c' },
+          explanation:
+            'Primero se descubre el comportamiento conversando con ejemplos (discovery), luego se formulan esos ejemplos como escenarios Gherkin (formulation) y finalmente se automatizan para guiar el desarrollo (automation).',
+          points: 4,
+          order_index: 3,
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt: '¿Cuál es la relación entre BDD y TDD?',
+          options: [
+            {
+              label: 'Son enfoques opuestos: si usás BDD no podés usar TDD',
+              value: 'a',
+            },
+            {
+              label:
+                'BDD evolucionó a partir de TDD: lleva la idea de "primero el test" al nivel del comportamiento de negocio, con un lenguaje que todo el equipo entiende',
+              value: 'b',
+            },
+            {
+              label: 'TDD es la versión moderna de BDD',
+              value: 'c',
+            },
+            {
+              label:
+                'No tienen relación: TDD es para backend y BDD para frontend',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'b' },
+          explanation:
+            'BDD nació como una evolución de TDD (Dan North): en lugar de pensar en "tests" técnicos, se piensa en "comportamientos" descritos en lenguaje de negocio, manteniendo el ciclo de escribir la especificación antes del código.',
+          points: 4,
+          order_index: 4,
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            '¿Qué significa que los escenarios BDD funcionen como "documentación viva" (living documentation)?',
+          options: [
+            {
+              label:
+                'Que se actualizan automáticamente con inteligencia artificial',
+              value: 'a',
+            },
+            {
+              label: 'Que están escritos en una wiki editable por cualquiera',
+              value: 'b',
+            },
+            {
+              label:
+                'Que la documentación se imprime y se archiva al final de cada sprint',
+              value: 'c',
+            },
+            {
+              label:
+                'Que al ser ejecutables contra el sistema, los escenarios no pueden quedar desactualizados sin que la suite falle: describen el comportamiento real',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'd' },
+          explanation:
+            'A diferencia de un documento estático, un escenario automatizado se ejecuta contra el sistema: si el comportamiento cambia y el escenario no, la suite falla. Eso obliga a mantener la especificación sincronizada con la realidad.',
+          points: 4,
+          order_index: 5,
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt: '¿Qué es Gherkin?',
+          options: [
+            {
+              label:
+                'Un lenguaje de programación para escribir step definitions',
+              value: 'a',
+            },
+            {
+              label:
+                'Un lenguaje estructurado de texto plano, legible por negocio, para describir comportamiento mediante escenarios que además pueden automatizarse',
+              value: 'b',
+            },
+            {
+              label: 'Una base de datos donde Cucumber guarda los resultados',
+              value: 'c',
+            },
+            {
+              label: 'Un plugin de Jira para gestionar criterios de aceptación',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'b' },
+          explanation:
+            'Gherkin es la sintaxis que usan Cucumber y herramientas similares: texto plano con keywords (Feature, Scenario, Given/When/Then) que una persona de negocio puede leer y una herramienta puede ejecutar.',
+          points: 4,
+          order_index: 6,
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            '¿Cuál es el principal beneficio de BDD para el rol de QA en un equipo?',
+          options: [
+            {
+              label:
+                'Los criterios de aceptación quedan definidos como ejemplos claros y verificables antes de escribir código, permitiendo detectar ambigüedades temprano (shift-left)',
+              value: 'a',
+            },
+            {
+              label:
+                'QA deja de participar en las reuniones porque todo queda automatizado',
+              value: 'b',
+            },
+            {
+              label: 'Se elimina la necesidad de hacer testing exploratorio',
+              value: 'c',
+            },
+            {
+              label:
+                'Los bugs de producción se corrigen solos al correr la suite',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'a' },
+          explanation:
+            'BDD mueve la detección de defectos hacia la izquierda: al discutir ejemplos concretos antes del desarrollo, QA encuentra ambigüedades y casos borde cuando corregirlos es más barato. El testing exploratorio sigue siendo necesario.',
+          points: 4,
+          order_index: 7,
+        },
+        {
+          question_type: 'true_false',
+          prompt:
+            'BDD es principalmente una herramienta de automatización cuyo objetivo es reemplazar a los testers manuales.',
+          correct_answer: { value: false },
+          explanation:
+            'BDD es una práctica de colaboración y comunicación. La automatización de escenarios es solo una de sus fases, y el criterio de QA (elegir buenos ejemplos, detectar casos borde) es justamente lo que la hace valiosa.',
+          points: 4,
+          order_index: 8,
+        },
+        {
+          question_type: 'true_false',
+          prompt:
+            'En BDD, los ejemplos concretos del comportamiento se conversan y acuerdan entre negocio, desarrollo y QA antes de implementar la funcionalidad.',
+          correct_answer: { value: true },
+          explanation:
+            'Esa es la fase de discovery: los ejemplos se definen en conversación (por ejemplo en sesiones de example mapping) antes del desarrollo, y se convierten en la especificación compartida del equipo.',
+          points: 4,
+          order_index: 9,
+        },
+      ],
+    },
+    {
+      slug: 'nivel-2-sintaxis-gherkin',
+      title: 'Nivel 2: Sintaxis Gherkin',
+      description:
+        'Demostrá que dominás las keywords de Gherkin: Feature, Scenario, Given/When/Then (Dado/Cuando/Entonces), And/But, Background y la localización en español.',
+      order_index: 2,
+      max_score: 32,
+      metadata: {
+        instructions:
+          'Preguntas sobre el rol semántico de cada keyword y la estructura de un archivo .feature, según la referencia oficial de Gherkin.',
+        suggestedMinutes: 11,
+      },
+      questions: [
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            '¿Cuál es el rol del paso Given (Dado) en un escenario Gherkin?',
+          options: [
+            {
+              label: 'Describir la acción principal que realiza el usuario',
+              value: 'a',
+            },
+            {
+              label:
+                'Establecer el contexto o estado inicial del sistema antes de que ocurra la acción',
+              value: 'b',
+            },
+            {
+              label: 'Verificar el resultado final del escenario',
+              value: 'c',
+            },
+            {
+              label: 'Definir los datos de la tabla de ejemplos',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'b' },
+          explanation:
+            'Given/Dado pone al sistema en un estado conocido: precondiciones, datos existentes, sesión iniciada. Es la "foto inicial" sobre la que actúa el escenario.',
+          points: 4,
+          order_index: 1,
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt: '¿Qué representa el paso When (Cuando) en un escenario?',
+          options: [
+            {
+              label: 'Las precondiciones del sistema',
+              value: 'a',
+            },
+            {
+              label: 'El resultado esperado de la prueba',
+              value: 'b',
+            },
+            {
+              label:
+                'La acción o evento que dispara el comportamiento que se está especificando',
+              value: 'c',
+            },
+            {
+              label: 'Un comentario que documenta el escenario',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'c' },
+          explanation:
+            'When/Cuando es el evento bajo prueba: la acción del usuario o del sistema que provoca el comportamiento. Idealmente hay un solo When por escenario, porque se especifica un solo comportamiento.',
+          points: 4,
+          order_index: 2,
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt: '¿Qué expresa el paso Then (Entonces)?',
+          options: [
+            {
+              label:
+                'El resultado esperado y observable que debe verificarse tras la acción',
+              value: 'a',
+            },
+            {
+              label: 'El estado inicial de la base de datos',
+              value: 'b',
+            },
+            {
+              label: 'El tiempo máximo de ejecución del escenario',
+              value: 'c',
+            },
+            {
+              label: 'La configuración del entorno de pruebas',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'a' },
+          explanation:
+            'Then/Entonces declara el resultado esperado: algo observable desde afuera (un mensaje, un estado, una respuesta). Ahí es donde la automatización hace las aserciones.',
+          points: 4,
+          order_index: 3,
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            '¿Para qué sirven las keywords And (Y) y But (Pero) en Gherkin?',
+          options: [
+            {
+              label: 'Para ejecutar pasos en paralelo y acelerar la suite',
+              value: 'a',
+            },
+            {
+              label:
+                'Para marcar pasos opcionales que pueden fallar sin romper el escenario',
+              value: 'b',
+            },
+            {
+              label: 'Para declarar variables que se usan en los Examples',
+              value: 'c',
+            },
+            {
+              label:
+                'Para encadenar pasos adicionales del mismo tipo que el paso anterior (Given/When/Then), mejorando la legibilidad',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'd' },
+          explanation:
+            'And/But heredan el tipo del paso anterior: "Dado... Y..." son dos Given. Evitan repetir la misma keyword y hacen el escenario más natural de leer. Para la herramienta son equivalentes al keyword que continúan.',
+          points: 4,
+          order_index: 4,
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            '¿Qué hace la sección Background (Antecedentes) en un archivo .feature?',
+          options: [
+            {
+              label:
+                'Define pasos comunes que se ejecutan antes de cada escenario de la feature, evitando repetir el mismo contexto',
+              value: 'a',
+            },
+            {
+              label: 'Documenta la historia de usuario sin ejecutarse nunca',
+              value: 'b',
+            },
+            {
+              label:
+                'Agrupa los escenarios que solo corren en el ambiente de staging',
+              value: 'c',
+            },
+            {
+              label: 'Define el color de fondo del reporte HTML',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'a' },
+          explanation:
+            'Background agrupa los Given compartidos por todos los escenarios de la feature y se ejecuta antes de cada uno. Conviene mantenerlo corto: si crece demasiado, los escenarios se vuelven difíciles de entender.',
+          points: 4,
+          order_index: 5,
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            '¿Qué permite la directiva `# language: es` al inicio de un archivo .feature?',
+          options: [
+            {
+              label: 'Traducir automáticamente los reportes al español',
+              value: 'a',
+            },
+            {
+              label:
+                'Escribir las keywords de Gherkin en español: Característica, Escenario, Dado, Cuando, Entonces, Y, Pero',
+              value: 'b',
+            },
+            {
+              label: 'Definir el idioma de la aplicación bajo prueba',
+              value: 'c',
+            },
+            {
+              label: 'Ejecutar los steps con datos localizados en español',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'b' },
+          explanation:
+            'Gherkin soporta más de 70 idiomas. Con `# language: es` el parser acepta las keywords en español, lo que permite que los escenarios se lean naturalmente con el equipo de negocio hispanohablante.',
+          points: 4,
+          order_index: 6,
+        },
+        {
+          question_type: 'true_false',
+          prompt:
+            'Un archivo .feature puede contener varias secciones Feature (Característica) para agrupar funcionalidades relacionadas.',
+          correct_answer: { value: false },
+          explanation:
+            'Cada archivo .feature contiene exactamente una Feature. Si necesitás describir otra funcionalidad, va en otro archivo: eso mantiene la especificación organizada y navegable.',
+          points: 4,
+          order_index: 7,
+        },
+        {
+          question_type: 'true_false',
+          prompt:
+            'Si dentro de un mismo escenario después de un Then aparece otro When, suele ser señal de que el escenario está especificando más de un comportamiento y conviene dividirlo.',
+          correct_answer: { value: true },
+          explanation:
+            'El flujo recomendado es Given → When → Then. Encadenar Then → When → Then indica que hay dos comportamientos en un solo escenario; dividirlo produce especificaciones más claras y fallas más fáciles de diagnosticar.',
+          points: 4,
+          order_index: 8,
+        },
+      ],
+    },
+    {
+      slug: 'nivel-3-escenarios-avanzados',
+      title: 'Nivel 3: Escenarios avanzados y aplicación en testing',
+      description:
+        'Aplicá Gherkin como se usa en proyectos reales: Scenario Outline con Examples, data tables, tags, estilo declarativo vs imperativo, step definitions y escenarios independientes.',
+      order_index: 3,
+      max_score: 32,
+      metadata: {
+        instructions:
+          'Preguntas sobre parametrización, organización de suites y buenas prácticas de escritura, con foco en cómo se conecta Gherkin con la automatización.',
+        suggestedMinutes: 12,
+      },
+      questions: [
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            '¿Para qué sirve un Scenario Outline (Esquema del escenario) junto con su tabla Examples (Ejemplos)?',
+          options: [
+            {
+              label:
+                'Para ejecutar el mismo escenario varias veces con distintos datos, reemplazando placeholders como <email> por cada fila de la tabla',
+              value: 'a',
+            },
+            {
+              label:
+                'Para dibujar el diagrama de flujo del escenario en el reporte',
+              value: 'b',
+            },
+            {
+              label:
+                'Para definir un borrador de escenario que todavía no se ejecuta',
+              value: 'c',
+            },
+            {
+              label: 'Para agrupar escenarios de features distintas',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'a' },
+          explanation:
+            'Scenario Outline parametriza un escenario: los placeholders entre <> se sustituyen con cada fila de Examples, generando una ejecución por fila. Es la forma Gherkin de hacer pruebas data-driven sin duplicar texto.',
+          points: 4,
+          order_index: 1,
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            '¿Cuál es la diferencia entre una data table (tabla de datos) y la tabla Examples de un Scenario Outline?',
+          options: [
+            {
+              label:
+                'Son exactamente lo mismo, solo cambia el nombre según la herramienta',
+              value: 'a',
+            },
+            {
+              label:
+                'La data table pasa datos estructurados a un único paso; Examples genera una ejecución completa del escenario por cada fila',
+              value: 'b',
+            },
+            {
+              label:
+                'Las data tables solo aceptan números y Examples solo texto',
+              value: 'c',
+            },
+            {
+              label: 'Examples se usa en Given y las data tables solo en Then',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'b' },
+          explanation:
+            'Una data table acompaña a un paso concreto (por ejemplo, "Dado los siguientes usuarios:" seguido de una tabla) y llega como argumento al step definition. Examples, en cambio, multiplica la ejecución del escenario entero.',
+          points: 4,
+          order_index: 2,
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            '¿Para qué se usan los tags (como @smoke o @regression) en Gherkin?',
+          options: [
+            {
+              label: 'Para asignar el escenario a un tester específico',
+              value: 'a',
+            },
+            {
+              label:
+                'Para definir la prioridad con la que se corrigen los bugs',
+              value: 'b',
+            },
+            {
+              label:
+                'Para organizar features y escenarios, y filtrar cuáles ejecutar (por ejemplo, correr solo @smoke en cada deploy) o engancharles hooks',
+              value: 'c',
+            },
+            {
+              label: 'Para versionar los archivos .feature en Git',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'c' },
+          explanation:
+            'Los tags permiten seleccionar subconjuntos de la suite en la ejecución (smoke, regresión, WIP) y asociar hooks condicionales. Son clave para integrar Gherkin en pipelines de CI con distintos niveles de profundidad.',
+          points: 4,
+          order_index: 3,
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            '¿Cuál es la diferencia entre el estilo declarativo y el imperativo al escribir escenarios?',
+          options: [
+            {
+              label:
+                'El declarativo describe la intención de negocio ("Cuando el usuario inicia sesión"); el imperativo detalla interacciones de bajo nivel con la UI ("Cuando hace clic en el botón azul") y es considerado un anti-patrón',
+              value: 'a',
+            },
+            {
+              label:
+                'El imperativo es más moderno y reemplazó al declarativo en Gherkin 6',
+              value: 'b',
+            },
+            {
+              label:
+                'El declarativo solo sirve para APIs y el imperativo solo para web',
+              value: 'c',
+            },
+            {
+              label:
+                'No hay diferencia práctica: ambos generan los mismos step definitions',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'a' },
+          explanation:
+            'El estilo declarativo mantiene los escenarios en el nivel del negocio y los hace resistentes a cambios de UI. El imperativo acopla la especificación a detalles de implementación: cualquier rediseño rompe decenas de escenarios.',
+          points: 4,
+          order_index: 4,
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            "Un escenario dice: \"Cuando hago clic en el campo email / Y escribo 'ana@test.com' / Y hago clic en el campo contraseña / Y escribo '1234' / Y hago clic en el botón Ingresar\". ¿Cuál es el principal problema?",
+          options: [
+            {
+              label: 'Le faltan tags para poder ejecutarlo en CI',
+              value: 'a',
+            },
+            {
+              label: 'Usa comillas simples en lugar de dobles para los datos',
+              value: 'b',
+            },
+            {
+              label: 'Tiene más de tres pasos, lo cual es inválido en Gherkin',
+              value: 'c',
+            },
+            {
+              label:
+                'Es imperativo y está acoplado a la UI: describe clics y campos en lugar de la intención ("Cuando inicia sesión con credenciales válidas")',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'd' },
+          explanation:
+            'El escenario describe el "cómo" (clics, campos) en vez del "qué" (iniciar sesión). Un solo paso declarativo comunica la intención, se lee con negocio y sobrevive a los cambios de diseño de la pantalla.',
+          points: 4,
+          order_index: 5,
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            'En Cucumber (o herramientas similares), ¿qué es un step definition?',
+          options: [
+            {
+              label:
+                'Un archivo de configuración que define el orden de ejecución de las features',
+              value: 'a',
+            },
+            {
+              label:
+                'La función de código que se enlaza a un paso Gherkin mediante una expresión, y que ejecuta la acción o aserción correspondiente',
+              value: 'b',
+            },
+            {
+              label: 'El glosario de términos de negocio del proyecto',
+              value: 'c',
+            },
+            {
+              label: 'Un paso especial que solo existe en los reportes',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'b' },
+          explanation:
+            'Cada paso del escenario se matchea (por cucumber expressions o regex) con un step definition: la función que automatiza ese paso. Así el texto de negocio queda conectado con el código que lo verifica.',
+          points: 4,
+          order_index: 6,
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            '¿Por qué cada escenario debe poder ejecutarse de forma independiente de los demás?',
+          options: [
+            {
+              label:
+                'Porque Gherkin no permite más de un escenario por archivo',
+              value: 'a',
+            },
+            {
+              label:
+                'Porque los tags dejan de funcionar si los escenarios comparten estado',
+              value: 'b',
+            },
+            {
+              label:
+                'Si un escenario depende del estado que dejó otro, no se puede ejecutar solo ni en paralelo, y una falla en cadena vuelve el diagnóstico confuso',
+              value: 'c',
+            },
+            {
+              label:
+                'Para que los reportes HTML se generen en orden alfabético',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'c' },
+          explanation:
+            'Los escenarios acoplados son un anti-patrón clásico: impiden filtrar por tags, paralelizar y reintentar, y cuando uno falla arrastra a los siguientes. Cada escenario debe preparar su propio contexto en los Given.',
+          points: 4,
+          order_index: 7,
+        },
+        {
+          question_type: 'true_false',
+          prompt:
+            'Un buen escenario Gherkin debería especificar y validar un solo comportamiento del sistema.',
+          correct_answer: { value: true },
+          explanation:
+            'Un escenario = un comportamiento. Escenarios enfocados fallan por una sola razón, se leen como documentación clara y evitan los mega-flujos frágiles que mezclan varios objetivos de prueba.',
+          points: 4,
+          order_index: 8,
+        },
+      ],
+    },
+  ],
+};

--- a/apps/frontend/src/app/assessments/gherkin-fundamentals/lib/gamification.ts
+++ b/apps/frontend/src/app/assessments/gherkin-fundamentals/lib/gamification.ts
@@ -1,0 +1,15 @@
+import { createAssessmentGamification } from '../../_shared/lib/gamification';
+
+const gamification = createAssessmentGamification({
+  prefix: 'GHERKIN_FUNDAMENTALS',
+  descriptions: {
+    completed: 'Completar el assessment Gherkin Fundamentals',
+    passed: 'Aprobar el assessment Gherkin Fundamentals (score >= 70)',
+    highScore: 'Score sobresaliente en Gherkin Fundamentals (>= 90)',
+  },
+});
+
+export const GHERKIN_FUNDAMENTALS_GAMIFICATION_RULES = gamification.rules;
+
+export const buildGherkinFundamentalsGamificationEvents =
+  gamification.buildEvents;

--- a/apps/frontend/src/app/assessments/gherkin-fundamentals/lib/seed.ts
+++ b/apps/frontend/src/app/assessments/gherkin-fundamentals/lib/seed.ts
@@ -1,0 +1,12 @@
+import { ensureAssessmentSeeded } from '../../_shared/lib/seed';
+import {
+  GHERKIN_FUNDAMENTALS_SEED_VERSION,
+  gherkinFundamentalsDefinition,
+} from '../data/assessment-definition';
+
+export async function ensureGherkinFundamentalsSeeded() {
+  return ensureAssessmentSeeded(
+    gherkinFundamentalsDefinition,
+    GHERKIN_FUNDAMENTALS_SEED_VERSION
+  );
+}

--- a/apps/frontend/src/app/assessments/gherkin-fundamentals/page.tsx
+++ b/apps/frontend/src/app/assessments/gherkin-fundamentals/page.tsx
@@ -1,0 +1,90 @@
+import { Metadata } from 'next';
+import { gherkinFundamentalsDefinition } from './data/assessment-definition';
+import AssessmentWelcome from '../_shared/components/AssessmentWelcome';
+
+export const metadata: Metadata = {
+  title: 'Gherkin y BDD — Fundamentos | AIQUAA',
+  description:
+    'Prueba técnica teórica sobre Gherkin y BDD: fundamentos de Behavior-Driven Development, sintaxis Dado/Cuando/Entonces y escenarios avanzados aplicados al testing.',
+  keywords: [
+    'Gherkin',
+    'BDD',
+    'Behavior-Driven Development',
+    'Cucumber',
+    'Given When Then',
+    'Dado Cuando Entonces',
+    'Scenario Outline',
+    'criterios de aceptación',
+    'QA',
+    'testing',
+    'AIQUAA',
+    'evaluación técnica',
+  ],
+  openGraph: {
+    title: 'Gherkin y BDD — Fundamentos | AIQUAA',
+    description:
+      'Prueba técnica teórica sobre Gherkin y BDD: fundamentos, sintaxis Dado/Cuando/Entonces y escenarios avanzados aplicados al testing.',
+    url: 'https://aiquaa.com/assessments/gherkin-fundamentals',
+    siteName: 'AIQUAA',
+    type: 'website',
+    locale: 'es_PY',
+    images: [
+      {
+        url: '/api/og?title=Gherkin%20y%20BDD%20-%20Fundamentos&subtitle=BDD%20y%20Gherkin%20para%20QA&section=Assessments',
+        width: 1200,
+        height: 630,
+        alt: 'Gherkin y BDD Fundamentos - AIQUAA',
+      },
+    ],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Gherkin y BDD — Fundamentos | AIQUAA',
+    description:
+      'Prueba técnica sobre BDD y la sintaxis Gherkin aplicada al testing.',
+    images: [
+      '/api/og?title=Gherkin%20y%20BDD%20-%20Fundamentos&subtitle=BDD%20y%20Gherkin&section=Assessments',
+    ],
+    creator: '@stevenayal',
+  },
+  alternates: {
+    canonical: 'https://aiquaa.com/assessments/gherkin-fundamentals',
+  },
+};
+
+export default function GherkinFundamentalsPage() {
+  const overview = {
+    assessment: {
+      id: 'static-gherkin-fundamentals',
+      slug: gherkinFundamentalsDefinition.slug,
+      title: gherkinFundamentalsDefinition.title,
+      description: gherkinFundamentalsDefinition.description,
+      level: gherkinFundamentalsDefinition.level,
+      type: gherkinFundamentalsDefinition.type,
+      duration_minutes: gherkinFundamentalsDefinition.duration_minutes,
+      total_score: gherkinFundamentalsDefinition.total_score,
+      is_active: gherkinFundamentalsDefinition.is_active,
+      metadata: gherkinFundamentalsDefinition.metadata,
+    },
+    sections: gherkinFundamentalsDefinition.sections.map((section, index) => ({
+      id: `static-section-${index + 1}`,
+      assessment_id: 'static-gherkin-fundamentals',
+      slug: section.slug,
+      title: section.title,
+      description: section.description,
+      order_index: section.order_index,
+      max_score: section.max_score,
+      metadata: section.metadata,
+    })),
+  };
+
+  return (
+    <AssessmentWelcome
+      overview={overview}
+      startHref="/assessments/gherkin-fundamentals/start"
+      evaluatesCopy="Qué es BDD, los 3 amigos, discovery/formulation/automation y documentación viva; sintaxis Gherkin: Dado/Cuando/Entonces, And/But, Background y keywords en español; Scenario Outline, data tables, tags, estilo declarativo vs imperativo y step definitions."
+      scoringCopy="Automático en los 3 niveles: selección múltiple y verdadero/falso."
+      resultCopy="Score total, score por nivel, fortalezas, debilidades y temas a reforzar."
+    />
+  );
+}

--- a/apps/frontend/src/app/assessments/gherkin-fundamentals/result/page.tsx
+++ b/apps/frontend/src/app/assessments/gherkin-fundamentals/result/page.tsx
@@ -1,0 +1,19 @@
+import { Suspense } from 'react';
+import AssessmentResultClient from '../../_shared/components/AssessmentResultClient';
+
+export default function GherkinFundamentalsResultPage() {
+  return (
+    <Suspense
+      fallback={
+        <div className="min-h-screen flex items-center justify-center bg-slate-950">
+          <div className="h-10 w-10 animate-spin rounded-full border-t-2 border-cyan-400" />
+        </div>
+      }
+    >
+      <AssessmentResultClient
+        startHref="/assessments/gherkin-fundamentals/start"
+        fallbackRecommendation="Repasá la referencia oficial de Gherkin y la guía de BDD de Cucumber: keywords Dado/Cuando/Entonces, Background, Scenario Outline y el estilo declarativo."
+      />
+    </Suspense>
+  );
+}

--- a/apps/frontend/src/app/assessments/gherkin-fundamentals/section/[sectionId]/page.tsx
+++ b/apps/frontend/src/app/assessments/gherkin-fundamentals/section/[sectionId]/page.tsx
@@ -1,0 +1,9 @@
+'use client';
+
+import AssessmentSectionScreen from '../../../_shared/components/AssessmentSectionScreen';
+
+export default function GherkinFundamentalsSectionPage() {
+  return (
+    <AssessmentSectionScreen basePath="/assessments/gherkin-fundamentals" />
+  );
+}

--- a/apps/frontend/src/app/assessments/gherkin-fundamentals/start/page.tsx
+++ b/apps/frontend/src/app/assessments/gherkin-fundamentals/start/page.tsx
@@ -1,0 +1,133 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { useTheme } from '@/contexts/ThemeContext';
+import { startAssessmentAttemptAction } from '@/actions/assessments';
+import ProcessCodeInput from '@/components/labs/ProcessCodeInput';
+import { GHERKIN_FUNDAMENTALS_SLUG } from '../data/assessment-definition';
+
+export default function StartGherkinFundamentalsPage() {
+  const router = useRouter();
+  const { isDarkMode } = useTheme();
+  const [processCode, setProcessCode] = useState('');
+  const [error, setError] = useState('');
+  const [isStarting, setIsStarting] = useState(false);
+
+  // Pre-fill desde ?code= (links de invitaciones/procesos de empresa)
+  useEffect(() => {
+    const codeParam = new URLSearchParams(window.location.search).get('code');
+    if (codeParam) setProcessCode(codeParam);
+  }, []);
+
+  async function handleStart() {
+    setError('');
+    setIsStarting(true);
+
+    try {
+      const result = await startAssessmentAttemptAction({
+        slug: GHERKIN_FUNDAMENTALS_SLUG,
+        processCode,
+      });
+
+      if ('error' in result) {
+        setIsStarting(false);
+        setError(result.error);
+        return;
+      }
+
+      const { attempt, sectionSlug } = result;
+
+      if (!sectionSlug) {
+        setIsStarting(false);
+        setError('No se encontró la primera sección del assessment.');
+        return;
+      }
+
+      setIsStarting(false);
+      router.push(
+        `/assessments/gherkin-fundamentals/section/${sectionSlug}?attempt=${attempt.id}`
+      );
+    } catch (startError) {
+      setIsStarting(false);
+      setError(
+        startError instanceof Error
+          ? startError.message
+          : 'No se pudo iniciar el assessment.'
+      );
+    }
+  }
+
+  return (
+    <div
+      className={`min-h-screen px-4 py-12 ${
+        isDarkMode ? 'bg-slate-950 text-white' : 'bg-slate-50 text-slate-900'
+      }`}
+    >
+      <div className="mx-auto max-w-3xl rounded-3xl border border-slate-800 bg-slate-900/80 p-8 text-slate-50 shadow-2xl shadow-cyan-950/20">
+        <p className="text-sm font-semibold uppercase tracking-[0.18em] text-cyan-200">
+          Preparación del intento
+        </p>
+        <h1 className="mt-3 text-3xl font-bold">Gherkin y BDD — Fundamentos</h1>
+        <p className="mt-3 text-slate-300">
+          Vas a completar 3 niveles teóricos con autosave, scoring por sección y
+          resultado final consolidado.
+        </p>
+
+        <div className="mt-8 grid gap-4 rounded-2xl border border-slate-800 bg-slate-950/70 p-5 md:grid-cols-3">
+          <div>
+            <p className="text-xs uppercase tracking-[0.18em] text-slate-400">
+              Duración sugerida
+            </p>
+            <p className="mt-2 text-lg font-semibold">~35 minutos</p>
+          </div>
+          <div>
+            <p className="text-xs uppercase tracking-[0.18em] text-slate-400">
+              Modalidad
+            </p>
+            <p className="mt-2 text-lg font-semibold">Conceptual</p>
+          </div>
+          <div>
+            <p className="text-xs uppercase tracking-[0.18em] text-slate-400">
+              Resultado
+            </p>
+            <p className="mt-2 text-lg font-semibold">Score total sobre 100</p>
+          </div>
+        </div>
+
+        <div className="mt-8">
+          <ProcessCodeInput
+            value={processCode}
+            onChange={setProcessCode}
+            onNormalizedCode={setProcessCode}
+            autoValidate
+          />
+        </div>
+
+        {error ? (
+          <div className="mt-6 rounded-2xl border border-red-500/30 bg-red-500/10 px-4 py-3 text-sm text-red-200">
+            {error}
+          </div>
+        ) : null}
+
+        <div className="mt-8 flex flex-col gap-3 sm:flex-row">
+          <button
+            type="button"
+            onClick={handleStart}
+            disabled={isStarting}
+            className="inline-flex items-center justify-center rounded-2xl bg-cyan-400 px-5 py-3 text-sm font-semibold text-slate-950 transition hover:bg-cyan-300 disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {isStarting ? 'Preparando intento...' : 'Iniciar o reanudar'}
+          </button>
+          <button
+            type="button"
+            onClick={() => router.push('/assessments/gherkin-fundamentals')}
+            className="inline-flex items-center justify-center rounded-2xl border border-slate-700 px-5 py-3 text-sm font-semibold text-slate-200 transition hover:bg-slate-800"
+          >
+            Volver al overview
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/src/app/assessments/page.tsx
+++ b/apps/frontend/src/app/assessments/page.tsx
@@ -3,6 +3,7 @@ import { apiDeveloperFundamentalsDefinition } from './api-developer-fundamentals
 import { apiTestingFundamentalsDefinition } from './api-testing-fundamentals/data/assessment-definition';
 import { databaseFundamentalsDefinition } from './database-fundamentals/data/assessment-definition';
 import { databasePracticeDefinition } from './database-practice/data/assessment-definition';
+import { gherkinFundamentalsDefinition } from './gherkin-fundamentals/data/assessment-definition';
 import { infrastructureFundamentalsDefinition } from './infrastructure-fundamentals/data/assessment-definition';
 import { playwrightFundamentalsDefinition } from './playwright-fundamentals/data/assessment-definition';
 
@@ -43,6 +44,13 @@ export default function AssessmentsIndexPage() {
       badgeColor: 'text-amber-300',
       accentColor: 'text-fuchsia-200',
       buttonClass: 'bg-fuchsia-500 hover:bg-fuchsia-400',
+    },
+    {
+      definition: gherkinFundamentalsDefinition,
+      badge: 'Examen teórico · Auto-corregido · BDD',
+      badgeColor: 'text-amber-300',
+      accentColor: 'text-lime-200',
+      buttonClass: 'bg-lime-500 hover:bg-lime-400',
     },
   ];
 

--- a/apps/frontend/src/app/dashboard/page.tsx
+++ b/apps/frontend/src/app/dashboard/page.tsx
@@ -84,6 +84,7 @@ export default function DashboardPage() {
     'infrastructure-fundamentals',
     'api-developer-fundamentals',
     'playwright-practico',
+    'gherkin-fundamentals',
   ];
   const recommended = allTypes.find((t) => !passedTypes.has(t)) ?? null;
   const allPassed = allTypes.every((t) => passedTypes.has(t));

--- a/apps/frontend/src/app/invitaciones/[token]/page.tsx
+++ b/apps/frontend/src/app/invitaciones/[token]/page.tsx
@@ -15,6 +15,7 @@ const EXAM_LABELS: Record<string, string> = {
   'database-practice': 'Bases de Datos — Práctica SQL',
   'infrastructure-fundamentals': 'Infraestructura — Fundamentos',
   'api-developer-fundamentals': 'APIs para Desarrolladores — Fundamentos',
+  'gherkin-fundamentals': 'Gherkin y BDD — Fundamentos',
 };
 
 type Props = { params: Promise<{ token: string }> };

--- a/apps/frontend/src/app/ranking/page.tsx
+++ b/apps/frontend/src/app/ranking/page.tsx
@@ -60,7 +60,8 @@ type ExamSlug =
   | 'infrastructure-fundamentals'
   | 'api-developer-fundamentals'
   | 'playwright-fundamentals'
-  | 'playwright-practico';
+  | 'playwright-practico'
+  | 'gherkin-fundamentals';
 
 const EXAM_SLUGS: ExamSlug[] = [
   'git',
@@ -75,6 +76,7 @@ const EXAM_SLUGS: ExamSlug[] = [
   'api-developer-fundamentals',
   'playwright-fundamentals',
   'playwright-practico',
+  'gherkin-fundamentals',
 ];
 
 interface Category {
@@ -152,6 +154,13 @@ const CATEGORIES: Category[] = [
     practico: 'playwright-practico',
   },
   {
+    key: 'bdd',
+    label: 'Gherkin y BDD',
+    emoji: '🥒',
+    color: 'from-lime-500 to-green-600',
+    teorico: 'gherkin-fundamentals',
+  },
+  {
     key: 'comunidad',
     label: 'Comunidad',
     emoji: '🚀',
@@ -175,6 +184,7 @@ const EXAM_TAB_URLS: Record<string, string> = {
   'api-developer-fundamentals': '/assessments/api-developer-fundamentals',
   'playwright-fundamentals': '/assessments/playwright-fundamentals',
   'playwright-practico': '/labs/playwright-practico',
+  'gherkin-fundamentals': '/assessments/gherkin-fundamentals',
 };
 
 const MEDAL = ['🥇', '🥈', '🥉'];
@@ -1044,6 +1054,7 @@ export default function RankingPage() {
     'database-practice': [],
     'infrastructure-fundamentals': [],
     'api-developer-fundamentals': [],
+    'gherkin-fundamentals': [],
   });
   const [examLoading, setExamLoading] = useState<Record<string, boolean>>({
     git: true,
@@ -1056,6 +1067,7 @@ export default function RankingPage() {
     'database-practice': true,
     'infrastructure-fundamentals': true,
     'api-developer-fundamentals': true,
+    'gherkin-fundamentals': true,
   });
   const [showWelcome, setShowWelcome] = useState(false);
 

--- a/apps/frontend/src/components/HomePromoCarousel.tsx
+++ b/apps/frontend/src/components/HomePromoCarousel.tsx
@@ -7,6 +7,7 @@ import { apiDeveloperFundamentalsDefinition } from '@/app/assessments/api-develo
 import { apiTestingFundamentalsDefinition } from '@/app/assessments/api-testing-fundamentals/data/assessment-definition';
 import { databaseFundamentalsDefinition } from '@/app/assessments/database-fundamentals/data/assessment-definition';
 import { databasePracticeDefinition } from '@/app/assessments/database-practice/data/assessment-definition';
+import { gherkinFundamentalsDefinition } from '@/app/assessments/gherkin-fundamentals/data/assessment-definition';
 import { infrastructureFundamentalsDefinition } from '@/app/assessments/infrastructure-fundamentals/data/assessment-definition';
 import LineIcon, { LineIconName } from '@/components/icons/LineIcon';
 
@@ -89,6 +90,11 @@ const SLIDES: PromoSlide[] = [
     apiDeveloperFundamentalsDefinition,
     'Fundamentos de APIs REST pensados para quien recién arranca a programar.',
     'from-indigo-500 to-violet-600'
+  ),
+  assessmentSlide(
+    gherkinFundamentalsDefinition,
+    'BDD y Gherkin: de Dado/Cuando/Entonces a escenarios avanzados.',
+    'from-lime-500 to-green-600'
   ),
   {
     id: 'api-banking',

--- a/apps/frontend/src/lib/exams.ts
+++ b/apps/frontend/src/lib/exams.ts
@@ -15,7 +15,8 @@ export type ExamType =
   | 'infrastructure-fundamentals'
   | 'api-developer-fundamentals'
   | 'playwright-practico'
-  | 'playwright-fundamentals';
+  | 'playwright-fundamentals'
+  | 'gherkin-fundamentals';
 
 export interface ExamMeta {
   emoji: string;
@@ -81,6 +82,11 @@ export const EXAM_META: Record<ExamType, ExamMeta> = {
     label: 'Playwright — Fundamentos',
     href: '/assessments/playwright-fundamentals',
   },
+  'gherkin-fundamentals': {
+    emoji: '🥒',
+    label: 'Gherkin y BDD — Fundamentos',
+    href: '/assessments/gherkin-fundamentals',
+  },
 };
 
 export const EXAM_TYPES = Object.keys(EXAM_META) as ExamType[];
@@ -96,6 +102,7 @@ export const POINTS_BASED_TYPES = new Set<ExamType>([
   'api-developer-fundamentals',
   'playwright-practico',
   'playwright-fundamentals',
+  'gherkin-fundamentals',
 ]);
 
 export interface ExamScoreFields {

--- a/apps/frontend/src/lib/labsCatalog.ts
+++ b/apps/frontend/src/lib/labsCatalog.ts
@@ -81,6 +81,17 @@ export const toolCategories: LabCategory[] = [
         implementedDate: 'Jul 2026',
       },
       {
+        id: 'gherkin-fundamentals',
+        name: 'Gherkin y BDD — Fundamentos',
+        description:
+          'Prueba técnica teórica sobre BDD (3 amigos, discovery, documentación viva), sintaxis Gherkin Dado/Cuando/Entonces y escenarios avanzados con Scenario Outline y tags — auto-corregido, 100 pts',
+        icon: '🥒',
+        color: 'from-lime-500 to-green-600',
+        href: '/assessments/gherkin-fundamentals',
+        featured: true,
+        implementedDate: 'Jul 2026',
+      },
+      {
         id: 'performance',
         name: 'Examen de Performance Testing',
         description:

--- a/apps/frontend/src/lib/ranking-achievements.ts
+++ b/apps/frontend/src/lib/ranking-achievements.ts
@@ -50,6 +50,7 @@ const RANKED_EXAM_TYPES: ExamType[] = [
   'api-developer-fundamentals',
   'playwright-practico',
   'playwright-fundamentals',
+  'gherkin-fundamentals',
 ];
 
 const ASSESSMENT_RANKING_TYPES = new Set<ExamType>([
@@ -58,6 +59,7 @@ const ASSESSMENT_RANKING_TYPES = new Set<ExamType>([
   'infrastructure-fundamentals',
   'api-developer-fundamentals',
   'playwright-fundamentals',
+  'gherkin-fundamentals',
 ]);
 
 function isMissingAchievementsTableError(error: { code?: string } | null) {

--- a/supabase/migrations/20260717_000000_gherkin_fundamentals.sql
+++ b/supabase/migrations/20260717_000000_gherkin_fundamentals.sql
@@ -1,0 +1,45 @@
+-- Habilita el assessment teórico "Gherkin y BDD — Fundamentos" en el
+-- ecosistema de resultados/ranking:
+-- 1. Amplía el CHECK de exam_results.exam_type con gherkin-fundamentals
+--    (sin esto los inserts fallan en silencio).
+-- 2. Reglas XP para el assessment (espejo de playwright-fundamentals).
+
+-- 1. exam_results.exam_type
+ALTER TABLE public.exam_results
+  DROP CONSTRAINT IF EXISTS exam_results_exam_type_check;
+
+ALTER TABLE public.exam_results
+  ADD CONSTRAINT exam_results_exam_type_check
+  CHECK (
+    exam_type = ANY (
+      ARRAY[
+        'git'::text,
+        'git-practico'::text,
+        'istqb'::text,
+        'performance'::text,
+        'test-app'::text,
+        'api-testing-fundamentals'::text,
+        'api-banking'::text,
+        'database-fundamentals'::text,
+        'database-practice'::text,
+        'infrastructure-fundamentals'::text,
+        'api-developer-fundamentals'::text,
+        'playwright-practico'::text,
+        'playwright-fundamentals'::text,
+        'gherkin-fundamentals'::text
+      ]
+    )
+  );
+
+-- 2. Reglas XP para el assessment Gherkin Fundamentals
+INSERT INTO public.xp_rules (event_type, xp_amount, description, daily_limit, is_active)
+VALUES
+  ('GHERKIN_FUNDAMENTALS_COMPLETED', 70, 'Completar el assessment Gherkin Fundamentals', 3, true),
+  ('GHERKIN_FUNDAMENTALS_PASSED', 120, 'Aprobar el assessment Gherkin Fundamentals (score >= 70)', 3, true),
+  ('GHERKIN_FUNDAMENTALS_HIGH_SCORE', 160, 'Score sobresaliente en Gherkin Fundamentals (>= 90)', 3, true)
+ON CONFLICT (event_type) DO UPDATE SET
+  xp_amount = EXCLUDED.xp_amount,
+  description = EXCLUDED.description,
+  daily_limit = EXCLUDED.daily_limit,
+  is_active = EXCLUDED.is_active,
+  updated_at = now();


### PR DESCRIPTION
## Summary
- Agrega un nuevo assessment teórico auto-corregido `/assessments/gherkin-fundamentals` (100 pts, 3 niveles, 25 preguntas de opción múltiple / verdadero-falso) sobre fundamentos de BDD, sintaxis Gherkin (Dado/Cuando/Entonces, Background) y escenarios avanzados (Scenario Outline, tags, estilo declarativo vs imperativo).
- Sigue el patrón existente de `infrastructure-fundamentals` / `playwright-fundamentals`: registrado en `assessments/_shared/registry.ts` con seed idempotente, scoring automático y eventos de gamificación.
- Wiring completo en el resto de la app: tipos de examen (`exams.ts`, `actions/exams.ts`), nueva categoría "Gherkin y BDD" en `/ranking` (top habilitado), card en `/assessments`, entrada en el catálogo de Labs, slide en el carrusel del home, dashboard, invitaciones y lista de assessments asignables por procesos de empresa.
- Nueva migración Supabase que amplía el `CHECK` de `exam_results.exam_type` y crea las reglas XP `GHERKIN_FUNDAMENTALS_COMPLETED/PASSED/HIGH_SCORE`.

## Test plan
- [x] `pnpm --filter @aiquaa/frontend test` — pasan los 13 archivos de tests de `assessments` (58 tests), incluyendo el nuevo `gherkin-fundamentals/__tests__/definition.test.ts` (consistencia de puntos/answer keys + entrada de registry).
- [x] `pnpm --filter @aiquaa/frontend type-check` sin errores.
- [x] `eslint` sin errores en los archivos nuevos/modificados.
- [ ] Aplicar la migración `20260717_000000_gherkin_fundamentals.sql` en el proyecto Supabase (no se aplicó en esta sesión) y validar el flujo end-to-end en dev: `/assessments` → `gherkin-fundamentals` → completar 3 niveles → `/result` con score, XP y aparición en `/ranking`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WGkxCk8R2C5RyvMmkZmPQD

---
_Generated by [Claude Code](https://claude.ai/code/session_01WGkxCk8R2C5RyvMmkZmPQD)_