### PR TITLE
feat(assessments): 5 pruebas tecnicas de bootcamp .NET/DevOps (rubrica proyecto final)

### DIFF
--- a/apps/frontend/src/actions/exams.ts
+++ b/apps/frontend/src/actions/exams.ts
@@ -23,6 +23,7 @@ interface SaveExamResultPayload {
     | 'infrastructure-fundamentals'
     | 'api-developer-fundamentals'
     | 'api-dotnet-fundamentals'
+    | 'docker-fundamentals'
     | 'playwright-practico'
     | 'playwright-fundamentals'
     | 'gherkin-fundamentals';

--- a/apps/frontend/src/actions/exams.ts
+++ b/apps/frontend/src/actions/exams.ts
@@ -24,6 +24,7 @@ interface SaveExamResultPayload {
     | 'api-developer-fundamentals'
     | 'api-dotnet-fundamentals'
     | 'docker-fundamentals'
+    | 'kubernetes-helm-fundamentals'
     | 'playwright-practico'
     | 'playwright-fundamentals'
     | 'gherkin-fundamentals';

--- a/apps/frontend/src/actions/exams.ts
+++ b/apps/frontend/src/actions/exams.ts
@@ -22,6 +22,7 @@ interface SaveExamResultPayload {
     | 'database-practice'
     | 'infrastructure-fundamentals'
     | 'api-developer-fundamentals'
+    | 'api-dotnet-fundamentals'
     | 'playwright-practico'
     | 'playwright-fundamentals'
     | 'gherkin-fundamentals';

--- a/apps/frontend/src/actions/exams.ts
+++ b/apps/frontend/src/actions/exams.ts
@@ -25,6 +25,7 @@ interface SaveExamResultPayload {
     | 'api-dotnet-fundamentals'
     | 'docker-fundamentals'
     | 'kubernetes-helm-fundamentals'
+    | 'observability-fundamentals'
     | 'playwright-practico'
     | 'playwright-fundamentals'
     | 'gherkin-fundamentals';

--- a/apps/frontend/src/actions/exams.ts
+++ b/apps/frontend/src/actions/exams.ts
@@ -26,6 +26,7 @@ interface SaveExamResultPayload {
     | 'docker-fundamentals'
     | 'kubernetes-helm-fundamentals'
     | 'observability-fundamentals'
+    | 'cicd-fundamentals'
     | 'playwright-practico'
     | 'playwright-fundamentals'
     | 'gherkin-fundamentals';

--- a/apps/frontend/src/app/assessments/_shared/registry.ts
+++ b/apps/frontend/src/app/assessments/_shared/registry.ts
@@ -80,6 +80,15 @@ import {
 } from '../kubernetes-helm-fundamentals/lib/gamification';
 import { ensureKubernetesHelmFundamentalsSeeded } from '../kubernetes-helm-fundamentals/lib/seed';
 import {
+  OBSERVABILITY_FUNDAMENTALS_SEED_VERSION,
+  OBSERVABILITY_FUNDAMENTALS_SLUG,
+} from '../observability-fundamentals/data/assessment-definition';
+import {
+  OBSERVABILITY_FUNDAMENTALS_GAMIFICATION_RULES,
+  buildObservabilityFundamentalsGamificationEvents,
+} from '../observability-fundamentals/lib/gamification';
+import { ensureObservabilityFundamentalsSeeded } from '../observability-fundamentals/lib/seed';
+import {
   PLAYWRIGHT_FUNDAMENTALS_SEED_VERSION,
   PLAYWRIGHT_FUNDAMENTALS_SLUG,
 } from '../playwright-fundamentals/data/assessment-definition';
@@ -103,6 +112,7 @@ export type AssessmentExamType =
   | 'gherkin-fundamentals'
   | 'infrastructure-fundamentals'
   | 'kubernetes-helm-fundamentals'
+  | 'observability-fundamentals'
   | 'playwright-fundamentals';
 
 export interface AssessmentGamificationEventInput {
@@ -209,6 +219,15 @@ export const ASSESSMENT_REGISTRY: Record<string, AssessmentRegistryEntry> = {
     gamificationSource: 'KUBERNETES_HELM_FUNDAMENTALS',
     gamificationRules: KUBERNETES_HELM_FUNDAMENTALS_GAMIFICATION_RULES,
     buildGamificationEvents: buildKubernetesHelmFundamentalsGamificationEvents,
+  },
+  [OBSERVABILITY_FUNDAMENTALS_SLUG]: {
+    slug: OBSERVABILITY_FUNDAMENTALS_SLUG,
+    seedVersion: OBSERVABILITY_FUNDAMENTALS_SEED_VERSION,
+    ensureSeeded: ensureObservabilityFundamentalsSeeded,
+    examType: 'observability-fundamentals',
+    gamificationSource: 'OBSERVABILITY_FUNDAMENTALS',
+    gamificationRules: OBSERVABILITY_FUNDAMENTALS_GAMIFICATION_RULES,
+    buildGamificationEvents: buildObservabilityFundamentalsGamificationEvents,
   },
   [PLAYWRIGHT_FUNDAMENTALS_SLUG]: {
     slug: PLAYWRIGHT_FUNDAMENTALS_SLUG,

--- a/apps/frontend/src/app/assessments/_shared/registry.ts
+++ b/apps/frontend/src/app/assessments/_shared/registry.ts
@@ -8,6 +8,15 @@ import {
 } from '../api-developer-fundamentals/lib/gamification';
 import { ensureApiDeveloperFundamentalsSeeded } from '../api-developer-fundamentals/lib/seed';
 import {
+  API_DOTNET_FUNDAMENTALS_SEED_VERSION,
+  API_DOTNET_FUNDAMENTALS_SLUG,
+} from '../api-dotnet-fundamentals/data/assessment-definition';
+import {
+  API_DOTNET_FUNDAMENTALS_GAMIFICATION_RULES,
+  buildApiDotnetFundamentalsGamificationEvents,
+} from '../api-dotnet-fundamentals/lib/gamification';
+import { ensureApiDotnetFundamentalsSeeded } from '../api-dotnet-fundamentals/lib/seed';
+import {
   API_TESTING_FUNDAMENTALS_SLUG,
   API_TESTING_SEED_VERSION,
 } from '../api-testing-fundamentals/data/assessment-definition';
@@ -68,6 +77,7 @@ import type {
 
 export type AssessmentExamType =
   | 'api-developer-fundamentals'
+  | 'api-dotnet-fundamentals'
   | 'api-testing-fundamentals'
   | 'database-fundamentals'
   | 'database-practice'
@@ -107,6 +117,15 @@ export const ASSESSMENT_REGISTRY: Record<string, AssessmentRegistryEntry> = {
     gamificationSource: 'API_DEVELOPER_FUNDAMENTALS',
     gamificationRules: API_DEVELOPER_FUNDAMENTALS_GAMIFICATION_RULES,
     buildGamificationEvents: buildApiDeveloperFundamentalsGamificationEvents,
+  },
+  [API_DOTNET_FUNDAMENTALS_SLUG]: {
+    slug: API_DOTNET_FUNDAMENTALS_SLUG,
+    seedVersion: API_DOTNET_FUNDAMENTALS_SEED_VERSION,
+    ensureSeeded: ensureApiDotnetFundamentalsSeeded,
+    examType: 'api-dotnet-fundamentals',
+    gamificationSource: 'API_DOTNET_FUNDAMENTALS',
+    gamificationRules: API_DOTNET_FUNDAMENTALS_GAMIFICATION_RULES,
+    buildGamificationEvents: buildApiDotnetFundamentalsGamificationEvents,
   },
   [API_TESTING_FUNDAMENTALS_SLUG]: {
     slug: API_TESTING_FUNDAMENTALS_SLUG,

--- a/apps/frontend/src/app/assessments/_shared/registry.ts
+++ b/apps/frontend/src/app/assessments/_shared/registry.ts
@@ -71,6 +71,15 @@ import {
 } from '../infrastructure-fundamentals/lib/gamification';
 import { ensureInfrastructureFundamentalsSeeded } from '../infrastructure-fundamentals/lib/seed';
 import {
+  KUBERNETES_HELM_FUNDAMENTALS_SEED_VERSION,
+  KUBERNETES_HELM_FUNDAMENTALS_SLUG,
+} from '../kubernetes-helm-fundamentals/data/assessment-definition';
+import {
+  KUBERNETES_HELM_FUNDAMENTALS_GAMIFICATION_RULES,
+  buildKubernetesHelmFundamentalsGamificationEvents,
+} from '../kubernetes-helm-fundamentals/lib/gamification';
+import { ensureKubernetesHelmFundamentalsSeeded } from '../kubernetes-helm-fundamentals/lib/seed';
+import {
   PLAYWRIGHT_FUNDAMENTALS_SEED_VERSION,
   PLAYWRIGHT_FUNDAMENTALS_SLUG,
 } from '../playwright-fundamentals/data/assessment-definition';
@@ -93,6 +102,7 @@ export type AssessmentExamType =
   | 'database-practice'
   | 'gherkin-fundamentals'
   | 'infrastructure-fundamentals'
+  | 'kubernetes-helm-fundamentals'
   | 'playwright-fundamentals';
 
 export interface AssessmentGamificationEventInput {
@@ -190,6 +200,15 @@ export const ASSESSMENT_REGISTRY: Record<string, AssessmentRegistryEntry> = {
     gamificationSource: 'INFRASTRUCTURE_FUNDAMENTALS',
     gamificationRules: INFRASTRUCTURE_FUNDAMENTALS_GAMIFICATION_RULES,
     buildGamificationEvents: buildInfrastructureFundamentalsGamificationEvents,
+  },
+  [KUBERNETES_HELM_FUNDAMENTALS_SLUG]: {
+    slug: KUBERNETES_HELM_FUNDAMENTALS_SLUG,
+    seedVersion: KUBERNETES_HELM_FUNDAMENTALS_SEED_VERSION,
+    ensureSeeded: ensureKubernetesHelmFundamentalsSeeded,
+    examType: 'kubernetes-helm-fundamentals',
+    gamificationSource: 'KUBERNETES_HELM_FUNDAMENTALS',
+    gamificationRules: KUBERNETES_HELM_FUNDAMENTALS_GAMIFICATION_RULES,
+    buildGamificationEvents: buildKubernetesHelmFundamentalsGamificationEvents,
   },
   [PLAYWRIGHT_FUNDAMENTALS_SLUG]: {
     slug: PLAYWRIGHT_FUNDAMENTALS_SLUG,

--- a/apps/frontend/src/app/assessments/_shared/registry.ts
+++ b/apps/frontend/src/app/assessments/_shared/registry.ts
@@ -12,6 +12,15 @@ import {
   API_DOTNET_FUNDAMENTALS_SLUG,
 } from '../api-dotnet-fundamentals/data/assessment-definition';
 import {
+  CICD_FUNDAMENTALS_SEED_VERSION,
+  CICD_FUNDAMENTALS_SLUG,
+} from '../cicd-fundamentals/data/assessment-definition';
+import {
+  CICD_FUNDAMENTALS_GAMIFICATION_RULES,
+  buildCicdFundamentalsGamificationEvents,
+} from '../cicd-fundamentals/lib/gamification';
+import { ensureCicdFundamentalsSeeded } from '../cicd-fundamentals/lib/seed';
+import {
   API_DOTNET_FUNDAMENTALS_GAMIFICATION_RULES,
   buildApiDotnetFundamentalsGamificationEvents,
 } from '../api-dotnet-fundamentals/lib/gamification';
@@ -106,6 +115,7 @@ export type AssessmentExamType =
   | 'api-developer-fundamentals'
   | 'api-dotnet-fundamentals'
   | 'api-testing-fundamentals'
+  | 'cicd-fundamentals'
   | 'docker-fundamentals'
   | 'database-fundamentals'
   | 'database-practice'
@@ -156,6 +166,15 @@ export const ASSESSMENT_REGISTRY: Record<string, AssessmentRegistryEntry> = {
     gamificationSource: 'API_DOTNET_FUNDAMENTALS',
     gamificationRules: API_DOTNET_FUNDAMENTALS_GAMIFICATION_RULES,
     buildGamificationEvents: buildApiDotnetFundamentalsGamificationEvents,
+  },
+  [CICD_FUNDAMENTALS_SLUG]: {
+    slug: CICD_FUNDAMENTALS_SLUG,
+    seedVersion: CICD_FUNDAMENTALS_SEED_VERSION,
+    ensureSeeded: ensureCicdFundamentalsSeeded,
+    examType: 'cicd-fundamentals',
+    gamificationSource: 'CICD_FUNDAMENTALS',
+    gamificationRules: CICD_FUNDAMENTALS_GAMIFICATION_RULES,
+    buildGamificationEvents: buildCicdFundamentalsGamificationEvents,
   },
   [API_TESTING_FUNDAMENTALS_SLUG]: {
     slug: API_TESTING_FUNDAMENTALS_SLUG,

--- a/apps/frontend/src/app/assessments/_shared/registry.ts
+++ b/apps/frontend/src/app/assessments/_shared/registry.ts
@@ -26,6 +26,15 @@ import {
 } from '../api-testing-fundamentals/lib/gamification';
 import { ensureApiTestingFundamentalsSeeded } from '../api-testing-fundamentals/lib/seed';
 import {
+  DOCKER_FUNDAMENTALS_SEED_VERSION,
+  DOCKER_FUNDAMENTALS_SLUG,
+} from '../docker-fundamentals/data/assessment-definition';
+import {
+  DOCKER_FUNDAMENTALS_GAMIFICATION_RULES,
+  buildDockerFundamentalsGamificationEvents,
+} from '../docker-fundamentals/lib/gamification';
+import { ensureDockerFundamentalsSeeded } from '../docker-fundamentals/lib/seed';
+import {
   DATABASE_FUNDAMENTALS_SEED_VERSION,
   DATABASE_FUNDAMENTALS_SLUG,
 } from '../database-fundamentals/data/assessment-definition';
@@ -79,6 +88,7 @@ export type AssessmentExamType =
   | 'api-developer-fundamentals'
   | 'api-dotnet-fundamentals'
   | 'api-testing-fundamentals'
+  | 'docker-fundamentals'
   | 'database-fundamentals'
   | 'database-practice'
   | 'gherkin-fundamentals'
@@ -135,6 +145,15 @@ export const ASSESSMENT_REGISTRY: Record<string, AssessmentRegistryEntry> = {
     gamificationSource: 'API_TESTING_FUNDAMENTALS',
     gamificationRules: API_TESTING_GAMIFICATION_RULES,
     buildGamificationEvents: buildApiTestingGamificationEvents,
+  },
+  [DOCKER_FUNDAMENTALS_SLUG]: {
+    slug: DOCKER_FUNDAMENTALS_SLUG,
+    seedVersion: DOCKER_FUNDAMENTALS_SEED_VERSION,
+    ensureSeeded: ensureDockerFundamentalsSeeded,
+    examType: 'docker-fundamentals',
+    gamificationSource: 'DOCKER_FUNDAMENTALS',
+    gamificationRules: DOCKER_FUNDAMENTALS_GAMIFICATION_RULES,
+    buildGamificationEvents: buildDockerFundamentalsGamificationEvents,
   },
   [DATABASE_FUNDAMENTALS_SLUG]: {
     slug: DATABASE_FUNDAMENTALS_SLUG,

--- a/apps/frontend/src/app/assessments/api-dotnet-fundamentals/__tests__/definition.test.ts
+++ b/apps/frontend/src/app/assessments/api-dotnet-fundamentals/__tests__/definition.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { assertAssessmentDefinitionConsistency } from '../../_shared/testing/assessment-definition-checks';
+import {
+  API_DOTNET_FUNDAMENTALS_SEED_VERSION,
+  API_DOTNET_FUNDAMENTALS_SLUG,
+  apiDotnetFundamentalsDefinition,
+} from '../data/assessment-definition';
+import { ASSESSMENT_REGISTRY } from '../../_shared/registry';
+
+describe('api-dotnet-fundamentals definition', () => {
+  it('mantiene presupuestos de puntos y answer keys consistentes', () => {
+    assertAssessmentDefinitionConsistency(apiDotnetFundamentalsDefinition);
+  });
+
+  it('define 4 secciones teóricas sobre 100 puntos', () => {
+    expect(apiDotnetFundamentalsDefinition.sections).toHaveLength(4);
+    expect(apiDotnetFundamentalsDefinition.total_score).toBe(100);
+    expect(apiDotnetFundamentalsDefinition.slug).toBe(
+      API_DOTNET_FUNDAMENTALS_SLUG
+    );
+  });
+
+  it('está registrado con el seedVersion correcto', () => {
+    const entry = ASSESSMENT_REGISTRY[API_DOTNET_FUNDAMENTALS_SLUG];
+    expect(entry).toBeDefined();
+    expect(entry.seedVersion).toBe(API_DOTNET_FUNDAMENTALS_SEED_VERSION);
+    expect(entry.examType).toBe('api-dotnet-fundamentals');
+  });
+});

--- a/apps/frontend/src/app/assessments/api-dotnet-fundamentals/data/assessment-definition.ts
+++ b/apps/frontend/src/app/assessments/api-dotnet-fundamentals/data/assessment-definition.ts
@@ -1,0 +1,700 @@
+import type { AssessmentSeedDefinition } from '../../_shared/types';
+
+export const API_DOTNET_FUNDAMENTALS_SLUG = 'api-dotnet-fundamentals';
+
+// Bumpear cuando cambie la definición (secciones/preguntas) para forzar re-seed.
+export const API_DOTNET_FUNDAMENTALS_SEED_VERSION = 1;
+
+export const apiDotnetFundamentalsDefinition: AssessmentSeedDefinition = {
+  slug: API_DOTNET_FUNDAMENTALS_SLUG,
+  title: 'API .NET — Fundamentos',
+  description:
+    'Evaluación teórica de diseño y construcción de APIs REST en .NET para bootcamp de desarrollo backend: diseño de rutas y verbos HTTP, versionado, contrato OpenAPI/Swagger, Clean Architecture (separación por capas) y manejo de errores sin exponer detalles internos.',
+  level: 'Trainee a Junior',
+  type: 'Desarrollo Backend .NET',
+  duration_minutes: 40,
+  total_score: 100,
+  is_active: true,
+  metadata: {
+    moduleName: 'AIQUAA Assessments / API .NET Fundamentals',
+    passingScore: 70,
+    candidateBands: [
+      { min: 0, max: 39, label: 'Inicial' },
+      { min: 40, max: 59, label: 'En formación' },
+      { min: 60, max: 74, label: 'Trainee' },
+      { min: 75, max: 89, label: 'Junior' },
+      { min: 90, max: 100, label: 'Junior avanzado' },
+    ],
+  },
+  sections: [
+    {
+      slug: 'diseno-rest-versionado',
+      title: 'Diseño REST y versionado',
+      description:
+        'Rutas semánticas orientadas a recursos, verbos HTTP correctos, idempotencia, códigos de estado y estrategias de versionado de una API .NET.',
+      order_index: 1,
+      max_score: 24,
+      metadata: {
+        instructions:
+          'Selección múltiple y verdadero/falso sobre convenciones REST aplicadas a ASP.NET Core Web API.',
+        suggestedMinutes: 10,
+      },
+      questions: [
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            '¿Cuál de estas rutas sigue mejor las convenciones REST para exponer la colección de pedidos y un pedido puntual?',
+          options: [
+            { label: 'GET /getOrders y GET /getOrderById?id=5', value: 'a' },
+            { label: 'GET /orders y GET /orders/5', value: 'b' },
+            { label: 'POST /orders/fetch y POST /orders/fetchOne', value: 'c' },
+            { label: 'GET /order y GET /order/find/5', value: 'd' },
+          ],
+          correct_answer: { value: 'b' },
+          explanation:
+            'REST modela recursos con sustantivos en plural (/orders) y usa el verbo HTTP para expresar la acción. La acción nunca va en la URL: eso es lo que diferencia una API REST de una API tipo RPC (getOrders, fetchOne).',
+          points: 4,
+          order_index: 1,
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            'Necesitás actualizar solo el campo "estado" de un pedido, sin reenviar el recurso completo. ¿Qué verbo HTTP es el más apropiado?',
+          options: [
+            { label: 'PUT, porque siempre reemplaza el recurso', value: 'a' },
+            {
+              label:
+                'PATCH, porque aplica una modificación parcial sobre el recurso existente',
+              value: 'b',
+            },
+            {
+              label: 'POST, porque POST sirve para cualquier cambio',
+              value: 'c',
+            },
+            {
+              label: 'DELETE seguido de POST con los datos completos',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'b' },
+          explanation:
+            'PATCH está pensado para modificaciones parciales. PUT es semánticamente un reemplazo completo del recurso (requiere enviar todos los campos); usarlo para un cambio parcial obliga al cliente a conocer y reenviar datos que no quiere tocar.',
+          points: 4,
+          order_index: 2,
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            '¿Qué significa que un verbo HTTP sea "idempotente" y cuáles de los siguientes lo son?',
+          options: [
+            {
+              label:
+                'Que no requiere autenticación; GET y POST son idempotentes',
+              value: 'a',
+            },
+            {
+              label:
+                'Que ejecutar la misma request varias veces produce el mismo resultado en el servidor que ejecutarla una sola vez; GET, PUT y DELETE son idempotentes, POST no lo es',
+              value: 'b',
+            },
+            {
+              label: 'Que la respuesta siempre es la misma; solo GET lo es',
+              value: 'c',
+            },
+            {
+              label:
+                'Que se puede cachear en el cliente; PATCH y POST son idempotentes',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'b' },
+          explanation:
+            'Idempotencia es sobre el efecto en el servidor, no sobre la respuesta. Repetir un PUT o un DELETE dos veces deja el sistema en el mismo estado que hacerlo una vez; repetir un POST típicamente crea un recurso nuevo cada vez.',
+          points: 4,
+          order_index: 3,
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            'Un cliente hace POST /orders y el pedido se crea correctamente en el recurso /orders/42. ¿Qué respuesta es la más correcta según convenciones REST?',
+          options: [
+            { label: '200 OK con el body vacío', value: 'a' },
+            {
+              label:
+                '201 Created, con header Location: /orders/42 y el recurso creado en el body',
+              value: 'b',
+            },
+            {
+              label: '204 No Content, sin body ni headers adicionales',
+              value: 'c',
+            },
+            {
+              label: '202 Accepted, sin indicar dónde quedó el recurso',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'b' },
+          explanation:
+            '201 Created es el código semánticamente correcto para una creación exitosa. El header Location le dice al cliente dónde quedó el nuevo recurso, y devolver el recurso en el body evita que el cliente tenga que pedirlo de nuevo.',
+          points: 4,
+          order_index: 4,
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            'Vas a versionar una API pública en .NET que va a tener breaking changes a futuro. ¿Cuál es la estrategia de versionado más simple de descubrir y documentar para los consumidores?',
+          options: [
+            {
+              label:
+                'Versionado por segmento de URL (/api/v1/orders, /api/v2/orders), explícito y fácil de documentar en Swagger por versión',
+              value: 'a',
+            },
+            {
+              label:
+                'No versionar nunca y romper a todos los clientes en simultáneo',
+              value: 'b',
+            },
+            {
+              label:
+                'Cambiar el nombre de los campos del JSON en cada release sin avisar',
+              value: 'c',
+            },
+            {
+              label: 'Versionar solo el nombre de la base de datos',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'a' },
+          explanation:
+            'El versionado por URL es el más explícito: el cliente ve la versión en la ruta, es trivial de rutear en ASP.NET Core (con convenciones o el paquete Asp.Versioning) y cada versión puede documentarse como un contrato Swagger separado.',
+          points: 4,
+          order_index: 5,
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            'Un endpoint soporta filtros y paginación: GET /orders?status=paid&page=2&pageSize=20. ¿Por qué es preferible a GET /orders/paid/page/2/size/20?',
+          options: [
+            {
+              label:
+                'Porque los query params son opcionales y no rompen la identidad del recurso (/orders sigue siendo el mismo recurso, solo se filtra la vista)',
+              value: 'a',
+            },
+            {
+              label: 'Porque los query params son más rápidos de procesar',
+              value: 'b',
+            },
+            {
+              label: 'Porque ASP.NET Core no soporta parámetros de ruta',
+              value: 'c',
+            },
+            {
+              label: 'No hay diferencia real, es solo una cuestión de estilo',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'a' },
+          explanation:
+            'Filtrar, ordenar y paginar son operaciones sobre la colección, no partes de su identidad. Codificarlas como segmentos de ruta (/orders/paid/page/2) mezcla identidad de recurso con criterios de consulta y hace la API más rígida y difícil de extender.',
+          points: 4,
+          order_index: 6,
+        },
+      ],
+    },
+    {
+      slug: 'contrato-openapi-swagger',
+      title: 'Contrato OpenAPI / Swagger',
+      description:
+        'Generación y calidad del contrato OpenAPI en ASP.NET Core: documentación de responses, status codes y comportamiento de [ApiController].',
+      order_index: 2,
+      max_score: 20,
+      metadata: {
+        instructions:
+          'Preguntas sobre Swashbuckle, atributos de documentación y buenas prácticas de contrato en ASP.NET Core Web API.',
+        suggestedMinutes: 8,
+      },
+      questions: [
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            '¿Qué paquete NuGet se usa habitualmente en ASP.NET Core para generar el documento OpenAPI y la UI de Swagger?',
+          options: [
+            { label: 'Swashbuckle.AspNetCore', value: 'a' },
+            { label: 'Newtonsoft.Json', value: 'b' },
+            { label: 'AutoMapper', value: 'c' },
+            { label: 'Microsoft.EntityFrameworkCore', value: 'd' },
+          ],
+          correct_answer: { value: 'a' },
+          explanation:
+            'Swashbuckle.AspNetCore es la librería estándar que inspecciona los controllers/endpoints y genera tanto el JSON de OpenAPI como la UI interactiva de Swagger.',
+          points: 4,
+          order_index: 1,
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            '¿Para qué sirve decorar una acción con [ProducesResponseType(StatusCodes.Status404NotFound)]?',
+          options: [
+            {
+              label:
+                'Documentar explícitamente en el contrato OpenAPI que ese endpoint puede responder 404, más allá del 200 de éxito',
+              value: 'a',
+            },
+            {
+              label: 'Forzar a que el endpoint siempre devuelva 404',
+              value: 'b',
+            },
+            {
+              label:
+                'Deshabilitar el manejo de errores automático de ASP.NET Core',
+              value: 'c',
+            },
+            { label: 'Configurar el timeout de la request', value: 'd' },
+          ],
+          correct_answer: { value: 'a' },
+          explanation:
+            'ProducesResponseType no cambia el comportamiento en runtime; es metadata para el generador de OpenAPI. Sin esa anotación, Swagger solo documenta el status code "feliz" y el consumidor de la API no sabe qué otros códigos esperar.',
+          points: 4,
+          order_index: 2,
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            'Al marcar un controller con [ApiController], ¿qué comportamiento automático agrega ASP.NET Core?',
+          options: [
+            {
+              label:
+                'Genera automáticamente la base de datos a partir del modelo',
+              value: 'a',
+            },
+            {
+              label:
+                'Si el model binding/validación falla, responde automáticamente 400 Bad Request con los errores, sin necesidad de chequear ModelState.IsValid a mano',
+              value: 'b',
+            },
+            {
+              label: 'Habilita CORS para todos los orígenes por defecto',
+              value: 'c',
+            },
+            {
+              label: 'Convierte el controller en un servicio de background',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'b' },
+          explanation:
+            '[ApiController] activa varias convenciones de API, entre ellas la validación automática de modelo: si el binding falla, el framework corta el pipeline y devuelve 400 con el detalle de los errores, sin que el desarrollador tenga que escribir ese chequeo en cada acción.',
+          points: 4,
+          order_index: 3,
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            '¿Cuál es la forma recomendada de documentar de manera uniforme las respuestas de error en un contrato OpenAPI moderno?',
+          options: [
+            {
+              label:
+                'Usando el formato ProblemDetails (RFC 7807), con un shape consistente (type, title, status, detail) para todos los errores',
+              value: 'a',
+            },
+            {
+              label:
+                'Cada endpoint devuelve un formato de error distinto según lo que le resulte más cómodo al desarrollador',
+              value: 'b',
+            },
+            {
+              label: 'Los errores no se documentan, solo el happy path',
+              value: 'c',
+            },
+            {
+              label:
+                'Se documentan como comentarios en el código, no en el contrato',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'a' },
+          explanation:
+            'ProblemDetails estandariza el shape de los errores HTTP. ASP.NET Core lo soporta nativamente (ProblemDetails, ValidationProblemDetails), lo que permite documentarlo una vez en Swagger y que todos los endpoints lo respeten.',
+          points: 4,
+          order_index: 4,
+        },
+        {
+          question_type: 'true_false',
+          prompt:
+            'Un contrato OpenAPI bien construido documenta los status codes de éxito, pero es opcional documentar los de error porque no forman parte del "contrato real" de la API.',
+          correct_answer: { value: false },
+          explanation:
+            'Los status codes de error son parte del contrato: le dicen al consumidor cómo distinguir un 400 de un 404 o un 409, y qué shape esperar en cada caso. Omitirlos obliga al cliente a descubrirlos en producción.',
+          points: 4,
+          order_index: 5,
+        },
+      ],
+    },
+    {
+      slug: 'clean-architecture',
+      title: 'Clean Architecture',
+      description:
+        'Separación en capas (Domain, Application, Infrastructure, API), la regla de dependencia y por qué mejora la testabilidad del sistema.',
+      order_index: 3,
+      max_score: 28,
+      metadata: {
+        instructions:
+          'Preguntas sobre la organización en capas de un proyecto .NET siguiendo Clean Architecture.',
+        suggestedMinutes: 11,
+      },
+      questions: [
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            '¿Cuál es la regla de dependencia central en Clean Architecture?',
+          options: [
+            {
+              label:
+                'Las dependencias del código fuente solo pueden apuntar hacia adentro: las capas externas (Infrastructure, API) dependen de las internas (Application, Domain), nunca al revés',
+              value: 'a',
+            },
+            {
+              label: 'Todas las capas pueden depender libremente entre sí',
+              value: 'b',
+            },
+            {
+              label:
+                'El Domain debe depender de Entity Framework para persistir datos',
+              value: 'c',
+            },
+            {
+              label: 'La API siempre debe ser la capa más interna del sistema',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'a' },
+          explanation:
+            'La "Dependency Rule" es el núcleo de Clean Architecture: el código fuente de una capa interna nunca menciona nada de una capa externa. Domain no sabe que existe una base de datos o un framework web.',
+          points: 4,
+          order_index: 1,
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            '¿Dónde debería vivir la lógica de negocio pura (entidades y reglas del dominio) en un proyecto .NET con Clean Architecture?',
+          options: [
+            { label: 'En los controllers de la capa API', value: 'a' },
+            {
+              label: 'En la capa Infrastructure, junto al DbContext',
+              value: 'b',
+            },
+            {
+              label:
+                'En la capa Domain, sin referencias a ASP.NET Core, Entity Framework ni ningún paquete de infraestructura',
+              value: 'c',
+            },
+            { label: 'En archivos de configuración JSON', value: 'd' },
+          ],
+          correct_answer: { value: 'c' },
+          explanation:
+            'Domain contiene entidades, value objects y reglas de negocio, y no referencia ningún framework externo. Eso permite que las reglas de negocio se entiendan y testeen sin levantar web ni base de datos.',
+          points: 4,
+          order_index: 2,
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            '¿Cómo se relacionan típicamente Application e Infrastructure en Clean Architecture para respetar la regla de dependencia?',
+          options: [
+            {
+              label:
+                'Application define interfaces (puertos, ej. IOrderRepository); Infrastructure las implementa (ej. con Entity Framework) mediante inyección de dependencias — esto es Dependency Inversion',
+              value: 'a',
+            },
+            {
+              label:
+                'Application referencia directamente las clases concretas de Entity Framework',
+              value: 'b',
+            },
+            {
+              label:
+                'Infrastructure define las reglas de negocio y Application solo las consume',
+              value: 'c',
+            },
+            {
+              label: 'No hay relación, cada capa se despliega por separado',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'a' },
+          explanation:
+            'Este es el principio de inversión de dependencias aplicado a capas: la capa de más alto nivel (Application) define el contrato que necesita, y la capa de detalle (Infrastructure) lo implementa. Application nunca referencia el paquete de Entity Framework directamente.',
+          points: 4,
+          order_index: 3,
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            '¿Cuál de los siguientes es un anti-patrón común que rompe Clean Architecture en un controller de ASP.NET Core?',
+          options: [
+            {
+              label:
+                'Inyectar un servicio de Application vía constructor y delegarle la lógica',
+              value: 'a',
+            },
+            {
+              label:
+                'Instanciar el DbContext directamente en el controller y armar la query LINQ ahí mismo, mezclando presentación con acceso a datos y reglas de negocio',
+              value: 'b',
+            },
+            {
+              label: 'Devolver un DTO en vez de la entidad de dominio',
+              value: 'c',
+            },
+            { label: 'Usar [ApiController] y model binding', value: 'd' },
+          ],
+          correct_answer: { value: 'b' },
+          explanation:
+            'El controller debería ser una capa delgada: recibe la request, la traduce a un caso de uso de Application y devuelve la respuesta. Acceder directo a la base de datos desde el controller acopla la capa de presentación al detalle de persistencia.',
+          points: 4,
+          order_index: 4,
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            '¿Por qué conviene separar los DTOs (Data Transfer Objects) expuestos por la API de las entidades de dominio internas?',
+          options: [
+            {
+              label:
+                'Porque así el contrato público de la API no queda acoplado a los detalles internos del dominio: se puede refactorizar el dominio sin romper a los consumidores, y se evita exponer campos sensibles o internos',
+              value: 'a',
+            },
+            {
+              label: 'Porque C# no permite serializar entidades a JSON',
+              value: 'b',
+            },
+            {
+              label:
+                'Porque los DTOs son obligatorios para usar Entity Framework',
+              value: 'c',
+            },
+            {
+              label:
+                'No hay ninguna razón real, es solo boilerplate innecesario',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'a' },
+          explanation:
+            'Sin esa separación, cualquier cambio interno en una entidad (renombrar un campo, agregar una relación) se filtra directamente al contrato público y puede romper a todos los clientes, además de arriesgar exponer datos que no deberían salir de la API.',
+          points: 4,
+          order_index: 5,
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            '¿Cuál es el principal beneficio de Clean Architecture a la hora de escribir tests?',
+          options: [
+            {
+              label:
+                'Las reglas de negocio en Domain/Application pueden testearse con tests unitarios rápidos, sin levantar base de datos ni servidor HTTP, porque dependen de interfaces (mockeables) y no de infraestructura concreta',
+              value: 'a',
+            },
+            {
+              label: 'Elimina por completo la necesidad de escribir tests',
+              value: 'b',
+            },
+            {
+              label: 'Obliga a testear únicamente a través de la UI',
+              value: 'c',
+            },
+            {
+              label:
+                'Los tests solo pueden ejecutarse contra la base de datos de producción',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'a' },
+          explanation:
+            'Al depender de abstracciones (interfaces) en vez de implementaciones concretas, Application y Domain se pueden testear con dobles de test (mocks/fakes) rápidos y aislados, sin infraestructura real.',
+          points: 4,
+          order_index: 6,
+        },
+        {
+          question_type: 'true_false',
+          prompt:
+            'En Clean Architecture, la capa Infrastructure puede referenciar directamente la capa Domain, pero Domain nunca referencia Infrastructure.',
+          correct_answer: { value: true },
+          explanation:
+            'Es la aplicación directa de la regla de dependencia: las capas externas conocen a las internas, pero las internas no saben que las externas existen. Domain es la capa más protegida del proyecto.',
+          points: 4,
+          order_index: 7,
+        },
+      ],
+    },
+    {
+      slug: 'manejo-de-errores',
+      title: 'Manejo de errores',
+      description:
+        'Manejo centralizado de excepciones, formato estándar de errores y qué información nunca debería filtrarse al cliente.',
+      order_index: 4,
+      max_score: 28,
+      metadata: {
+        instructions:
+          'Preguntas sobre exception handling middleware, ProblemDetails y códigos de estado en ASP.NET Core.',
+        suggestedMinutes: 11,
+      },
+      questions: [
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            '¿Cuál es la forma recomendada de manejar excepciones no controladas de forma centralizada en una API ASP.NET Core?',
+          options: [
+            {
+              label:
+                'Envolver cada acción de cada controller en su propio try/catch con lógica repetida',
+              value: 'a',
+            },
+            {
+              label:
+                'Usar un middleware centralizado (por ejemplo UseExceptionHandler o un middleware custom) que capture las excepciones no manejadas en un solo lugar y devuelva una respuesta uniforme',
+              value: 'b',
+            },
+            {
+              label: 'Dejar que la excepción llegue tal cual al cliente',
+              value: 'c',
+            },
+            { label: 'Ignorar la excepción y devolver 200 igual', value: 'd' },
+          ],
+          correct_answer: { value: 'b' },
+          explanation:
+            'Centralizar el manejo de errores en middleware evita repetir try/catch en cada acción, garantiza una respuesta consistente para toda la API y es el único lugar que hay que tocar para cambiar el formato de error.',
+          points: 4,
+          order_index: 1,
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            '¿Qué estándar define el formato recomendado (type, title, status, detail, instance) para respuestas de error en APIs REST modernas, y que ASP.NET Core soporta nativamente?',
+          options: [
+            { label: 'RFC 7807 — Problem Details for HTTP APIs', value: 'a' },
+            { label: 'OAuth 2.0', value: 'b' },
+            { label: 'JSON Schema Draft 7', value: 'c' },
+            { label: 'CORS (Cross-Origin Resource Sharing)', value: 'd' },
+          ],
+          correct_answer: { value: 'a' },
+          explanation:
+            'RFC 7807 estandariza el shape de un error HTTP para que cualquier cliente pueda parsearlo de forma predecible. ASP.NET Core lo implementa a través de la clase ProblemDetails y su generación automática para errores de validación y excepciones.',
+          points: 4,
+          order_index: 2,
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            'En producción, ¿qué información NO debería incluirse en el body de una respuesta de error devuelta al cliente?',
+          options: [
+            {
+              label:
+                'Un mensaje claro sobre qué salió mal desde la perspectiva del cliente',
+              value: 'a',
+            },
+            {
+              label:
+                'El stack trace completo, el mensaje interno de la excepción de .NET y detalles de infraestructura (connection strings, nombres de tablas, rutas de archivos)',
+              value: 'b',
+            },
+            {
+              label: 'Un código de error o correlationId para trazabilidad',
+              value: 'c',
+            },
+            { label: 'El status code HTTP correspondiente', value: 'd' },
+          ],
+          correct_answer: { value: 'b' },
+          explanation:
+            'Exponer stack traces o detalles internos filtra información valiosa para un atacante (paths, versiones de librerías, estructura de datos) y no le sirve al cliente legítimo. Esos detalles deben ir solo al log del servidor.',
+          points: 4,
+          order_index: 3,
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            'Un cliente envía un body que no pasa las validaciones del modelo (por ejemplo, un email con formato inválido). ¿Qué código de estado corresponde?',
+          options: [
+            { label: '500 Internal Server Error', value: 'a' },
+            { label: '400 Bad Request', value: 'b' },
+            { label: '404 Not Found', value: 'c' },
+            { label: '204 No Content', value: 'd' },
+          ],
+          correct_answer: { value: 'b' },
+          explanation:
+            '400 Bad Request indica que la request del cliente está mal formada o no cumple las reglas de validación. Es un error del cliente, no del servidor, por lo que un 500 sería semánticamente incorrecto.',
+          points: 4,
+          order_index: 4,
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            'Un usuario autenticado intenta acceder a un recurso para el que no tiene permisos. ¿Qué código corresponde, y en qué se diferencia de un 401?',
+          options: [
+            {
+              label:
+                '403 Forbidden: el usuario está identificado pero no autorizado para esa acción; 401 Unauthorized se usa cuando no hay credenciales válidas',
+              value: 'a',
+            },
+            {
+              label: '401 Unauthorized en ambos casos, no hay diferencia',
+              value: 'b',
+            },
+            {
+              label: '404 Not Found, para no revelar que el recurso existe',
+              value: 'c',
+            },
+            {
+              label: '400 Bad Request, porque el permiso es parte del body',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'a' },
+          explanation:
+            '401 responde "no sé quién sos" (falta o falla la autenticación); 403 responde "sé quién sos, pero no podés hacer esto" (falla la autorización). Confundirlos es un error de contrato frecuente.',
+          points: 4,
+          order_index: 5,
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            '¿Por qué es una mala práctica capturar catch (Exception ex) de forma genérica en un controller y devolver 200 OK con un mensaje de error dentro del body?',
+          options: [
+            {
+              label:
+                'Porque rompe el contrato HTTP semántico: clientes, proxies, herramientas de monitoreo y el propio Swagger asumen que 200 significa éxito, y ese error queda invisible para cualquier chequeo automático',
+              value: 'a',
+            },
+            {
+              label: 'Porque C# no permite hacer catch de Exception genérica',
+              value: 'b',
+            },
+            {
+              label: 'Porque 200 OK es un código reservado solo para GET',
+              value: 'c',
+            },
+            {
+              label: 'No es una mala práctica, es la forma recomendada',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'a' },
+          explanation:
+            'El status code es la señal de más alto nivel que consume cualquier infraestructura HTTP (load balancers, dashboards, alerting). Devolver 200 en un caso de error esconde el fallo de todo lo que solo mira el status code.',
+          points: 4,
+          order_index: 6,
+        },
+        {
+          question_type: 'true_false',
+          prompt:
+            'Loggear la excepción completa (stack trace) del lado del servidor, mientras al cliente se le devuelve solo un mensaje genérico junto con un código de error o correlationId trazable, es una buena práctica.',
+          correct_answer: { value: true },
+          explanation:
+            'Esa separación es exactamente la idea: el equipo de desarrollo tiene toda la información para diagnosticar en los logs, y el cliente recibe una respuesta segura y accionable sin exponer detalles internos.',
+          points: 4,
+          order_index: 7,
+        },
+      ],
+    },
+  ],
+};

--- a/apps/frontend/src/app/assessments/api-dotnet-fundamentals/lib/gamification.ts
+++ b/apps/frontend/src/app/assessments/api-dotnet-fundamentals/lib/gamification.ts
@@ -1,0 +1,15 @@
+import { createAssessmentGamification } from '../../_shared/lib/gamification';
+
+const gamification = createAssessmentGamification({
+  prefix: 'API_DOTNET_FUNDAMENTALS',
+  descriptions: {
+    completed: 'Completar el assessment API .NET Fundamentals',
+    passed: 'Aprobar el assessment API .NET Fundamentals (score >= 70)',
+    highScore: 'Score sobresaliente en API .NET Fundamentals (>= 90)',
+  },
+});
+
+export const API_DOTNET_FUNDAMENTALS_GAMIFICATION_RULES = gamification.rules;
+
+export const buildApiDotnetFundamentalsGamificationEvents =
+  gamification.buildEvents;

--- a/apps/frontend/src/app/assessments/api-dotnet-fundamentals/lib/seed.ts
+++ b/apps/frontend/src/app/assessments/api-dotnet-fundamentals/lib/seed.ts
@@ -1,0 +1,12 @@
+import { ensureAssessmentSeeded } from '../../_shared/lib/seed';
+import {
+  API_DOTNET_FUNDAMENTALS_SEED_VERSION,
+  apiDotnetFundamentalsDefinition,
+} from '../data/assessment-definition';
+
+export async function ensureApiDotnetFundamentalsSeeded() {
+  return ensureAssessmentSeeded(
+    apiDotnetFundamentalsDefinition,
+    API_DOTNET_FUNDAMENTALS_SEED_VERSION
+  );
+}

--- a/apps/frontend/src/app/assessments/api-dotnet-fundamentals/page.tsx
+++ b/apps/frontend/src/app/assessments/api-dotnet-fundamentals/page.tsx
@@ -1,0 +1,92 @@
+import { Metadata } from 'next';
+import { apiDotnetFundamentalsDefinition } from './data/assessment-definition';
+import AssessmentWelcome from '../_shared/components/AssessmentWelcome';
+
+export const metadata: Metadata = {
+  title: 'API .NET — Fundamentos | AIQUAA',
+  description:
+    'Prueba técnica teórica para bootcamp de desarrollo: diseño REST y versionado en .NET, contrato OpenAPI/Swagger, Clean Architecture y manejo de errores.',
+  keywords: [
+    '.NET',
+    'ASP.NET Core',
+    'API REST',
+    'Clean Architecture',
+    'OpenAPI',
+    'Swagger',
+    'manejo de errores',
+    'ProblemDetails',
+    'desarrollo backend',
+    'bootcamp',
+    'AIQUAA',
+    'evaluación técnica',
+  ],
+  openGraph: {
+    title: 'API .NET — Fundamentos | AIQUAA',
+    description:
+      'Prueba técnica teórica sobre diseño REST, OpenAPI/Swagger, Clean Architecture y manejo de errores en .NET.',
+    url: 'https://aiquaa.com/assessments/api-dotnet-fundamentals',
+    siteName: 'AIQUAA',
+    type: 'website',
+    locale: 'es_PY',
+    images: [
+      {
+        url: '/api/og?title=API%20.NET%20-%20Fundamentos&subtitle=REST%2C%20Swagger%20y%20Clean%20Architecture&section=Assessments',
+        width: 1200,
+        height: 630,
+        alt: 'API .NET Fundamentos - AIQUAA',
+      },
+    ],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'API .NET — Fundamentos | AIQUAA',
+    description:
+      'Prueba técnica sobre diseño REST, Swagger, Clean Architecture y manejo de errores en .NET.',
+    images: [
+      '/api/og?title=API%20.NET%20-%20Fundamentos&subtitle=REST%2C%20Swagger%20y%20Clean%20Architecture&section=Assessments',
+    ],
+    creator: '@stevenayal',
+  },
+  alternates: {
+    canonical: 'https://aiquaa.com/assessments/api-dotnet-fundamentals',
+  },
+};
+
+export default function ApiDotnetFundamentalsPage() {
+  const overview = {
+    assessment: {
+      id: 'static-api-dotnet-fundamentals',
+      slug: apiDotnetFundamentalsDefinition.slug,
+      title: apiDotnetFundamentalsDefinition.title,
+      description: apiDotnetFundamentalsDefinition.description,
+      level: apiDotnetFundamentalsDefinition.level,
+      type: apiDotnetFundamentalsDefinition.type,
+      duration_minutes: apiDotnetFundamentalsDefinition.duration_minutes,
+      total_score: apiDotnetFundamentalsDefinition.total_score,
+      is_active: apiDotnetFundamentalsDefinition.is_active,
+      metadata: apiDotnetFundamentalsDefinition.metadata,
+    },
+    sections: apiDotnetFundamentalsDefinition.sections.map(
+      (section, index) => ({
+        id: `static-section-${index + 1}`,
+        assessment_id: 'static-api-dotnet-fundamentals',
+        slug: section.slug,
+        title: section.title,
+        description: section.description,
+        order_index: section.order_index,
+        max_score: section.max_score,
+        metadata: section.metadata,
+      })
+    ),
+  };
+
+  return (
+    <AssessmentWelcome
+      overview={overview}
+      startHref="/assessments/api-dotnet-fundamentals/start"
+      evaluatesCopy="Diseño de rutas REST, verbos HTTP e idempotencia, versionado de API; contrato OpenAPI/Swagger y atributos de documentación; separación en capas con Clean Architecture y la regla de dependencia; manejo centralizado de errores con ProblemDetails sin filtrar detalles internos."
+      scoringCopy="Automático en las 4 secciones: selección múltiple y verdadero/falso."
+      resultCopy="Score total, score por sección, fortalezas, debilidades y temas a reforzar."
+    />
+  );
+}

--- a/apps/frontend/src/app/assessments/api-dotnet-fundamentals/result/page.tsx
+++ b/apps/frontend/src/app/assessments/api-dotnet-fundamentals/result/page.tsx
@@ -1,0 +1,19 @@
+import { Suspense } from 'react';
+import AssessmentResultClient from '../../_shared/components/AssessmentResultClient';
+
+export default function ApiDotnetFundamentalsResultPage() {
+  return (
+    <Suspense
+      fallback={
+        <div className="min-h-screen flex items-center justify-center bg-slate-950">
+          <div className="h-10 w-10 animate-spin rounded-full border-t-2 border-cyan-400" />
+        </div>
+      }
+    >
+      <AssessmentResultClient
+        startHref="/assessments/api-dotnet-fundamentals/start"
+        fallbackRecommendation="Repasá la documentación oficial de ASP.NET Core: convenciones REST, Swashbuckle/OpenAPI, la guía de Clean Architecture (Microsoft eShopOnWeb) y el manejo de excepciones con ProblemDetails."
+      />
+    </Suspense>
+  );
+}

--- a/apps/frontend/src/app/assessments/api-dotnet-fundamentals/section/[sectionId]/page.tsx
+++ b/apps/frontend/src/app/assessments/api-dotnet-fundamentals/section/[sectionId]/page.tsx
@@ -1,0 +1,9 @@
+'use client';
+
+import AssessmentSectionScreen from '../../../_shared/components/AssessmentSectionScreen';
+
+export default function ApiDotnetFundamentalsSectionPage() {
+  return (
+    <AssessmentSectionScreen basePath="/assessments/api-dotnet-fundamentals" />
+  );
+}

--- a/apps/frontend/src/app/assessments/api-dotnet-fundamentals/start/page.tsx
+++ b/apps/frontend/src/app/assessments/api-dotnet-fundamentals/start/page.tsx
@@ -1,0 +1,133 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { useTheme } from '@/contexts/ThemeContext';
+import { startAssessmentAttemptAction } from '@/actions/assessments';
+import ProcessCodeInput from '@/components/labs/ProcessCodeInput';
+import { API_DOTNET_FUNDAMENTALS_SLUG } from '../data/assessment-definition';
+
+export default function StartApiDotnetFundamentalsPage() {
+  const router = useRouter();
+  const { isDarkMode } = useTheme();
+  const [processCode, setProcessCode] = useState('');
+  const [error, setError] = useState('');
+  const [isStarting, setIsStarting] = useState(false);
+
+  // Pre-fill desde ?code= (links de invitaciones/procesos de empresa)
+  useEffect(() => {
+    const codeParam = new URLSearchParams(window.location.search).get('code');
+    if (codeParam) setProcessCode(codeParam);
+  }, []);
+
+  async function handleStart() {
+    setError('');
+    setIsStarting(true);
+
+    try {
+      const result = await startAssessmentAttemptAction({
+        slug: API_DOTNET_FUNDAMENTALS_SLUG,
+        processCode,
+      });
+
+      if ('error' in result) {
+        setIsStarting(false);
+        setError(result.error);
+        return;
+      }
+
+      const { attempt, sectionSlug } = result;
+
+      if (!sectionSlug) {
+        setIsStarting(false);
+        setError('No se encontró la primera sección del assessment.');
+        return;
+      }
+
+      setIsStarting(false);
+      router.push(
+        `/assessments/api-dotnet-fundamentals/section/${sectionSlug}?attempt=${attempt.id}`
+      );
+    } catch (startError) {
+      setIsStarting(false);
+      setError(
+        startError instanceof Error
+          ? startError.message
+          : 'No se pudo iniciar el assessment.'
+      );
+    }
+  }
+
+  return (
+    <div
+      className={`min-h-screen px-4 py-12 ${
+        isDarkMode ? 'bg-slate-950 text-white' : 'bg-slate-50 text-slate-900'
+      }`}
+    >
+      <div className="mx-auto max-w-3xl rounded-3xl border border-slate-800 bg-slate-900/80 p-8 text-slate-50 shadow-2xl shadow-cyan-950/20">
+        <p className="text-sm font-semibold uppercase tracking-[0.18em] text-cyan-200">
+          Preparación del intento
+        </p>
+        <h1 className="mt-3 text-3xl font-bold">API .NET — Fundamentos</h1>
+        <p className="mt-3 text-slate-300">
+          Vas a completar 4 secciones teóricas con autosave, scoring por sección
+          y resultado final consolidado.
+        </p>
+
+        <div className="mt-8 grid gap-4 rounded-2xl border border-slate-800 bg-slate-950/70 p-5 md:grid-cols-3">
+          <div>
+            <p className="text-xs uppercase tracking-[0.18em] text-slate-400">
+              Duración sugerida
+            </p>
+            <p className="mt-2 text-lg font-semibold">~40 minutos</p>
+          </div>
+          <div>
+            <p className="text-xs uppercase tracking-[0.18em] text-slate-400">
+              Modalidad
+            </p>
+            <p className="mt-2 text-lg font-semibold">Conceptual</p>
+          </div>
+          <div>
+            <p className="text-xs uppercase tracking-[0.18em] text-slate-400">
+              Resultado
+            </p>
+            <p className="mt-2 text-lg font-semibold">Score total sobre 100</p>
+          </div>
+        </div>
+
+        <div className="mt-8">
+          <ProcessCodeInput
+            value={processCode}
+            onChange={setProcessCode}
+            onNormalizedCode={setProcessCode}
+            autoValidate
+          />
+        </div>
+
+        {error ? (
+          <div className="mt-6 rounded-2xl border border-red-500/30 bg-red-500/10 px-4 py-3 text-sm text-red-200">
+            {error}
+          </div>
+        ) : null}
+
+        <div className="mt-8 flex flex-col gap-3 sm:flex-row">
+          <button
+            type="button"
+            onClick={handleStart}
+            disabled={isStarting}
+            className="inline-flex items-center justify-center rounded-2xl bg-cyan-400 px-5 py-3 text-sm font-semibold text-slate-950 transition hover:bg-cyan-300 disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {isStarting ? 'Preparando intento...' : 'Iniciar o reanudar'}
+          </button>
+          <button
+            type="button"
+            onClick={() => router.push('/assessments/api-dotnet-fundamentals')}
+            className="inline-flex items-center justify-center rounded-2xl border border-slate-700 px-5 py-3 text-sm font-semibold text-slate-200 transition hover:bg-slate-800"
+          >
+            Volver al overview
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/src/app/assessments/cicd-fundamentals/__tests__/definition.test.ts
+++ b/apps/frontend/src/app/assessments/cicd-fundamentals/__tests__/definition.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { assertAssessmentDefinitionConsistency } from '../../_shared/testing/assessment-definition-checks';
+import {
+  CICD_FUNDAMENTALS_SEED_VERSION,
+  CICD_FUNDAMENTALS_SLUG,
+  cicdFundamentalsDefinition,
+} from '../data/assessment-definition';
+import { ASSESSMENT_REGISTRY } from '../../_shared/registry';
+
+describe('cicd-fundamentals definition', () => {
+  it('mantiene presupuestos de puntos y answer keys consistentes', () => {
+    assertAssessmentDefinitionConsistency(cicdFundamentalsDefinition);
+  });
+
+  it('define 3 secciones teóricas sobre 100 puntos', () => {
+    expect(cicdFundamentalsDefinition.sections).toHaveLength(3);
+    expect(cicdFundamentalsDefinition.total_score).toBe(100);
+    expect(cicdFundamentalsDefinition.slug).toBe(CICD_FUNDAMENTALS_SLUG);
+  });
+
+  it('está registrado con el seedVersion correcto', () => {
+    const entry = ASSESSMENT_REGISTRY[CICD_FUNDAMENTALS_SLUG];
+    expect(entry).toBeDefined();
+    expect(entry.seedVersion).toBe(CICD_FUNDAMENTALS_SEED_VERSION);
+    expect(entry.examType).toBe('cicd-fundamentals');
+  });
+});

--- a/apps/frontend/src/app/assessments/cicd-fundamentals/data/assessment-definition.ts
+++ b/apps/frontend/src/app/assessments/cicd-fundamentals/data/assessment-definition.ts
@@ -1,0 +1,721 @@
+import type { AssessmentSeedDefinition } from '../../_shared/types';
+
+export const CICD_FUNDAMENTALS_SLUG = 'cicd-fundamentals';
+
+// Bumpear cuando cambie la definición (secciones/preguntas) para forzar re-seed.
+export const CICD_FUNDAMENTALS_SEED_VERSION = 1;
+
+export const cicdFundamentalsDefinition: AssessmentSeedDefinition = {
+  slug: CICD_FUNDAMENTALS_SLUG,
+  title: 'CI/CD — Fundamentos',
+  description:
+    'Evaluación teórica de CI/CD para bootcamp de desarrollo backend: pipelines de integración continua (restore/build/test), despliegue continuo automatizado, y buenas prácticas DevOps de versionado y organización del repositorio.',
+  level: 'Trainee a Junior',
+  type: 'Desarrollo DevOps',
+  duration_minutes: 35,
+  total_score: 100,
+  is_active: true,
+  metadata: {
+    moduleName: 'AIQUAA Assessments / CI/CD Fundamentals',
+    passingScore: 70,
+    candidateBands: [
+      { min: 0, max: 39, label: 'Inicial' },
+      { min: 40, max: 59, label: 'En formación' },
+      { min: 60, max: 74, label: 'Trainee' },
+      { min: 75, max: 89, label: 'Junior' },
+      { min: 90, max: 100, label: 'Junior avanzado' },
+    ],
+  },
+  sections: [
+    {
+      slug: 'pipeline-ci',
+      title: 'Pipeline CI',
+      description:
+        'Integración continua: restore, build y tests automáticos disparados en cada cambio para detectar problemas temprano.',
+      order_index: 1,
+      max_score: 36,
+      metadata: {
+        instructions:
+          'Selección múltiple y verdadero/falso sobre integración continua (CI) en pipelines de desarrollo.',
+        suggestedMinutes: 13,
+      },
+      questions: [
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            '¿Qué es CI (Integración Continua) en el contexto de un pipeline de desarrollo?',
+          options: [
+            {
+              label:
+                'La práctica de integrar cambios de código frecuentemente a una rama compartida, ejecutando automáticamente build y tests en cada cambio para detectar problemas lo antes posible',
+              value: 'a',
+            },
+            {
+              label: 'Un servidor donde se guarda el código fuente',
+              value: 'b',
+            },
+            { label: 'Un tipo de base de datos distribuida', value: 'c' },
+            {
+              label: 'Un reemplazo de Git para el control de versiones',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'a' },
+          explanation:
+            'CI busca reducir el costo de integrar cambios: mientras más seguido se integran y validan cambios pequeños, más fácil es detectar y aislar un problema, en vez de descubrirlo semanas después con cambios acumulados.',
+          points: 4,
+          order_index: 1,
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            '¿Cuál es el objetivo principal del step de "restore" en un pipeline CI de un proyecto .NET o Node.js?',
+          options: [
+            {
+              label:
+                'Descargar e instalar las dependencias declaradas (paquetes NuGet, paquetes npm) necesarias para compilar y ejecutar el proyecto, de forma reproducible según el archivo de lock',
+              value: 'a',
+            },
+            {
+              label: 'Restaurar una copia de seguridad de la base de datos',
+              value: 'b',
+            },
+            { label: 'Deshacer el último commit realizado', value: 'c' },
+            { label: 'Reiniciar el servidor de producción', value: 'd' },
+          ],
+          correct_answer: { value: 'a' },
+          explanation:
+            'Sin este paso, el build fallaría por falta de dependencias. Es el primer paso típico de cualquier pipeline: asegurarse de que el entorno de build tenga exactamente lo que el proyecto necesita.',
+          points: 4,
+          order_index: 2,
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            '¿Por qué es importante que el pipeline CI se dispare automáticamente en cada push o Pull Request, en vez de ejecutarse manualmente "cuando alguien se acuerda"?',
+          options: [
+            {
+              label:
+                'Garantiza que cada cambio se valide de forma consistente sin depender de que una persona recuerde ejecutar los checks, detectando regresiones antes de que lleguen a la rama principal',
+              value: 'a',
+            },
+            {
+              label: 'Los pipelines manuales están prohibidos por Git',
+              value: 'b',
+            },
+            {
+              label: 'Es más lento pero más seguro ejecutarlo manualmente',
+              value: 'c',
+            },
+            {
+              label: 'No hay ninguna diferencia real entre ambos enfoques',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'a' },
+          explanation:
+            'La automatización elimina el factor humano como punto único de falla del proceso de calidad: el pipeline corre siempre, sin excepciones ni "me olvidé de correr los tests".',
+          points: 4,
+          order_index: 3,
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            '¿Qué debería ocurrir si el step de "build" falla en el pipeline CI ejecutado sobre un Pull Request?',
+          options: [
+            {
+              label:
+                'El pipeline debe marcar el check como fallido y, idealmente, bloquear el merge del Pull Request hasta que el problema se corrija',
+              value: 'a',
+            },
+            {
+              label: 'El pipeline debería ignorar el error y continuar igual',
+              value: 'b',
+            },
+            {
+              label: 'El PR se mergea automáticamente de todas formas',
+              value: 'c',
+            },
+            {
+              label: 'Se debe eliminar la rama del PR inmediatamente',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'a' },
+          explanation:
+            'Un build roto que se mergea a la rama principal rompe el trabajo de todo el equipo. Bloquear el merge hasta que el pipeline esté en verde es la protección más básica y efectiva contra eso.',
+          points: 4,
+          order_index: 4,
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            '¿Por qué correr los tests automatizados como parte del pipeline CI, y no conformarse solo con que el proyecto compile (build)?',
+          options: [
+            {
+              label:
+                'Un build exitoso solo confirma que el código compila; los tests validan que el comportamiento sigue siendo el esperado, atrapando regresiones funcionales que el compilador no puede detectar',
+              value: 'a',
+            },
+            {
+              label: 'El build y los tests son exactamente lo mismo',
+              value: 'b',
+            },
+            {
+              label: 'Correr tests hace que el build sea más rápido',
+              value: 'c',
+            },
+            {
+              label: 'No aporta ningún valor adicional correr los tests en CI',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'a' },
+          explanation:
+            'El compilador solo verifica que el código sea sintácticamente válido y tipado correctamente; no sabe si la lógica de negocio sigue haciendo lo correcto. Eso es exactamente lo que los tests verifican.',
+          points: 4,
+          order_index: 5,
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            '¿Qué ventaja tiene cachear las dependencias restauradas entre ejecuciones sucesivas del pipeline CI?',
+          options: [
+            {
+              label:
+                'Reduce significativamente el tiempo de cada ejecución del pipeline, evitando descargar/instalar las mismas dependencias en cada build cuando no cambiaron',
+              value: 'a',
+            },
+            {
+              label: 'Hace que los tests pasen automáticamente sin ejecutarse',
+              value: 'b',
+            },
+            {
+              label:
+                'Elimina la necesidad de tener un archivo de lock de dependencias',
+              value: 'c',
+            },
+            {
+              label: 'No tiene ningún impacto real en el tiempo de ejecución',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'a' },
+          explanation:
+            'Descargar decenas o cientos de paquetes en cada ejecución puede consumir buena parte del tiempo total del pipeline; cachear esa capa (cuando el lockfile no cambió) acelera notablemente el feedback.',
+          points: 4,
+          order_index: 6,
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            'En un pipeline con varios jobs independientes (por ejemplo lint, tests unitarios, build), ¿por qué conviene que corran en paralelo cuando no dependen entre sí?',
+          options: [
+            {
+              label:
+                'Reduce el tiempo total de feedback para el desarrollador: no hay razón para esperar a que un job termine antes de empezar otro si no existe una dependencia real entre ellos',
+              value: 'a',
+            },
+            {
+              label: 'Es un requisito técnico obligatorio de todo pipeline',
+              value: 'b',
+            },
+            {
+              label: 'Corriendo en paralelo se consume menos memoria total',
+              value: 'c',
+            },
+            {
+              label: 'No cambia nada respecto a correrlos en secuencia',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'a' },
+          explanation:
+            'Si lint, tests y build son independientes entre sí, ejecutarlos en secuencia solo suma tiempos de espera innecesarios; en paralelo, el tiempo total del pipeline se acerca al del job más lento, no a la suma de todos.',
+          points: 4,
+          order_index: 7,
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            '¿Qué es un "pipeline verde" y por qué es una señal de calidad valorada por el equipo?',
+          options: [
+            {
+              label:
+                'Indica que todos los checks automatizados (build, tests, lint) pasaron correctamente; da confianza de que el código en esa rama está en un estado desplegable o mergeable',
+              value: 'a',
+            },
+            {
+              label:
+                'Significa que el pipeline usa un tema visual de color verde',
+              value: 'b',
+            },
+            {
+              label: 'Indica que no se ejecutó ningún test todavía',
+              value: 'c',
+            },
+            {
+              label:
+                'Es simplemente una etiqueta decorativa sin significado técnico',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'a' },
+          explanation:
+            'El color (verde/rojo) es solo la representación visual; lo que importa es que representa una señal objetiva y automatizada sobre el estado real del código, algo que un humano no podría verificar tan rápido ni consistentemente.',
+          points: 4,
+          order_index: 8,
+        },
+        {
+          question_type: 'true_false',
+          prompt:
+            'Un pipeline CI que solo verifica que el código compila, sin ejecutar ningún test automatizado, ofrece el mismo nivel de confianza que uno que además corre la suite de tests.',
+          correct_answer: { value: false },
+          explanation:
+            'Compilar exitosamente no garantiza que el comportamiento sea correcto. Un pipeline sin tests puede dejar pasar regresiones funcionales graves mientras muestra un check verde, dando una falsa sensación de seguridad.',
+          points: 4,
+          order_index: 9,
+        },
+      ],
+    },
+    {
+      slug: 'cd',
+      title: 'CD',
+      description:
+        'Despliegue continuo: artefactos versionados, promoción entre ambientes, idempotencia y rollback.',
+      order_index: 2,
+      max_score: 32,
+      metadata: {
+        instructions:
+          'Preguntas sobre despliegue continuo (CD), artefactos y promoción entre ambientes.',
+        suggestedMinutes: 11,
+      },
+      questions: [
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            '¿Cuál es la diferencia entre Continuous Delivery y Continuous Deployment?',
+          options: [
+            {
+              label:
+                'Continuous Delivery deja el artefacto listo para desplegar, requiriendo un paso manual de aprobación final; Continuous Deployment despliega automáticamente a producción en cuanto el pipeline pasa, sin intervención humana',
+              value: 'a',
+            },
+            {
+              label: 'Son exactamente lo mismo, solo cambia el nombre',
+              value: 'b',
+            },
+            {
+              label: 'Delivery es para frontend y Deployment solo para backend',
+              value: 'c',
+            },
+            {
+              label: 'Deployment nunca automatiza nada, siempre es manual',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'a' },
+          explanation:
+            'Ambas automatizan hasta tener un artefacto listo; la diferencia está en el último paso hacia producción: con aprobación humana (Delivery) o completamente automático (Deployment).',
+          points: 4,
+          order_index: 1,
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            '¿Qué es un "artefacto" en el contexto de un pipeline CD para una API .NET, por ejemplo?',
+          options: [
+            {
+              label:
+                'El resultado empaquetado y versionado del build (por ejemplo, una imagen Docker o un paquete publicado) que se promueve entre ambientes sin volver a compilarse cada vez',
+              value: 'a',
+            },
+            { label: 'El código fuente sin compilar del proyecto', value: 'b' },
+            { label: 'Un archivo de configuración de Git', value: 'c' },
+            {
+              label: 'La documentación del proyecto en formato PDF',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'a' },
+          explanation:
+            'El artefacto es el producto final del proceso de build (binario, imagen de contenedor, paquete), identificado con una versión o tag, listo para ejecutarse en cualquier ambiente compatible.',
+          points: 4,
+          order_index: 2,
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            '¿Por qué es preferible desplegar el mismo artefacto ya construido y testeado a distintos ambientes (staging, producción), en vez de reconstruirlo específicamente para cada uno?',
+          options: [
+            {
+              label:
+                'Garantiza que lo que se testeó es exactamente lo que se despliega, eliminando la posibilidad de que una reconstrucción para producción introduzca diferencias respecto a lo validado en staging',
+              value: 'a',
+            },
+            {
+              label:
+                'Reconstruir el artefacto por ambiente siempre es obligatorio',
+              value: 'b',
+            },
+            {
+              label: 'No hay ninguna diferencia real entre ambos enfoques',
+              value: 'c',
+            },
+            { label: 'Es más rápido reconstruir en cada ambiente', value: 'd' },
+          ],
+          correct_answer: { value: 'a' },
+          explanation:
+            'Este principio ("build once, deploy many") evita el clásico "funcionaba en staging pero no en producción" causado por diferencias sutiles entre dos builds distintos del mismo código.',
+          points: 4,
+          order_index: 3,
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            '¿Qué rol cumple un ambiente de staging (o un despliegue simulado en local) antes de promover un cambio a producción?',
+          options: [
+            {
+              label:
+                'Permite validar el despliegue y el comportamiento de la aplicación en condiciones similares a producción, detectando problemas antes de que afecten a usuarios reales',
+              value: 'a',
+            },
+            {
+              label: 'Es un ambiente decorativo sin ningún propósito técnico',
+              value: 'b',
+            },
+            {
+              label: 'Reemplaza completamente la necesidad de tener producción',
+              value: 'c',
+            },
+            { label: 'Solo sirve para almacenar backups', value: 'd' },
+          ],
+          correct_answer: { value: 'a' },
+          explanation:
+            'Staging actúa como una red de seguridad: problemas de configuración, integración o infraestructura que no aparecen en el entorno local del desarrollador suelen salir a la luz ahí, antes de impactar usuarios reales.',
+          points: 4,
+          order_index: 4,
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            'Si un despliegue automatizado a producción falla a mitad de camino, ¿qué característica del pipeline CD ayuda a minimizar el impacto en los usuarios?',
+          options: [
+            {
+              label:
+                'La capacidad de hacer rollback: volver automáticamente, o con un solo comando, a la última versión conocida como buena',
+              value: 'a',
+            },
+            {
+              label: 'Aumentar manualmente el tamaño del servidor',
+              value: 'b',
+            },
+            { label: 'Reiniciar la base de datos completa', value: 'c' },
+            {
+              label:
+                'Esperar a que el equipo llegue a la oficina al día siguiente',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'a' },
+          explanation:
+            'Un rollback rápido y confiable es lo que convierte un despliegue fallido en un incidente menor (unos minutos de downtime) en vez de uno grave (horas debuggeando en producción bajo presión).',
+          points: 4,
+          order_index: 5,
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            '¿Qué significa que un proceso de despliegue sea "idempotente"?',
+          options: [
+            {
+              label:
+                'Que ejecutar el mismo proceso de despliegue varias veces produce el mismo resultado final, sin efectos secundarios acumulativos por repetirlo',
+              value: 'a',
+            },
+            {
+              label:
+                'Que el despliegue solo puede ejecutarse una única vez en la vida del proyecto',
+              value: 'b',
+            },
+            {
+              label:
+                'Que el despliegue siempre falla la segunda vez que se ejecuta',
+              value: 'c',
+            },
+            {
+              label: 'Que requiere aprobación manual cada vez que se corre',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'a' },
+          explanation:
+            'La idempotencia en despliegues es clave para poder reintentar con confianza: si algo falla a mitad de camino, volver a correr el mismo proceso no debería dejar el sistema en un estado peor o inconsistente.',
+          points: 4,
+          order_index: 6,
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            '¿Por qué automatizar el despliegue (en vez de conectarse manualmente al servidor a ejecutar comandos) reduce el riesgo de errores humanos?',
+          options: [
+            {
+              label:
+                'El proceso queda definido como código versionado y repetible, eliminando pasos manuales propensos a olvidos, errores de tipeo o inconsistencias entre un despliegue y el siguiente',
+              value: 'a',
+            },
+            {
+              label: 'Los despliegues manuales son técnicamente imposibles',
+              value: 'b',
+            },
+            {
+              label:
+                'La automatización elimina por completo la necesidad de monitoreo',
+              value: 'c',
+            },
+            {
+              label: 'No hay diferencia real en el riesgo entre ambos enfoques',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'a' },
+          explanation:
+            'Un despliegue manual depende de que una persona recuerde cada paso exacto, en el orden correcto, cada vez. Un script o pipeline versionado ejecuta siempre la misma secuencia, eliminando esa variabilidad.',
+          points: 4,
+          order_index: 7,
+        },
+        {
+          question_type: 'true_false',
+          prompt:
+            'En un pipeline CD bien diseñado, desplegar a producción no debería requerir que una persona ejecute comandos manuales conectada directamente al servidor de destino.',
+          correct_answer: { value: true },
+          explanation:
+            'Ese es justamente el objetivo de CD: todo el proceso de despliegue queda automatizado y repetible desde el pipeline, sin pasos manuales ad-hoc que dependan de la memoria o disponibilidad de una persona específica.',
+          points: 4,
+          order_index: 8,
+        },
+      ],
+    },
+    {
+      slug: 'buenas-practicas',
+      title: 'Buenas prácticas DevOps',
+      description:
+        'Versionado con Conventional Commits, repositorio limpio, .gitignore y documentación mínima necesaria en el README.',
+      order_index: 3,
+      max_score: 32,
+      metadata: {
+        instructions:
+          'Preguntas sobre versionado, organización del repositorio y documentación mínima de un proyecto.',
+        suggestedMinutes: 11,
+      },
+      questions: [
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            '¿Qué ventaja aporta seguir una convención como Conventional Commits (feat:, fix:, chore:, etc.) en los mensajes de commit?',
+          options: [
+            {
+              label:
+                'Facilita generar changelogs automáticos, entender el historial de cambios de un vistazo, y en algunos flujos determinar automáticamente el próximo número de versión (versionado semántico)',
+              value: 'a',
+            },
+            { label: 'Hace que Git compile el código más rápido', value: 'b' },
+            { label: 'Es un requisito técnico obligatorio de Git', value: 'c' },
+            {
+              label: 'No aporta ningún beneficio real, es solo estética',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'a' },
+          explanation:
+            'Un historial con mensajes consistentes y categorizados (feat/fix/chore) puede procesarse con herramientas automáticas para generar releases y changelogs, y es mucho más fácil de navegar para cualquier persona del equipo.',
+          points: 4,
+          order_index: 1,
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            '¿Qué tipo de archivos NO deberían versionarse en el repositorio Git de un proyecto backend?',
+          options: [
+            {
+              label:
+                'Archivos con secretos o credenciales reales (por ejemplo un .env con valores de producción), artefactos de build (bin/, obj/, node_modules/) y archivos generados localmente que no aportan al código fuente',
+              value: 'a',
+            },
+            { label: 'El código fuente de la aplicación', value: 'b' },
+            {
+              label:
+                'Los archivos de configuración de CI (por ejemplo el pipeline YAML)',
+              value: 'c',
+            },
+            { label: 'El README del proyecto', value: 'd' },
+          ],
+          correct_answer: { value: 'a' },
+          explanation:
+            'Commitear secretos los expone permanentemente en el historial; commitear artefactos de build genera diffs enormes e inútiles y desincroniza fácilmente con el código fuente real.',
+          points: 4,
+          order_index: 2,
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            '¿Para qué sirve un archivo .gitignore bien configurado en un proyecto?',
+          options: [
+            {
+              label:
+                'Evitar que archivos generados automáticamente, dependencias descargadas o configuración local/sensible terminen commiteados por error al repositorio',
+              value: 'a',
+            },
+            {
+              label:
+                'Bloquear el acceso de otros desarrolladores al repositorio',
+              value: 'b',
+            },
+            {
+              label: 'Eliminar archivos del disco duro del servidor',
+              value: 'c',
+            },
+            {
+              label: 'Encriptar automáticamente el contenido del repositorio',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'a' },
+          explanation:
+            '.gitignore es una lista de patrones que Git ignora al hacer `git add`, funcionando como una primera línea de defensa contra commits accidentales de archivos que no deberían estar versionados.',
+          points: 4,
+          order_index: 3,
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            '¿Qué información mínima debería tener un buen README para que otra persona del equipo pueda levantar el proyecto localmente sin tener que preguntar?',
+          options: [
+            {
+              label:
+                'Cómo instalar las dependencias, cómo configurar las variables de entorno necesarias, y el comando exacto para correr el proyecto (y correr los tests) localmente',
+              value: 'a',
+            },
+            {
+              label: 'Solo el nombre del proyecto y el nombre del autor',
+              value: 'b',
+            },
+            {
+              label: 'Una lista de todos los commits realizados hasta la fecha',
+              value: 'c',
+            },
+            {
+              label:
+                'No hace falta ninguna información, el código se explica solo',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'a' },
+          explanation:
+            'El README es la primera puerta de entrada al proyecto para cualquier persona nueva (incluido el "yo" de dentro de seis meses); sin esos pasos básicos, cada onboarding depende de preguntar a alguien más.',
+          points: 4,
+          order_index: 4,
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            '¿Por qué es una buena práctica trabajar en ramas de feature (feature branches) en vez de commitear directamente sobre la rama principal?',
+          options: [
+            {
+              label:
+                'Aísla los cambios en progreso, permite que el pipeline CI valide el cambio dentro de un Pull Request antes de integrarlo, y facilita el code review previo al merge',
+              value: 'a',
+            },
+            {
+              label:
+                'Git no permite hacer commits directos sobre la rama principal',
+              value: 'b',
+            },
+            {
+              label:
+                'Las ramas de feature son obligatorias para que el código compile',
+              value: 'c',
+            },
+            {
+              label:
+                'No aporta ninguna ventaja real sobre commitear directo a main',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'a' },
+          explanation:
+            'Trabajar en una rama separada da la oportunidad de validar el cambio (CI + review humano) antes de que impacte a todo el equipo a través de la rama principal, reduciendo el riesgo de romper el trabajo de otros.',
+          points: 4,
+          order_index: 5,
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            '¿Qué problema genera dejar acumular código comentado, archivos de prueba temporales y TODOs sin resolver en el repositorio a lo largo del tiempo?',
+          options: [
+            {
+              label:
+                'Genera ruido que dificulta entender qué código está realmente en uso, aumenta la carga cognitiva para futuros lectores del código, y puede esconder deuda técnica real sin que nadie la vea',
+              value: 'a',
+            },
+            {
+              label: 'Mejora el rendimiento de la aplicación en producción',
+              value: 'b',
+            },
+            {
+              label: 'No genera ningún problema real a largo plazo',
+              value: 'c',
+            },
+            { label: 'Hace que el pipeline CI corra más rápido', value: 'd' },
+          ],
+          correct_answer: { value: 'a' },
+          explanation:
+            'Un repositorio con mucho "ruido" (código muerto, archivos sueltos, TODOs olvidados) hace que sea más difícil distinguir lo intencional de lo accidental, y esconde problemas reales entre el desorden.',
+          points: 4,
+          order_index: 6,
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            '¿Por qué es importante que el historial de commits sea legible (mensajes claros, commits de tamaño razonable), en vez de un único commit gigante titulado "cambios varios"?',
+          options: [
+            {
+              label:
+                'Facilita hacer code review, entender por qué se hizo un cambio específico (usando git blame/log), y revertir selectivamente una parte del trabajo si algo sale mal, sin tener que deshacer todo junto',
+              value: 'a',
+            },
+            {
+              label: 'Git rechaza directamente los commits grandes',
+              value: 'b',
+            },
+            {
+              label:
+                'Los commits pequeños ocupan menos espacio en disco de forma significativa',
+              value: 'c',
+            },
+            {
+              label:
+                'No hay ninguna ventaja real en tener un historial legible',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'a' },
+          explanation:
+            'Un historial granular y bien descrito convierte a git log/blame en una herramienta de diagnóstico útil; un solo commit gigante obliga a revisar todo el diff junto para entender cualquier cambio puntual.',
+          points: 4,
+          order_index: 7,
+        },
+        {
+          question_type: 'true_false',
+          prompt:
+            'Un repositorio se considera "limpio" únicamente si el código compila sin errores, sin importar si contiene archivos innecesarios, secretos hardcodeados o un README desactualizado.',
+          correct_answer: { value: false },
+          explanation:
+            'Que compile es una condición necesaria pero no suficiente. Un repositorio limpio también implica ausencia de secretos expuestos, archivos irrelevantes versionados y documentación que refleje el estado real del proyecto.',
+          points: 4,
+          order_index: 8,
+        },
+      ],
+    },
+  ],
+};

--- a/apps/frontend/src/app/assessments/cicd-fundamentals/lib/gamification.ts
+++ b/apps/frontend/src/app/assessments/cicd-fundamentals/lib/gamification.ts
@@ -1,0 +1,14 @@
+import { createAssessmentGamification } from '../../_shared/lib/gamification';
+
+const gamification = createAssessmentGamification({
+  prefix: 'CICD_FUNDAMENTALS',
+  descriptions: {
+    completed: 'Completar el assessment CI/CD Fundamentals',
+    passed: 'Aprobar el assessment CI/CD Fundamentals (score >= 70)',
+    highScore: 'Score sobresaliente en CI/CD Fundamentals (>= 90)',
+  },
+});
+
+export const CICD_FUNDAMENTALS_GAMIFICATION_RULES = gamification.rules;
+
+export const buildCicdFundamentalsGamificationEvents = gamification.buildEvents;

--- a/apps/frontend/src/app/assessments/cicd-fundamentals/lib/seed.ts
+++ b/apps/frontend/src/app/assessments/cicd-fundamentals/lib/seed.ts
@@ -1,0 +1,12 @@
+import { ensureAssessmentSeeded } from '../../_shared/lib/seed';
+import {
+  CICD_FUNDAMENTALS_SEED_VERSION,
+  cicdFundamentalsDefinition,
+} from '../data/assessment-definition';
+
+export async function ensureCicdFundamentalsSeeded() {
+  return ensureAssessmentSeeded(
+    cicdFundamentalsDefinition,
+    CICD_FUNDAMENTALS_SEED_VERSION
+  );
+}

--- a/apps/frontend/src/app/assessments/cicd-fundamentals/page.tsx
+++ b/apps/frontend/src/app/assessments/cicd-fundamentals/page.tsx
@@ -1,0 +1,88 @@
+import { Metadata } from 'next';
+import { cicdFundamentalsDefinition } from './data/assessment-definition';
+import AssessmentWelcome from '../_shared/components/AssessmentWelcome';
+
+export const metadata: Metadata = {
+  title: 'CI/CD — Fundamentos | AIQUAA',
+  description:
+    'Prueba técnica teórica para bootcamp de desarrollo: pipelines de integración continua (restore/build/test), despliegue continuo automatizado y buenas prácticas DevOps de versionado.',
+  keywords: [
+    'CI/CD',
+    'integración continua',
+    'despliegue continuo',
+    'pipeline',
+    'Conventional Commits',
+    'buenas prácticas DevOps',
+    'desarrollo backend',
+    'bootcamp',
+    'AIQUAA',
+    'evaluación técnica',
+  ],
+  openGraph: {
+    title: 'CI/CD — Fundamentos | AIQUAA',
+    description:
+      'Prueba técnica teórica sobre pipelines de CI, despliegue continuo y buenas prácticas de versionado.',
+    url: 'https://aiquaa.com/assessments/cicd-fundamentals',
+    siteName: 'AIQUAA',
+    type: 'website',
+    locale: 'es_PY',
+    images: [
+      {
+        url: '/api/og?title=CI%2FCD%20-%20Fundamentos&subtitle=Pipelines%2C%20deploy%20y%20buenas%20pr%C3%A1cticas&section=Assessments',
+        width: 1200,
+        height: 630,
+        alt: 'CI/CD Fundamentos - AIQUAA',
+      },
+    ],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'CI/CD — Fundamentos | AIQUAA',
+    description:
+      'Prueba técnica sobre pipelines de CI, despliegue continuo y buenas prácticas DevOps.',
+    images: [
+      '/api/og?title=CI%2FCD%20-%20Fundamentos&subtitle=Pipelines%2C%20deploy%20y%20buenas%20pr%C3%A1cticas&section=Assessments',
+    ],
+    creator: '@stevenayal',
+  },
+  alternates: {
+    canonical: 'https://aiquaa.com/assessments/cicd-fundamentals',
+  },
+};
+
+export default function CicdFundamentalsPage() {
+  const overview = {
+    assessment: {
+      id: 'static-cicd-fundamentals',
+      slug: cicdFundamentalsDefinition.slug,
+      title: cicdFundamentalsDefinition.title,
+      description: cicdFundamentalsDefinition.description,
+      level: cicdFundamentalsDefinition.level,
+      type: cicdFundamentalsDefinition.type,
+      duration_minutes: cicdFundamentalsDefinition.duration_minutes,
+      total_score: cicdFundamentalsDefinition.total_score,
+      is_active: cicdFundamentalsDefinition.is_active,
+      metadata: cicdFundamentalsDefinition.metadata,
+    },
+    sections: cicdFundamentalsDefinition.sections.map((section, index) => ({
+      id: `static-section-${index + 1}`,
+      assessment_id: 'static-cicd-fundamentals',
+      slug: section.slug,
+      title: section.title,
+      description: section.description,
+      order_index: section.order_index,
+      max_score: section.max_score,
+      metadata: section.metadata,
+    })),
+  };
+
+  return (
+    <AssessmentWelcome
+      overview={overview}
+      startHref="/assessments/cicd-fundamentals/start"
+      evaluatesCopy="Integración continua: restore, build y tests disparados automáticamente en cada cambio; despliegue continuo con artefactos versionados, idempotencia y rollback; buenas prácticas de versionado (Conventional Commits, .gitignore) y documentación mínima del repositorio."
+      scoringCopy="Automático en las 3 secciones: selección múltiple y verdadero/falso."
+      resultCopy="Score total, score por sección, fortalezas, debilidades y temas a reforzar."
+    />
+  );
+}

--- a/apps/frontend/src/app/assessments/cicd-fundamentals/result/page.tsx
+++ b/apps/frontend/src/app/assessments/cicd-fundamentals/result/page.tsx
@@ -1,0 +1,19 @@
+import { Suspense } from 'react';
+import AssessmentResultClient from '../../_shared/components/AssessmentResultClient';
+
+export default function CicdFundamentalsResultPage() {
+  return (
+    <Suspense
+      fallback={
+        <div className="min-h-screen flex items-center justify-center bg-slate-950">
+          <div className="h-10 w-10 animate-spin rounded-full border-t-2 border-cyan-400" />
+        </div>
+      }
+    >
+      <AssessmentResultClient
+        startHref="/assessments/cicd-fundamentals/start"
+        fallbackRecommendation="Repasá los conceptos de integración y despliegue continuo (CI/CD), Conventional Commits, y buenas prácticas de organización de un repositorio Git para un proyecto real."
+      />
+    </Suspense>
+  );
+}

--- a/apps/frontend/src/app/assessments/cicd-fundamentals/section/[sectionId]/page.tsx
+++ b/apps/frontend/src/app/assessments/cicd-fundamentals/section/[sectionId]/page.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import AssessmentSectionScreen from '../../../_shared/components/AssessmentSectionScreen';
+
+export default function CicdFundamentalsSectionPage() {
+  return <AssessmentSectionScreen basePath="/assessments/cicd-fundamentals" />;
+}

--- a/apps/frontend/src/app/assessments/cicd-fundamentals/start/page.tsx
+++ b/apps/frontend/src/app/assessments/cicd-fundamentals/start/page.tsx
@@ -1,0 +1,133 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { useTheme } from '@/contexts/ThemeContext';
+import { startAssessmentAttemptAction } from '@/actions/assessments';
+import ProcessCodeInput from '@/components/labs/ProcessCodeInput';
+import { CICD_FUNDAMENTALS_SLUG } from '../data/assessment-definition';
+
+export default function StartCicdFundamentalsPage() {
+  const router = useRouter();
+  const { isDarkMode } = useTheme();
+  const [processCode, setProcessCode] = useState('');
+  const [error, setError] = useState('');
+  const [isStarting, setIsStarting] = useState(false);
+
+  // Pre-fill desde ?code= (links de invitaciones/procesos de empresa)
+  useEffect(() => {
+    const codeParam = new URLSearchParams(window.location.search).get('code');
+    if (codeParam) setProcessCode(codeParam);
+  }, []);
+
+  async function handleStart() {
+    setError('');
+    setIsStarting(true);
+
+    try {
+      const result = await startAssessmentAttemptAction({
+        slug: CICD_FUNDAMENTALS_SLUG,
+        processCode,
+      });
+
+      if ('error' in result) {
+        setIsStarting(false);
+        setError(result.error);
+        return;
+      }
+
+      const { attempt, sectionSlug } = result;
+
+      if (!sectionSlug) {
+        setIsStarting(false);
+        setError('No se encontró la primera sección del assessment.');
+        return;
+      }
+
+      setIsStarting(false);
+      router.push(
+        `/assessments/cicd-fundamentals/section/${sectionSlug}?attempt=${attempt.id}`
+      );
+    } catch (startError) {
+      setIsStarting(false);
+      setError(
+        startError instanceof Error
+          ? startError.message
+          : 'No se pudo iniciar el assessment.'
+      );
+    }
+  }
+
+  return (
+    <div
+      className={`min-h-screen px-4 py-12 ${
+        isDarkMode ? 'bg-slate-950 text-white' : 'bg-slate-50 text-slate-900'
+      }`}
+    >
+      <div className="mx-auto max-w-3xl rounded-3xl border border-slate-800 bg-slate-900/80 p-8 text-slate-50 shadow-2xl shadow-cyan-950/20">
+        <p className="text-sm font-semibold uppercase tracking-[0.18em] text-cyan-200">
+          Preparación del intento
+        </p>
+        <h1 className="mt-3 text-3xl font-bold">CI/CD — Fundamentos</h1>
+        <p className="mt-3 text-slate-300">
+          Vas a completar 3 secciones teóricas con autosave, scoring por sección
+          y resultado final consolidado.
+        </p>
+
+        <div className="mt-8 grid gap-4 rounded-2xl border border-slate-800 bg-slate-950/70 p-5 md:grid-cols-3">
+          <div>
+            <p className="text-xs uppercase tracking-[0.18em] text-slate-400">
+              Duración sugerida
+            </p>
+            <p className="mt-2 text-lg font-semibold">~35 minutos</p>
+          </div>
+          <div>
+            <p className="text-xs uppercase tracking-[0.18em] text-slate-400">
+              Modalidad
+            </p>
+            <p className="mt-2 text-lg font-semibold">Conceptual</p>
+          </div>
+          <div>
+            <p className="text-xs uppercase tracking-[0.18em] text-slate-400">
+              Resultado
+            </p>
+            <p className="mt-2 text-lg font-semibold">Score total sobre 100</p>
+          </div>
+        </div>
+
+        <div className="mt-8">
+          <ProcessCodeInput
+            value={processCode}
+            onChange={setProcessCode}
+            onNormalizedCode={setProcessCode}
+            autoValidate
+          />
+        </div>
+
+        {error ? (
+          <div className="mt-6 rounded-2xl border border-red-500/30 bg-red-500/10 px-4 py-3 text-sm text-red-200">
+            {error}
+          </div>
+        ) : null}
+
+        <div className="mt-8 flex flex-col gap-3 sm:flex-row">
+          <button
+            type="button"
+            onClick={handleStart}
+            disabled={isStarting}
+            className="inline-flex items-center justify-center rounded-2xl bg-cyan-400 px-5 py-3 text-sm font-semibold text-slate-950 transition hover:bg-cyan-300 disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {isStarting ? 'Preparando intento...' : 'Iniciar o reanudar'}
+          </button>
+          <button
+            type="button"
+            onClick={() => router.push('/assessments/cicd-fundamentals')}
+            className="inline-flex items-center justify-center rounded-2xl border border-slate-700 px-5 py-3 text-sm font-semibold text-slate-200 transition hover:bg-slate-800"
+          >
+            Volver al overview
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/src/app/assessments/docker-fundamentals/__tests__/definition.test.ts
+++ b/apps/frontend/src/app/assessments/docker-fundamentals/__tests__/definition.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { assertAssessmentDefinitionConsistency } from '../../_shared/testing/assessment-definition-checks';
+import {
+  DOCKER_FUNDAMENTALS_SEED_VERSION,
+  DOCKER_FUNDAMENTALS_SLUG,
+  dockerFundamentalsDefinition,
+} from '../data/assessment-definition';
+import { ASSESSMENT_REGISTRY } from '../../_shared/registry';
+
+describe('docker-fundamentals definition', () => {
+  it('mantiene presupuestos de puntos y answer keys consistentes', () => {
+    assertAssessmentDefinitionConsistency(dockerFundamentalsDefinition);
+  });
+
+  it('define 3 secciones teóricas sobre 100 puntos', () => {
+    expect(dockerFundamentalsDefinition.sections).toHaveLength(3);
+    expect(dockerFundamentalsDefinition.total_score).toBe(100);
+    expect(dockerFundamentalsDefinition.slug).toBe(DOCKER_FUNDAMENTALS_SLUG);
+  });
+
+  it('está registrado con el seedVersion correcto', () => {
+    const entry = ASSESSMENT_REGISTRY[DOCKER_FUNDAMENTALS_SLUG];
+    expect(entry).toBeDefined();
+    expect(entry.seedVersion).toBe(DOCKER_FUNDAMENTALS_SEED_VERSION);
+    expect(entry.examType).toBe('docker-fundamentals');
+  });
+});

--- a/apps/frontend/src/app/assessments/docker-fundamentals/data/assessment-definition.ts
+++ b/apps/frontend/src/app/assessments/docker-fundamentals/data/assessment-definition.ts
@@ -1,0 +1,689 @@
+import type { AssessmentSeedDefinition } from '../../_shared/types';
+
+export const DOCKER_FUNDAMENTALS_SLUG = 'docker-fundamentals';
+
+// Bumpear cuando cambie la definición (secciones/preguntas) para forzar re-seed.
+export const DOCKER_FUNDAMENTALS_SEED_VERSION = 1;
+
+export const dockerFundamentalsDefinition: AssessmentSeedDefinition = {
+  slug: DOCKER_FUNDAMENTALS_SLUG,
+  title: 'Docker — Fundamentos',
+  description:
+    'Evaluación teórica de Docker para bootcamp de desarrollo backend: construcción correcta de Dockerfiles (multistage, imágenes livianas), manejo de variables de entorno sin hardcodear configuración, y ejecución/reproducibilidad local de contenedores.',
+  level: 'Trainee a Junior',
+  type: 'Desarrollo DevOps',
+  duration_minutes: 35,
+  total_score: 100,
+  is_active: true,
+  metadata: {
+    moduleName: 'AIQUAA Assessments / Docker Fundamentals',
+    passingScore: 70,
+    candidateBands: [
+      { min: 0, max: 39, label: 'Inicial' },
+      { min: 40, max: 59, label: 'En formación' },
+      { min: 60, max: 74, label: 'Trainee' },
+      { min: 75, max: 89, label: 'Junior' },
+      { min: 90, max: 100, label: 'Junior avanzado' },
+    ],
+  },
+  sections: [
+    {
+      slug: 'dockerfile-correcto',
+      title: 'Dockerfile correcto',
+      description:
+        'Multistage builds, imágenes livianas, orden de capas, .dockerignore y buenas prácticas de construcción de una imagen productiva.',
+      order_index: 1,
+      max_score: 36,
+      metadata: {
+        instructions:
+          'Selección múltiple y verdadero/falso sobre construcción de Dockerfiles para aplicaciones backend.',
+        suggestedMinutes: 13,
+      },
+      questions: [
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            '¿Qué es un multi-stage build en Docker y para qué sirve principalmente?',
+          options: [
+            {
+              label:
+                'Usar múltiples instrucciones FROM en un mismo Dockerfile para separar la etapa de compilación de la etapa final, copiando solo los artefactos necesarios y dejando afuera el SDK y el código fuente',
+              value: 'a',
+            },
+            {
+              label:
+                'Ejecutar el mismo contenedor en varios servidores a la vez',
+              value: 'b',
+            },
+            {
+              label:
+                'Construir varias imágenes completamente independientes en paralelo sin relación entre sí',
+              value: 'c',
+            },
+            {
+              label:
+                'Una forma de versionar el Dockerfile en distintas ramas de Git',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'a' },
+          explanation:
+            'Cada FROM abre una nueva "stage". Una etapa temprana compila con el SDK completo; la etapa final parte de una imagen liviana y usa COPY --from para traer solo el resultado compilado, sin las herramientas de build.',
+          points: 4,
+          order_index: 1,
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            '¿Por qué conviene usar una imagen base liviana (por ejemplo una variante "slim" o "alpine", o la imagen de runtime en vez de la de SDK) para la etapa final de runtime?',
+          options: [
+            {
+              label:
+                'Reduce el tamaño final de la imagen y la superficie de ataque: la imagen de SDK trae compiladores y herramientas que no hacen falta para ejecutar la app en producción',
+              value: 'a',
+            },
+            {
+              label: 'Porque las imágenes livianas corren más rápido el código',
+              value: 'b',
+            },
+            {
+              label:
+                'Porque Docker no permite usar imágenes grandes en producción',
+              value: 'c',
+            },
+            {
+              label: 'No hay ninguna diferencia real, es solo preferencia',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'a' },
+          explanation:
+            'Una imagen de runtime liviana descarga más rápido, ocupa menos espacio y expone menos herramientas/paquetes que un atacante podría aprovechar si compromete el contenedor.',
+          points: 4,
+          order_index: 2,
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            '¿Qué hace la instrucción `COPY --from=build /app/publish .` en la etapa final de un Dockerfile multistage?',
+          options: [
+            {
+              label:
+                'Copia los artefactos ya compilados/publicados desde la etapa llamada "build" hacia la imagen final, sin traer el código fuente ni las dependencias de compilación',
+              value: 'a',
+            },
+            {
+              label: 'Descarga el proyecto directamente desde GitHub',
+              value: 'b',
+            },
+            {
+              label: 'Copia toda la imagen "build" completa, incluyendo el SDK',
+              value: 'c',
+            },
+            {
+              label:
+                'Ejecuta los tests del proyecto dentro del contenedor final',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'a' },
+          explanation:
+            'COPY --from referencia una stage anterior por su nombre (definido con `FROM ... AS build`) y copia solo la ruta indicada, que típicamente son los binarios o artefactos ya listos para ejecutar.',
+          points: 4,
+          order_index: 3,
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            'En un Dockerfile de una API, ¿por qué conviene copiar primero el archivo de dependencias (por ejemplo el .csproj o package.json) y correr el restore/install, antes de copiar el resto del código fuente?',
+          options: [
+            {
+              label:
+                'Porque Docker cachea cada capa: si el código fuente cambia pero las dependencias no, la capa de restore se reutiliza desde cache y el build es mucho más rápido',
+              value: 'a',
+            },
+            {
+              label:
+                'Porque Docker exige ese orden específico o falla el build',
+              value: 'b',
+            },
+            {
+              label:
+                'Porque así el archivo de dependencias queda oculto en la imagen final',
+              value: 'c',
+            },
+            {
+              label: 'No influye en nada, es solo una convención estética',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'a' },
+          explanation:
+            'Cada instrucción genera una capa cacheable. Si se copia todo el código junto con el archivo de dependencias, cualquier cambio en el código invalida también la capa de restore, forzando a reinstalar dependencias en cada build.',
+          points: 4,
+          order_index: 4,
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt: '¿Para qué sirve el archivo .dockerignore?',
+          options: [
+            {
+              label:
+                'Excluir archivos y carpetas (como bin/, obj/, node_modules/, .git/) del contexto que se envía al build, reduciendo el tamaño del contexto y evitando copiar artefactos locales o información sensible',
+              value: 'a',
+            },
+            {
+              label: 'Definir qué contenedores se ignoran al hacer docker ps',
+              value: 'b',
+            },
+            {
+              label: 'Bloquear el acceso a internet del contenedor',
+              value: 'c',
+            },
+            {
+              label: 'Configurar qué puertos quedan cerrados por firewall',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'a' },
+          explanation:
+            'Funciona igual que .gitignore pero para el contexto de build de Docker: evita que carpetas pesadas o irrelevantes (y potencialmente archivos con secretos locales) terminen dentro de la imagen o ralenticen el build.',
+          points: 4,
+          order_index: 5,
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            '¿Por qué es una buena práctica correr el proceso final del contenedor con un usuario no-root (por ejemplo, agregando `USER appuser` al final del Dockerfile)?',
+          options: [
+            {
+              label:
+                'Aplica el principio de menor privilegio: si un atacante compromete el proceso dentro del contenedor, no obtiene privilegios de root sobre el sistema de archivos del contenedor',
+              value: 'a',
+            },
+            {
+              label: 'Porque los contenedores root consumen más memoria',
+              value: 'b',
+            },
+            {
+              label: 'Porque Docker no permite ejecutar procesos como root',
+              value: 'c',
+            },
+            {
+              label: 'Es solo una preferencia estética sin impacto real',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'a' },
+          explanation:
+            'Por defecto los contenedores corren como root si no se especifica lo contrario. Definir un usuario sin privilegios reduce el impacto de una eventual explotación del proceso dentro del contenedor.',
+          points: 4,
+          order_index: 6,
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            '¿Qué problema genera usar `FROM node:latest` (o cualquier imagen base con tag "latest") en el Dockerfile de un proyecto que se va a mantener en el tiempo?',
+          options: [
+            {
+              label:
+                'El build deja de ser reproducible: "latest" apunta a una versión distinta según cuándo se construya la imagen, por lo que el mismo Dockerfile puede producir resultados diferentes en distintos momentos',
+              value: 'a',
+            },
+            {
+              label: 'Docker no permite usar la tag "latest" en producción',
+              value: 'b',
+            },
+            {
+              label: 'La imagen queda encriptada y no se puede correr',
+              value: 'c',
+            },
+            {
+              label: 'No genera ningún problema, es la práctica recomendada',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'a' },
+          explanation:
+            'Pinear una versión específica (por ejemplo node:20.11-slim) garantiza que reconstruir la imagen hoy o dentro de seis meses parta de la misma base, evitando sorpresas por cambios en la imagen "latest".',
+          points: 4,
+          order_index: 7,
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            '¿Cuál es la diferencia principal entre CMD y ENTRYPOINT en un Dockerfile?',
+          options: [
+            {
+              label:
+                'ENTRYPOINT define el ejecutable fijo del contenedor; CMD define argumentos por defecto que se pueden sobreescribir al ejecutar `docker run <imagen> <otro-comando>`',
+              value: 'a',
+            },
+            {
+              label: 'Son exactamente lo mismo, se usan indistintamente',
+              value: 'b',
+            },
+            {
+              label: 'CMD solo funciona en Linux y ENTRYPOINT solo en Windows',
+              value: 'c',
+            },
+            {
+              label: 'ENTRYPOINT se ejecuta en build-time y CMD en runtime',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'a' },
+          explanation:
+            'ENTRYPOINT fija el proceso principal del contenedor; CMD aporta argumentos por defecto para ese proceso (o el comando completo si no hay ENTRYPOINT), y es lo primero que se reemplaza si se pasan argumentos extra a docker run.',
+          points: 4,
+          order_index: 8,
+        },
+        {
+          question_type: 'true_false',
+          prompt:
+            'Combinar varias instrucciones RUN relacionadas en una sola (por ejemplo, `RUN apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/*`) ayuda a reducir la cantidad de capas y el tamaño final de la imagen.',
+          correct_answer: { value: true },
+          explanation:
+            'Cada RUN crea una capa nueva. Encadenar comandos relacionados en una sola instrucción evita capas intermedias con archivos temporales que después no se pueden limpiar sin agregar aún más capas.',
+          points: 4,
+          order_index: 9,
+        },
+      ],
+    },
+    {
+      slug: 'variables-de-entorno',
+      title: 'Variables de entorno',
+      description:
+        'Uso correcto de ARG y ENV, por qué no hardcodear configuración sensible en la imagen, y cómo inyectar configuración por ambiente.',
+      order_index: 2,
+      max_score: 32,
+      metadata: {
+        instructions:
+          'Preguntas sobre manejo de configuración y secretos en Dockerfiles, docker run y docker-compose.',
+        suggestedMinutes: 11,
+      },
+      questions: [
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            '¿Cuál es la diferencia principal entre ARG y ENV en un Dockerfile?',
+          options: [
+            {
+              label:
+                'ARG solo existe durante el proceso de build (no queda disponible en el contenedor en runtime); ENV define una variable que persiste y está disponible cuando el contenedor está corriendo',
+              value: 'a',
+            },
+            {
+              label: 'Son sinónimos, ambos hacen exactamente lo mismo',
+              value: 'b',
+            },
+            {
+              label: 'ARG es para strings y ENV solo para números',
+              value: 'c',
+            },
+            {
+              label:
+                'ENV solo funciona dentro de docker-compose, nunca en un Dockerfile',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'a' },
+          explanation:
+            'ARG se usa para parametrizar el build (por ejemplo, una versión a instalar) y no queda accesible en el contenedor final salvo que se copie explícitamente a un ENV. ENV sí persiste como variable de entorno del proceso en runtime.',
+          points: 4,
+          order_index: 1,
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            '¿Por qué NO es buena práctica escribir `ENV DB_PASSWORD=superSecreto123` directamente en el Dockerfile de un proyecto real?',
+          options: [
+            {
+              label:
+                'El valor queda embebido en la imagen (visible con `docker history` o inspeccionando las capas) y no puede cambiar por ambiente sin reconstruir la imagen; además suele terminar versionado en el repositorio',
+              value: 'a',
+            },
+            {
+              label: 'Docker no permite usar ENV para contraseñas',
+              value: 'b',
+            },
+            { label: 'ENV solo acepta valores numéricos', value: 'c' },
+            {
+              label: 'No hay ningún problema, es la forma recomendada',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'a' },
+          explanation:
+            'Cualquiera con acceso a la imagen (o al Dockerfile en el repo) puede leer ese secreto. La configuración sensible debe inyectarse en runtime (variables de entorno externas, secret manager, Secrets de Kubernetes), nunca hardcodeada en la imagen.',
+          points: 4,
+          order_index: 2,
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            '¿Cuál es la forma correcta de pasarle a un contenedor la URL de la base de datos, sabiendo que va a ser distinta en desarrollo, staging y producción?',
+          options: [
+            {
+              label:
+                'Inyectarla en runtime como variable de entorno (`docker run -e DB_URL=... ` / `--env-file` / o vía Secrets/ConfigMaps si corre en Kubernetes), no hardcodeada en el Dockerfile',
+              value: 'a',
+            },
+            {
+              label:
+                'Escribir tres Dockerfiles distintos, uno por ambiente, cada uno con su URL fija',
+              value: 'b',
+            },
+            {
+              label: 'Hardcodearla en el código fuente de la aplicación',
+              value: 'c',
+            },
+            {
+              label:
+                'No es necesario configurarla, Docker la detecta automáticamente',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'a' },
+          explanation:
+            'La misma imagen debe poder correr en cualquier ambiente; lo que cambia es la configuración externa que se le inyecta en runtime, no el contenido de la imagen (principio de 12-factor app).',
+          points: 4,
+          order_index: 3,
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            '¿Qué comando permite inspeccionar el historial de capas de una imagen, lo que puede revelar secretos hardcodeados por error en instrucciones RUN o ENV?',
+          options: [
+            { label: 'docker history <imagen>', value: 'a' },
+            { label: 'docker ps -a', value: 'b' },
+            { label: 'docker network ls', value: 'c' },
+            { label: 'docker volume prune', value: 'd' },
+          ],
+          correct_answer: { value: 'a' },
+          explanation:
+            'docker history muestra cada capa y el comando que la generó. Si un secreto se escribió en una instrucción ENV o RUN, suele quedar visible ahí (o extraíble de la capa) aunque se haya "borrado" en una instrucción posterior.',
+          points: 4,
+          order_index: 4,
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            'En un docker-compose.yml, ¿para qué sirve la clave `env_file`?',
+          options: [
+            {
+              label:
+                'Cargar variables de entorno desde un archivo externo (ej. .env, que no se versiona) en vez de escribir los valores directamente en el compose file que sí queda en el repositorio',
+              value: 'a',
+            },
+            { label: 'Definir el nombre del contenedor', value: 'b' },
+            { label: 'Especificar qué imagen base usar', value: 'c' },
+            { label: 'Configurar el healthcheck del servicio', value: 'd' },
+          ],
+          correct_answer: { value: 'a' },
+          explanation:
+            'env_file apunta a un archivo (típicamente ignorado por git) con los valores reales, mientras que el docker-compose.yml versionado solo referencia el archivo, sin exponer los secretos en el control de versiones.',
+          points: 4,
+          order_index: 5,
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            '¿Por qué es preferible que una misma imagen Docker sea configurable por variables de entorno en vez de tener el ambiente "quemado" en el build?',
+          options: [
+            {
+              label:
+                'Permite construir la imagen una sola vez y promoverla sin cambios entre dev, staging y producción, cambiando solo la configuración externa en cada ambiente',
+              value: 'a',
+            },
+            {
+              label: 'Porque así la imagen ocupa menos espacio en disco',
+              value: 'b',
+            },
+            {
+              label: 'Porque Docker Hub lo exige para publicar imágenes',
+              value: 'c',
+            },
+            { label: 'No hay ninguna ventaja real en hacerlo así', value: 'd' },
+          ],
+          correct_answer: { value: 'a' },
+          explanation:
+            'Si cada ambiente requiere reconstruir la imagen con su propia configuración, se pierde la garantía de que "lo que se testeó es lo que se despliega". Separar build de configuración es central en el enfoque 12-factor.',
+          points: 4,
+          order_index: 6,
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            '¿Qué riesgo concreto tiene commitear al repositorio un archivo .env con credenciales reales de producción?',
+          options: [
+            {
+              label:
+                'Las credenciales quedan expuestas en el historial de Git de forma permanente, accesibles para cualquiera con acceso al repositorio (incluso si después se borra el archivo)',
+              value: 'a',
+            },
+            { label: 'El proyecto deja de compilar', value: 'b' },
+            { label: 'Docker rechaza construir la imagen', value: 'c' },
+            {
+              label: 'No hay ningún riesgo real si el repositorio es privado',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'a' },
+          explanation:
+            'Borrar el archivo en un commit posterior no elimina el secreto del historial de Git; sigue siendo recuperable. Por eso .env (y cualquier archivo con secretos reales) debe estar en .gitignore desde el principio.',
+          points: 4,
+          order_index: 7,
+        },
+        {
+          question_type: 'true_false',
+          prompt:
+            'Las variables definidas con ENV en el Dockerfile pueden sobreescribirse al correr el contenedor con `docker run -e VARIABLE=nuevo_valor`.',
+          correct_answer: { value: true },
+          explanation:
+            'ENV en el Dockerfile define un valor por defecto; `docker run -e` (o `--env-file`) lo sobreescribe en runtime sin necesidad de reconstruir la imagen.',
+          points: 4,
+          order_index: 8,
+        },
+      ],
+    },
+    {
+      slug: 'ejecucion-local',
+      title: 'Ejecución local',
+      description:
+        'Construcción y ejecución de contenedores, mapeo de puertos, healthchecks, docker-compose y herramientas básicas de debugging.',
+      order_index: 3,
+      max_score: 32,
+      metadata: {
+        instructions:
+          'Preguntas sobre el ciclo de build/run local y reproducibilidad del entorno de desarrollo con Docker.',
+        suggestedMinutes: 11,
+      },
+      questions: [
+        {
+          question_type: 'multiple_choice',
+          prompt: '¿Qué hace el comando `docker build -t myapp:1.0 .`?',
+          options: [
+            {
+              label:
+                'Construye una imagen a partir del Dockerfile encontrado en el directorio actual (usado como contexto de build) y la etiqueta como myapp:1.0',
+              value: 'a',
+            },
+            {
+              label: 'Ejecuta el contenedor myapp:1.0 en modo detached',
+              value: 'b',
+            },
+            {
+              label: 'Descarga la imagen myapp:1.0 desde Docker Hub',
+              value: 'c',
+            },
+            {
+              label: 'Elimina todas las imágenes locales llamadas myapp',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'a' },
+          explanation:
+            'El punto final (.) indica el contexto de build (el directorio que se envía al daemon de Docker), -t asigna nombre y tag a la imagen resultante. Todavía no ejecuta nada, solo construye la imagen.',
+          points: 4,
+          order_index: 1,
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            '¿Qué logra la opción `-p 8080:80` al ejecutar `docker run -p 8080:80 myapp`?',
+          options: [
+            {
+              label:
+                'Mapea el puerto 80 dentro del contenedor al puerto 8080 del host, permitiendo acceder a la app desde http://localhost:8080',
+              value: 'a',
+            },
+            {
+              label: 'Limita el contenedor a usar máximo 8080 MB de memoria',
+              value: 'b',
+            },
+            {
+              label: 'Define el número de réplicas del contenedor',
+              value: 'c',
+            },
+            { label: 'Establece un timeout de 8080 milisegundos', value: 'd' },
+          ],
+          correct_answer: { value: 'a' },
+          explanation:
+            'La sintaxis es `-p <puerto_host>:<puerto_contenedor>`. Sin este mapeo, el puerto 80 solo sería accesible dentro de la red interna de Docker, no desde el host.',
+          points: 4,
+          order_index: 2,
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt: '¿Qué es y para qué sirve un HEALTHCHECK en un Dockerfile?',
+          options: [
+            {
+              label:
+                'Define un comando que Docker ejecuta periódicamente dentro del contenedor para determinar si está "healthy" o "unhealthy", información que puede usar un orquestador para reiniciar o dejar de enrutar tráfico a ese contenedor',
+              value: 'a',
+            },
+            {
+              label:
+                'Verifica automáticamente si hay vulnerabilidades de seguridad en la imagen',
+              value: 'b',
+            },
+            {
+              label: 'Corre los tests unitarios del proyecto antes del build',
+              value: 'c',
+            },
+            { label: 'Genera un reporte de cobertura de código', value: 'd' },
+          ],
+          correct_answer: { value: 'a' },
+          explanation:
+            'HEALTHCHECK no reemplaza al monitoreo de la aplicación, pero le da a Docker (y a orquestadores como Kubernetes vía probes análogas) una señal simple de si el proceso interno responde correctamente.',
+          points: 4,
+          order_index: 3,
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            '¿Por qué conviene usar docker-compose para levantar en desarrollo local la API junto con sus dependencias (por ejemplo, una base de datos y un cache)?',
+          options: [
+            {
+              label:
+                'Reproducibilidad: un solo archivo versionado y un solo comando (`docker-compose up`) levantan todo el stack con la misma configuración de red y volúmenes para cualquier persona del equipo',
+              value: 'a',
+            },
+            {
+              label: 'Porque docker run no permite correr más de un contenedor',
+              value: 'b',
+            },
+            {
+              label:
+                'Porque es la única forma de conectar dos contenedores entre sí',
+              value: 'c',
+            },
+            {
+              label: 'Porque mejora el rendimiento de la CPU del host',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'a' },
+          explanation:
+            'Sin docker-compose también se pueden conectar contenedores manualmente (redes, docker run individuales), pero compose declara todo el stack en un archivo versionado, eliminando pasos manuales propensos a error y diferencias entre máquinas.',
+          points: 4,
+          order_index: 4,
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            '¿Qué comando permite ver los logs de un contenedor que ya está corriendo?',
+          options: [
+            {
+              label:
+                'docker logs <container> (agregando -f para seguirlos en tiempo real)',
+              value: 'a',
+            },
+            { label: 'docker inspect <container> --logs', value: 'b' },
+            { label: 'docker top <container>', value: 'c' },
+            { label: 'docker stats <container>', value: 'd' },
+          ],
+          correct_answer: { value: 'a' },
+          explanation:
+            'docker logs muestra la salida estándar/error del proceso principal del contenedor (PID 1). Es el primer lugar donde buscar cuando algo falla, antes de asumir que hace falta reconstruir la imagen.',
+          points: 4,
+          order_index: 5,
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            '¿Qué comando permite abrir una shell interactiva dentro de un contenedor que ya está corriendo, para inspeccionar archivos o procesos en vivo?',
+          options: [
+            { label: 'docker exec -it <container> /bin/sh', value: 'a' },
+            { label: 'docker create <container> --shell', value: 'b' },
+            { label: 'docker pull <container> --interactive', value: 'c' },
+            { label: 'docker commit <container>', value: 'd' },
+          ],
+          correct_answer: { value: 'a' },
+          explanation:
+            '-it habilita modo interactivo con una terminal asignada, y `/bin/sh` (o `/bin/bash` si la imagen lo tiene) abre una shell dentro del contenedor en ejecución, útil para debugging sin detenerlo.',
+          points: 4,
+          order_index: 6,
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            '¿Por qué pinear la versión exacta de la imagen base (por ejemplo `FROM node:20.11-slim` en vez de `FROM node`) ayuda a que el build sea reproducible entre distintas máquinas y momentos en el tiempo?',
+          options: [
+            {
+              label:
+                'Garantiza que el mismo Dockerfile parta siempre de la misma base, evitando que un build de hoy y otro de dentro de unos meses (o en la máquina de otro desarrollador) usen versiones distintas de la imagen base sin que nadie lo haya decidido',
+              value: 'a',
+            },
+            { label: 'Hace que el build sea más rápido siempre', value: 'b' },
+            {
+              label:
+                'Es un requisito obligatorio de Docker Hub para publicar imágenes',
+              value: 'c',
+            },
+            {
+              label: 'No tiene relación con la reproducibilidad del build',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'a' },
+          explanation:
+            'Sin una versión fija, "la imagen base" es un blanco móvil: el clásico "funciona en mi máquina" muchas veces se origina en que dos builds partieron de versiones distintas de la misma imagen "genérica".',
+          points: 4,
+          order_index: 7,
+        },
+        {
+          question_type: 'true_false',
+          prompt:
+            'Si un contenedor se detiene inesperadamente con un exit code distinto de 0, revisar `docker logs` del contenedor es un buen primer paso antes de asumir que hay que reescribir el Dockerfile.',
+          correct_answer: { value: true },
+          explanation:
+            'La mayoría de las veces el motivo está en la salida del proceso (una excepción no manejada, una variable de entorno faltante, un puerto ocupado). Los logs suelen apuntar directamente a la causa antes de tocar la imagen.',
+          points: 4,
+          order_index: 8,
+        },
+      ],
+    },
+  ],
+};

--- a/apps/frontend/src/app/assessments/docker-fundamentals/lib/gamification.ts
+++ b/apps/frontend/src/app/assessments/docker-fundamentals/lib/gamification.ts
@@ -1,0 +1,15 @@
+import { createAssessmentGamification } from '../../_shared/lib/gamification';
+
+const gamification = createAssessmentGamification({
+  prefix: 'DOCKER_FUNDAMENTALS',
+  descriptions: {
+    completed: 'Completar el assessment Docker Fundamentals',
+    passed: 'Aprobar el assessment Docker Fundamentals (score >= 70)',
+    highScore: 'Score sobresaliente en Docker Fundamentals (>= 90)',
+  },
+});
+
+export const DOCKER_FUNDAMENTALS_GAMIFICATION_RULES = gamification.rules;
+
+export const buildDockerFundamentalsGamificationEvents =
+  gamification.buildEvents;

--- a/apps/frontend/src/app/assessments/docker-fundamentals/lib/seed.ts
+++ b/apps/frontend/src/app/assessments/docker-fundamentals/lib/seed.ts
@@ -1,0 +1,12 @@
+import { ensureAssessmentSeeded } from '../../_shared/lib/seed';
+import {
+  DOCKER_FUNDAMENTALS_SEED_VERSION,
+  dockerFundamentalsDefinition,
+} from '../data/assessment-definition';
+
+export async function ensureDockerFundamentalsSeeded() {
+  return ensureAssessmentSeeded(
+    dockerFundamentalsDefinition,
+    DOCKER_FUNDAMENTALS_SEED_VERSION
+  );
+}

--- a/apps/frontend/src/app/assessments/docker-fundamentals/page.tsx
+++ b/apps/frontend/src/app/assessments/docker-fundamentals/page.tsx
@@ -1,0 +1,89 @@
+import { Metadata } from 'next';
+import { dockerFundamentalsDefinition } from './data/assessment-definition';
+import AssessmentWelcome from '../_shared/components/AssessmentWelcome';
+
+export const metadata: Metadata = {
+  title: 'Docker — Fundamentos | AIQUAA',
+  description:
+    'Prueba técnica teórica para bootcamp de desarrollo: Dockerfiles multistage e imágenes livianas, variables de entorno sin hardcode, y ejecución/reproducibilidad local de contenedores.',
+  keywords: [
+    'Docker',
+    'Dockerfile',
+    'multistage build',
+    'contenedores',
+    'variables de entorno',
+    'docker-compose',
+    'desarrollo backend',
+    'DevOps',
+    'bootcamp',
+    'AIQUAA',
+    'evaluación técnica',
+  ],
+  openGraph: {
+    title: 'Docker — Fundamentos | AIQUAA',
+    description:
+      'Prueba técnica teórica sobre Dockerfiles, variables de entorno y ejecución/reproducibilidad local de contenedores.',
+    url: 'https://aiquaa.com/assessments/docker-fundamentals',
+    siteName: 'AIQUAA',
+    type: 'website',
+    locale: 'es_PY',
+    images: [
+      {
+        url: '/api/og?title=Docker%20-%20Fundamentos&subtitle=Dockerfile%2C%20env%20vars%20y%20ejecuci%C3%B3n%20local&section=Assessments',
+        width: 1200,
+        height: 630,
+        alt: 'Docker Fundamentos - AIQUAA',
+      },
+    ],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Docker — Fundamentos | AIQUAA',
+    description:
+      'Prueba técnica sobre Dockerfiles, variables de entorno y ejecución local de contenedores.',
+    images: [
+      '/api/og?title=Docker%20-%20Fundamentos&subtitle=Dockerfile%2C%20env%20vars%20y%20ejecuci%C3%B3n%20local&section=Assessments',
+    ],
+    creator: '@stevenayal',
+  },
+  alternates: {
+    canonical: 'https://aiquaa.com/assessments/docker-fundamentals',
+  },
+};
+
+export default function DockerFundamentalsPage() {
+  const overview = {
+    assessment: {
+      id: 'static-docker-fundamentals',
+      slug: dockerFundamentalsDefinition.slug,
+      title: dockerFundamentalsDefinition.title,
+      description: dockerFundamentalsDefinition.description,
+      level: dockerFundamentalsDefinition.level,
+      type: dockerFundamentalsDefinition.type,
+      duration_minutes: dockerFundamentalsDefinition.duration_minutes,
+      total_score: dockerFundamentalsDefinition.total_score,
+      is_active: dockerFundamentalsDefinition.is_active,
+      metadata: dockerFundamentalsDefinition.metadata,
+    },
+    sections: dockerFundamentalsDefinition.sections.map((section, index) => ({
+      id: `static-section-${index + 1}`,
+      assessment_id: 'static-docker-fundamentals',
+      slug: section.slug,
+      title: section.title,
+      description: section.description,
+      order_index: section.order_index,
+      max_score: section.max_score,
+      metadata: section.metadata,
+    })),
+  };
+
+  return (
+    <AssessmentWelcome
+      overview={overview}
+      startHref="/assessments/docker-fundamentals/start"
+      evaluatesCopy="Dockerfiles multistage e imágenes livianas, orden de capas y .dockerignore; diferencia entre ARG y ENV y por qué no hardcodear configuración sensible; ejecución local, mapeo de puertos, healthchecks, docker-compose y comandos básicos de debugging."
+      scoringCopy="Automático en las 3 secciones: selección múltiple y verdadero/falso."
+      resultCopy="Score total, score por sección, fortalezas, debilidades y temas a reforzar."
+    />
+  );
+}

--- a/apps/frontend/src/app/assessments/docker-fundamentals/result/page.tsx
+++ b/apps/frontend/src/app/assessments/docker-fundamentals/result/page.tsx
@@ -1,0 +1,19 @@
+import { Suspense } from 'react';
+import AssessmentResultClient from '../../_shared/components/AssessmentResultClient';
+
+export default function DockerFundamentalsResultPage() {
+  return (
+    <Suspense
+      fallback={
+        <div className="min-h-screen flex items-center justify-center bg-slate-950">
+          <div className="h-10 w-10 animate-spin rounded-full border-t-2 border-cyan-400" />
+        </div>
+      }
+    >
+      <AssessmentResultClient
+        startHref="/assessments/docker-fundamentals/start"
+        fallbackRecommendation="Repasá la documentación oficial de Docker: builder/multi-stage builds, best practices para Dockerfiles, manejo de variables de entorno y docker-compose para desarrollo local."
+      />
+    </Suspense>
+  );
+}

--- a/apps/frontend/src/app/assessments/docker-fundamentals/section/[sectionId]/page.tsx
+++ b/apps/frontend/src/app/assessments/docker-fundamentals/section/[sectionId]/page.tsx
@@ -1,0 +1,9 @@
+'use client';
+
+import AssessmentSectionScreen from '../../../_shared/components/AssessmentSectionScreen';
+
+export default function DockerFundamentalsSectionPage() {
+  return (
+    <AssessmentSectionScreen basePath="/assessments/docker-fundamentals" />
+  );
+}

--- a/apps/frontend/src/app/assessments/docker-fundamentals/start/page.tsx
+++ b/apps/frontend/src/app/assessments/docker-fundamentals/start/page.tsx
@@ -1,0 +1,133 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { useTheme } from '@/contexts/ThemeContext';
+import { startAssessmentAttemptAction } from '@/actions/assessments';
+import ProcessCodeInput from '@/components/labs/ProcessCodeInput';
+import { DOCKER_FUNDAMENTALS_SLUG } from '../data/assessment-definition';
+
+export default function StartDockerFundamentalsPage() {
+  const router = useRouter();
+  const { isDarkMode } = useTheme();
+  const [processCode, setProcessCode] = useState('');
+  const [error, setError] = useState('');
+  const [isStarting, setIsStarting] = useState(false);
+
+  // Pre-fill desde ?code= (links de invitaciones/procesos de empresa)
+  useEffect(() => {
+    const codeParam = new URLSearchParams(window.location.search).get('code');
+    if (codeParam) setProcessCode(codeParam);
+  }, []);
+
+  async function handleStart() {
+    setError('');
+    setIsStarting(true);
+
+    try {
+      const result = await startAssessmentAttemptAction({
+        slug: DOCKER_FUNDAMENTALS_SLUG,
+        processCode,
+      });
+
+      if ('error' in result) {
+        setIsStarting(false);
+        setError(result.error);
+        return;
+      }
+
+      const { attempt, sectionSlug } = result;
+
+      if (!sectionSlug) {
+        setIsStarting(false);
+        setError('No se encontró la primera sección del assessment.');
+        return;
+      }
+
+      setIsStarting(false);
+      router.push(
+        `/assessments/docker-fundamentals/section/${sectionSlug}?attempt=${attempt.id}`
+      );
+    } catch (startError) {
+      setIsStarting(false);
+      setError(
+        startError instanceof Error
+          ? startError.message
+          : 'No se pudo iniciar el assessment.'
+      );
+    }
+  }
+
+  return (
+    <div
+      className={`min-h-screen px-4 py-12 ${
+        isDarkMode ? 'bg-slate-950 text-white' : 'bg-slate-50 text-slate-900'
+      }`}
+    >
+      <div className="mx-auto max-w-3xl rounded-3xl border border-slate-800 bg-slate-900/80 p-8 text-slate-50 shadow-2xl shadow-cyan-950/20">
+        <p className="text-sm font-semibold uppercase tracking-[0.18em] text-cyan-200">
+          Preparación del intento
+        </p>
+        <h1 className="mt-3 text-3xl font-bold">Docker — Fundamentos</h1>
+        <p className="mt-3 text-slate-300">
+          Vas a completar 3 secciones teóricas con autosave, scoring por sección
+          y resultado final consolidado.
+        </p>
+
+        <div className="mt-8 grid gap-4 rounded-2xl border border-slate-800 bg-slate-950/70 p-5 md:grid-cols-3">
+          <div>
+            <p className="text-xs uppercase tracking-[0.18em] text-slate-400">
+              Duración sugerida
+            </p>
+            <p className="mt-2 text-lg font-semibold">~35 minutos</p>
+          </div>
+          <div>
+            <p className="text-xs uppercase tracking-[0.18em] text-slate-400">
+              Modalidad
+            </p>
+            <p className="mt-2 text-lg font-semibold">Conceptual</p>
+          </div>
+          <div>
+            <p className="text-xs uppercase tracking-[0.18em] text-slate-400">
+              Resultado
+            </p>
+            <p className="mt-2 text-lg font-semibold">Score total sobre 100</p>
+          </div>
+        </div>
+
+        <div className="mt-8">
+          <ProcessCodeInput
+            value={processCode}
+            onChange={setProcessCode}
+            onNormalizedCode={setProcessCode}
+            autoValidate
+          />
+        </div>
+
+        {error ? (
+          <div className="mt-6 rounded-2xl border border-red-500/30 bg-red-500/10 px-4 py-3 text-sm text-red-200">
+            {error}
+          </div>
+        ) : null}
+
+        <div className="mt-8 flex flex-col gap-3 sm:flex-row">
+          <button
+            type="button"
+            onClick={handleStart}
+            disabled={isStarting}
+            className="inline-flex items-center justify-center rounded-2xl bg-cyan-400 px-5 py-3 text-sm font-semibold text-slate-950 transition hover:bg-cyan-300 disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {isStarting ? 'Preparando intento...' : 'Iniciar o reanudar'}
+          </button>
+          <button
+            type="button"
+            onClick={() => router.push('/assessments/docker-fundamentals')}
+            className="inline-flex items-center justify-center rounded-2xl border border-slate-700 px-5 py-3 text-sm font-semibold text-slate-200 transition hover:bg-slate-800"
+          >
+            Volver al overview
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/src/app/assessments/kubernetes-helm-fundamentals/__tests__/definition.test.ts
+++ b/apps/frontend/src/app/assessments/kubernetes-helm-fundamentals/__tests__/definition.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { assertAssessmentDefinitionConsistency } from '../../_shared/testing/assessment-definition-checks';
+import {
+  KUBERNETES_HELM_FUNDAMENTALS_SEED_VERSION,
+  KUBERNETES_HELM_FUNDAMENTALS_SLUG,
+  kubernetesHelmFundamentalsDefinition,
+} from '../data/assessment-definition';
+import { ASSESSMENT_REGISTRY } from '../../_shared/registry';
+
+describe('kubernetes-helm-fundamentals definition', () => {
+  it('mantiene presupuestos de puntos y answer keys consistentes', () => {
+    assertAssessmentDefinitionConsistency(kubernetesHelmFundamentalsDefinition);
+  });
+
+  it('define 4 secciones teóricas sobre 100 puntos', () => {
+    expect(kubernetesHelmFundamentalsDefinition.sections).toHaveLength(4);
+    expect(kubernetesHelmFundamentalsDefinition.total_score).toBe(100);
+    expect(kubernetesHelmFundamentalsDefinition.slug).toBe(
+      KUBERNETES_HELM_FUNDAMENTALS_SLUG
+    );
+  });
+
+  it('está registrado con el seedVersion correcto', () => {
+    const entry = ASSESSMENT_REGISTRY[KUBERNETES_HELM_FUNDAMENTALS_SLUG];
+    expect(entry).toBeDefined();
+    expect(entry.seedVersion).toBe(KUBERNETES_HELM_FUNDAMENTALS_SEED_VERSION);
+    expect(entry.examType).toBe('kubernetes-helm-fundamentals');
+  });
+});

--- a/apps/frontend/src/app/assessments/kubernetes-helm-fundamentals/data/assessment-definition.ts
+++ b/apps/frontend/src/app/assessments/kubernetes-helm-fundamentals/data/assessment-definition.ts
@@ -1,0 +1,658 @@
+import type { AssessmentSeedDefinition } from '../../_shared/types';
+
+export const KUBERNETES_HELM_FUNDAMENTALS_SLUG = 'kubernetes-helm-fundamentals';
+
+// Bumpear cuando cambie la definición (secciones/preguntas) para forzar re-seed.
+export const KUBERNETES_HELM_FUNDAMENTALS_SEED_VERSION = 1;
+
+export const kubernetesHelmFundamentalsDefinition: AssessmentSeedDefinition = {
+  slug: KUBERNETES_HELM_FUNDAMENTALS_SLUG,
+  title: 'Kubernetes + Helm — Fundamentos',
+  description:
+    'Evaluación teórica de Kubernetes y Helm para bootcamp de desarrollo backend: manifiestos Deployment/Service, ConfigMaps y Secrets, empaquetado de charts con Helm, y despliegue funcional en Minikube.',
+  level: 'Trainee a Junior',
+  type: 'Desarrollo DevOps',
+  duration_minutes: 40,
+  total_score: 100,
+  is_active: true,
+  metadata: {
+    moduleName: 'AIQUAA Assessments / Kubernetes + Helm Fundamentals',
+    passingScore: 70,
+    candidateBands: [
+      { min: 0, max: 39, label: 'Inicial' },
+      { min: 40, max: 59, label: 'En formación' },
+      { min: 60, max: 74, label: 'Trainee' },
+      { min: 75, max: 89, label: 'Junior' },
+      { min: 90, max: 100, label: 'Junior avanzado' },
+    ],
+  },
+  sections: [
+    {
+      slug: 'manifiestos-kubernetes',
+      title: 'Manifiestos Kubernetes',
+      description:
+        'Deployment y Service: qué declaran, cómo se relacionan y cómo se actualizan sin downtime.',
+      order_index: 1,
+      max_score: 28,
+      metadata: {
+        instructions:
+          'Selección múltiple y verdadero/falso sobre manifiestos Deployment y Service en Kubernetes.',
+        suggestedMinutes: 12,
+      },
+      questions: [
+        {
+          question_type: 'multiple_choice',
+          prompt: '¿Qué declara un objeto Deployment en Kubernetes?',
+          options: [
+            {
+              label:
+                'El estado deseado de un conjunto de Pods (imagen, número de réplicas, estrategia de actualización); Kubernetes crea y gestiona un ReplicaSet para mantener ese estado',
+              value: 'a',
+            },
+            {
+              label: 'Únicamente la configuración de red del clúster',
+              value: 'b',
+            },
+            {
+              label: 'Las credenciales de acceso al registry de imágenes',
+              value: 'c',
+            },
+            { label: 'El almacenamiento persistente del nodo', value: 'd' },
+          ],
+          correct_answer: { value: 'a' },
+          explanation:
+            'Un Deployment es un controlador de más alto nivel: describe cómo deberían verse los Pods y cuántas réplicas debe haber, y Kubernetes se encarga de reconciliar la realidad con esa declaración.',
+          points: 4,
+          order_index: 1,
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt: '¿Qué controla el campo `replicas` de un Deployment?',
+          options: [
+            {
+              label:
+                'Cuántas instancias idénticas del Pod deben mantenerse corriendo en simultáneo; si una falla o el nodo se cae, Kubernetes crea una nueva para mantener ese número',
+              value: 'a',
+            },
+            {
+              label: 'Cuántas veces se reintenta el build de la imagen',
+              value: 'b',
+            },
+            { label: 'La cantidad de nodos del clúster', value: 'c' },
+            { label: 'El tiempo máximo de vida de un Pod', value: 'd' },
+          ],
+          correct_answer: { value: 'a' },
+          explanation:
+            'replicas es la cantidad deseada de Pods. El controlador del Deployment compara constantemente el estado real contra este número y crea o elimina Pods para converger hacia él.',
+          points: 4,
+          order_index: 2,
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            '¿Cuál es la diferencia principal entre un Service tipo ClusterIP y uno tipo NodePort?',
+          options: [
+            {
+              label:
+                'ClusterIP expone el Service solo dentro del clúster con una IP interna estable; NodePort además abre un puerto fijo en cada nodo del clúster, permitiendo acceso desde fuera',
+              value: 'a',
+            },
+            {
+              label: 'Son exactamente lo mismo con nombres distintos',
+              value: 'b',
+            },
+            {
+              label:
+                'ClusterIP solo funciona en Minikube, NodePort solo en la nube',
+              value: 'c',
+            },
+            {
+              label:
+                'NodePort es para bases de datos y ClusterIP solo para APIs',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'a' },
+          explanation:
+            'ClusterIP es el tipo por defecto, pensado para comunicación interna entre servicios del clúster. NodePort agrega exposición externa básica reservando un puerto (30000-32767 por defecto) en cada nodo.',
+          points: 4,
+          order_index: 3,
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            '¿Cómo determina un Service a qué Pods enviarles el tráfico que recibe?',
+          options: [
+            {
+              label:
+                'Mediante un selector de labels: el Service enruta tráfico a todos los Pods cuyos labels coincidan con el selector definido, sin importar en qué nodo estén',
+              value: 'a',
+            },
+            {
+              label: 'Por el orden en que los Pods fueron creados',
+              value: 'b',
+            },
+            { label: 'Por la dirección IP fija de cada Pod', value: 'c' },
+            {
+              label:
+                'El Service se conecta manualmente a cada Pod por su nombre',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'a' },
+          explanation:
+            'El selector es la pieza clave: si los labels del template de Pods del Deployment no coinciden con el selector del Service, el Service no tiene a quién enviar tráfico aunque los Pods estén corriendo perfectamente.',
+          points: 4,
+          order_index: 4,
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            '¿Qué estrategia usa un Deployment por defecto para actualizar la versión de la imagen sin causar downtime?',
+          options: [
+            {
+              label:
+                'RollingUpdate: reemplaza los Pods viejos por nuevos de forma gradual, manteniendo siempre una cantidad mínima de Pods disponibles sirviendo tráfico',
+              value: 'a',
+            },
+            {
+              label:
+                'Recreate: apaga todos los Pods viejos antes de crear los nuevos',
+              value: 'b',
+            },
+            {
+              label: 'No existe forma de actualizar un Deployment sin downtime',
+              value: 'c',
+            },
+            {
+              label: 'Blue/Green automático sin configuración adicional',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'a' },
+          explanation:
+            'RollingUpdate es la estrategia por defecto: crea Pods nuevos e va apagando los viejos progresivamente, respetando maxUnavailable/maxSurge, para que siempre haya capacidad sirviendo tráfico.',
+          points: 4,
+          order_index: 5,
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            '¿Qué comando permite ver el estado actual de los Pods gestionados por un Deployment?',
+          options: [
+            {
+              label:
+                'kubectl get pods (opcionalmente con -l para filtrar por label)',
+              value: 'a',
+            },
+            { label: 'docker ps -a', value: 'b' },
+            { label: 'helm status', value: 'c' },
+            { label: 'kubectl get nodes', value: 'd' },
+          ],
+          correct_answer: { value: 'a' },
+          explanation:
+            'kubectl get pods lista los Pods del namespace actual con su estado (Running, Pending, CrashLoopBackOff, etc.); es el primer comando para verificar si un Deployment logró desplegarse correctamente.',
+          points: 4,
+          order_index: 6,
+        },
+        {
+          question_type: 'true_false',
+          prompt:
+            'Editar directamente un Pod administrado por un Deployment es la forma recomendada de aplicar un cambio permanente, en vez de modificar el manifiesto del Deployment.',
+          correct_answer: { value: false },
+          explanation:
+            'Los Pods creados por un Deployment son efímeros y están bajo control del ReplicaSet: un cambio manual se pierde en cuanto el Pod se recrea. Los cambios permanentes deben aplicarse al manifiesto del Deployment (y reaplicarse con kubectl apply o Helm).',
+          points: 4,
+          order_index: 7,
+        },
+      ],
+    },
+    {
+      slug: 'configmaps-secrets',
+      title: 'ConfigMaps & Secrets',
+      description:
+        'Separación de configuración y datos sensibles del código de la aplicación, y cómo consumirlos desde un Pod.',
+      order_index: 2,
+      max_score: 24,
+      metadata: {
+        instructions:
+          'Preguntas sobre el uso correcto de ConfigMaps y Secrets en Kubernetes.',
+        suggestedMinutes: 10,
+      },
+      questions: [
+        {
+          question_type: 'multiple_choice',
+          prompt: '¿Para qué sirve un ConfigMap en Kubernetes?',
+          options: [
+            {
+              label:
+                'Almacenar configuración no sensible (variables, archivos de configuración) desacoplada de la imagen del contenedor, para poder cambiarla sin reconstruir ni redeployar la imagen',
+              value: 'a',
+            },
+            { label: 'Guardar el código fuente de la aplicación', value: 'b' },
+            { label: 'Definir las reglas de firewall del clúster', value: 'c' },
+            { label: 'Almacenar imágenes Docker', value: 'd' },
+          ],
+          correct_answer: { value: 'a' },
+          explanation:
+            'ConfigMap externaliza configuración de la imagen: la misma imagen puede correr con distinta configuración en distintos ambientes simplemente cambiando el ConfigMap que se le monta o inyecta.',
+          points: 4,
+          order_index: 1,
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt: '¿En qué se diferencia un Secret de un ConfigMap?',
+          options: [
+            {
+              label:
+                'Secret está pensado para datos sensibles (contraseñas, tokens, claves); sus valores se almacenan codificados en base64 (no encriptados por defecto) y Kubernetes los trata con más cuidado, por ejemplo no mostrándolos en texto plano en kubectl describe',
+              value: 'a',
+            },
+            { label: 'No hay ninguna diferencia real entre ambos', value: 'b' },
+            { label: 'Secret solo puede usarse en Minikube', value: 'c' },
+            { label: 'ConfigMap encripta los datos y Secret no', value: 'd' },
+          ],
+          correct_answer: { value: 'a' },
+          explanation:
+            'Base64 es codificación, no encriptación: cualquiera con acceso al Secret puede decodificarlo trivialmente. Kubernetes le da un tratamiento distinto (menos exposición en logs/describe), pero para protección real hace falta encriptación en reposo o un secret manager externo.',
+          points: 4,
+          order_index: 2,
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            '¿Cuáles son las dos formas principales en que un Pod puede consumir un ConfigMap o Secret?',
+          options: [
+            {
+              label:
+                'Como variables de entorno inyectadas al contenedor, o montados como archivos dentro de un volumen',
+              value: 'a',
+            },
+            {
+              label:
+                'Solo se pueden leer manualmente con kubectl desde fuera del Pod',
+              value: 'b',
+            },
+            {
+              label:
+                'Únicamente escribiendo el valor directamente en la imagen',
+              value: 'c',
+            },
+            { label: 'Solo a través de una base de datos externa', value: 'd' },
+          ],
+          correct_answer: { value: 'a' },
+          explanation:
+            'envFrom/valueFrom inyecta las claves como variables de entorno del contenedor; montarlo como volumen expone cada clave como un archivo. La elección depende de si la app espera env vars o archivos de configuración.',
+          points: 4,
+          order_index: 3,
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            '¿Por qué NO conviene escribir el valor real de un Secret directamente en el manifiesto YAML que se versiona en el repositorio de Git?',
+          options: [
+            {
+              label:
+                'Queda expuesto en el historial del repositorio en un formato (base64) trivialmente reversible, accesible para cualquiera con acceso al repo',
+              value: 'a',
+            },
+            {
+              label:
+                'Kubernetes rechaza aplicar manifiestos que contengan Secrets',
+              value: 'b',
+            },
+            { label: 'YAML no soporta el tipo Secret', value: 'c' },
+            {
+              label: 'No hay ningún problema en hacerlo si el repo es privado',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'a' },
+          explanation:
+            'Igual que con cualquier credencial hardcodeada, versionar un Secret en texto (aunque esté en base64) lo expone permanentemente en el historial de git. La práctica recomendada es generarlo fuera del control de versiones o usar herramientas de secret management/encriptación (ej. Sealed Secrets, External Secrets).',
+          points: 4,
+          order_index: 4,
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            'Si actualizás el valor de un ConfigMap que está montado como volumen en un Pod que ya está corriendo, ¿qué es lo más probable que ocurra?',
+          options: [
+            {
+              label:
+                'El archivo montado eventualmente se actualiza, pero la aplicación normalmente no relee el archivo por sí sola; en la práctica suele necesitarse reiniciar el Pod para que tome el nuevo valor, salvo que la app implemente watch de archivos',
+              value: 'a',
+            },
+            {
+              label:
+                'La aplicación se reinicia automáticamente y aplica el cambio sin ninguna configuración adicional',
+              value: 'b',
+            },
+            { label: 'El clúster entero se reinicia', value: 'c' },
+            {
+              label: 'El cambio se ignora completamente y nunca llega al Pod',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'a' },
+          explanation:
+            'Kubernetes actualiza el contenido del volumen, pero la mayoría de las aplicaciones leen la configuración una sola vez al arrancar. Por eso muchos equipos disparan un rollout (reinicio de Pods) cuando cambia un ConfigMap crítico.',
+          points: 4,
+          order_index: 5,
+        },
+        {
+          question_type: 'true_false',
+          prompt:
+            'Es una buena práctica que la aplicación reciba la cadena de conexión a la base de datos vía ConfigMap/Secret externo en vez de tenerla hardcodeada dentro de la imagen del contenedor.',
+          correct_answer: { value: true },
+          explanation:
+            'Es la misma idea de separar configuración de la imagen que en Docker: la imagen debe ser la misma en todos los ambientes, y lo que cambia (URLs, credenciales) se inyecta externamente vía ConfigMap/Secret.',
+          points: 4,
+          order_index: 6,
+        },
+      ],
+    },
+    {
+      slug: 'helm',
+      title: 'Helm',
+      description:
+        'Empaquetado de manifiestos como charts reutilizables, values.yaml y el ciclo de vida de un release con Helm.',
+      order_index: 3,
+      max_score: 24,
+      metadata: {
+        instructions:
+          'Preguntas sobre Helm como gestor de paquetes para Kubernetes.',
+        suggestedMinutes: 9,
+      },
+      questions: [
+        {
+          question_type: 'multiple_choice',
+          prompt: '¿Qué es Helm en el contexto de Kubernetes?',
+          options: [
+            {
+              label:
+                'Un gestor de paquetes para Kubernetes: empaqueta un conjunto de manifiestos como un "chart" reutilizable y parametrizable, y gestiona su ciclo de vida como una unidad (install, upgrade, rollback, uninstall)',
+              value: 'a',
+            },
+            {
+              label: 'Un reemplazo de Docker para construir imágenes',
+              value: 'b',
+            },
+            {
+              label: 'Un tipo de base de datos usada dentro de Kubernetes',
+              value: 'c',
+            },
+            {
+              label: 'Un proveedor de nube alternativo a AWS/Azure/GCP',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'a' },
+          explanation:
+            'Helm resuelve el problema de mantener a mano decenas de manifiestos YAML casi idénticos entre ambientes: un chart parametrizado se puede desplegar en cualquier ambiente cambiando solo los valores.',
+          points: 4,
+          order_index: 1,
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt: '¿Para qué sirve el archivo values.yaml en un chart de Helm?',
+          options: [
+            {
+              label:
+                'Define los valores por defecto (parámetros) que los templates del chart usan, permitiendo personalizar el despliegue (réplicas, imagen, recursos, etc.) sin modificar los templates',
+              value: 'a',
+            },
+            {
+              label: 'Contiene el código fuente compilado de la aplicación',
+              value: 'b',
+            },
+            {
+              label: 'Define los usuarios que tienen acceso al clúster',
+              value: 'c',
+            },
+            { label: 'Es un archivo de logs generado por Helm', value: 'd' },
+          ],
+          correct_answer: { value: 'a' },
+          explanation:
+            'values.yaml es la capa de configuración del chart. Los templates quedan genéricos y reutilizables; lo que cambia por ambiente o despliegue son los valores, no la estructura de los manifiestos.',
+          points: 4,
+          order_index: 2,
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            'Dentro de un template de Helm (por ejemplo templates/deployment.yaml), ¿cómo se referencia un valor definido en values.yaml?',
+          options: [
+            {
+              label: 'Con la sintaxis {{ .Values.nombreDelValor }}',
+              value: 'a',
+            },
+            { label: 'Con la sintaxis $ENV{nombreDelValor}', value: 'b' },
+            {
+              label: 'Escribiendo directamente #include values.yaml',
+              value: 'c',
+            },
+            {
+              label: 'No es posible referenciar values.yaml desde un template',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'a' },
+          explanation:
+            'Helm usa el motor de templates de Go. `.Values` es el objeto raíz que expone todo lo definido en values.yaml (y lo sobreescrito por -f o --set) dentro de los templates.',
+          points: 4,
+          order_index: 3,
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            '¿Qué comando instala un chart como un nuevo release en el clúster, o lo actualiza si ya existe?',
+          options: [
+            {
+              label: 'helm upgrade --install <release> <chart> -f values.yaml',
+              value: 'a',
+            },
+            { label: 'kubectl create chart <chart>', value: 'b' },
+            { label: 'docker helm run <chart>', value: 'c' },
+            { label: 'helm delete --install <chart>', value: 'd' },
+          ],
+          correct_answer: { value: 'a' },
+          explanation:
+            '`helm upgrade --install` es el patrón idempotente típico en CI/CD: instala el release si no existe, o lo actualiza si ya está desplegado, sin tener que distinguir manualmente entre install y upgrade.',
+          points: 4,
+          order_index: 4,
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            '¿Cuál es la principal ventaja de usar Helm en vez de aplicar manifiestos YAML sueltos con `kubectl apply -f`?',
+          options: [
+            {
+              label:
+                'Helm versiona cada release, permite hacer rollback a una versión anterior, reutiliza templates entre ambientes cambiando solo los values, y gestiona el conjunto de recursos como una sola unidad desplegable',
+              value: 'a',
+            },
+            {
+              label:
+                'kubectl apply no funciona con Deployments, solo Helm puede crearlos',
+              value: 'b',
+            },
+            {
+              label: 'Helm es más rápido en todos los casos sin excepción',
+              value: 'c',
+            },
+            {
+              label: 'No hay ninguna ventaja real, son intercambiables siempre',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'a' },
+          explanation:
+            'kubectl apply funciona perfectamente para manifiestos sueltos, pero no versiona releases ni ofrece rollback nativo, ni resuelve la reutilización entre ambientes tan bien como un chart parametrizado.',
+          points: 4,
+          order_index: 5,
+        },
+        {
+          question_type: 'true_false',
+          prompt:
+            'Un mismo chart de Helm puede desplegarse en distintos ambientes (dev/staging/prod) usando distintos archivos de values (por ejemplo values-dev.yaml y values-prod.yaml) sin modificar los templates del chart.',
+          correct_answer: { value: true },
+          explanation:
+            'Esa es justamente la idea central de Helm: los templates definen la estructura, y los distintos archivos values solo cambian los parámetros (réplicas, recursos, nombres de host, etc.) por ambiente.',
+          points: 4,
+          order_index: 6,
+        },
+      ],
+    },
+    {
+      slug: 'despliegue-funcional',
+      title: 'Despliegue funcional en Minikube',
+      description:
+        'Levantar y verificar un despliegue real en un clúster local con Minikube, y diagnosticar Pods que no llegan a Running.',
+      order_index: 4,
+      max_score: 24,
+      metadata: {
+        instructions:
+          'Preguntas sobre el flujo práctico de desplegar y depurar una aplicación en Minikube.',
+        suggestedMinutes: 9,
+      },
+      questions: [
+        {
+          question_type: 'multiple_choice',
+          prompt: '¿Qué es Minikube?',
+          options: [
+            {
+              label:
+                'Una herramienta que levanta un clúster de Kubernetes de un solo nodo de forma local, pensada para desarrollo y pruebas sin necesitar infraestructura en la nube',
+              value: 'a',
+            },
+            {
+              label: 'Un proveedor de Kubernetes administrado en la nube',
+              value: 'b',
+            },
+            { label: 'Un registry privado de imágenes Docker', value: 'c' },
+            {
+              label: 'Una alternativa a Docker para construir imágenes',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'a' },
+          explanation:
+            'Minikube corre un clúster completo (control plane + nodo) dentro de una VM o contenedor local, permitiendo practicar manifiestos y Helm charts reales sin costo de infraestructura en la nube.',
+          points: 4,
+          order_index: 1,
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            'Construiste una imagen Docker localmente y querés usarla en un Deployment de Minikube sin subirla a un registry externo. ¿Qué paso adicional suele hacer falta?',
+          options: [
+            {
+              label:
+                'Apuntar el build al daemon de Docker de Minikube (`eval $(minikube docker-env)`) o cargar la imagen ya construida con `minikube image load`, para que el clúster la encuentre localmente sin necesitar hacer pull de un registry',
+              value: 'a',
+            },
+            {
+              label:
+                'Ningún paso adicional, Minikube siempre ve las imágenes locales del host automáticamente',
+              value: 'b',
+            },
+            {
+              label: 'Hace falta reinstalar Kubernetes desde cero',
+              value: 'c',
+            },
+            {
+              label: 'Hay que convertir la imagen a un formato .helm',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'a' },
+          explanation:
+            'Por defecto, el clúster de Minikube corre en un entorno Docker separado del host. Sin ese paso, Kubernetes intenta hacer pull de la imagen desde un registry externo y falla con ImagePullBackOff aunque la imagen exista localmente en el host.',
+          points: 4,
+          order_index: 2,
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            '¿Qué comando permite abrir en el navegador, de forma rápida, un Service que está corriendo en Minikube?',
+          options: [
+            { label: 'minikube service <nombre-del-service>', value: 'a' },
+            { label: 'docker open <service>', value: 'b' },
+            { label: 'helm browse <service>', value: 'c' },
+            { label: 'kubectl open service', value: 'd' },
+          ],
+          correct_answer: { value: 'a' },
+          explanation:
+            'minikube service resuelve automáticamente la URL accesible del Service (incluyendo el túnel necesario para tipos NodePort/LoadBalancer en Minikube) y puede abrirla directamente en el navegador.',
+          points: 4,
+          order_index: 3,
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            'Un Pod queda en estado CrashLoopBackOff. ¿Cuál es el primer comando recomendado para empezar a diagnosticar la causa?',
+          options: [
+            {
+              label:
+                'kubectl logs <pod> (y kubectl describe pod <pod> para ver eventos recientes, como fallas de liveness probe o errores de arranque)',
+              value: 'a',
+            },
+            {
+              label: 'kubectl delete pod <pod> --force inmediatamente',
+              value: 'b',
+            },
+            { label: 'helm uninstall del release completo', value: 'c' },
+            { label: 'Reiniciar Minikube desde cero', value: 'd' },
+          ],
+          correct_answer: { value: 'a' },
+          explanation:
+            'CrashLoopBackOff significa que el contenedor arranca y falla repetidamente. Los logs del proceso (y los eventos del Pod) casi siempre muestran directamente la excepción o el motivo del crash, antes de tomar medidas más drásticas.',
+          points: 4,
+          order_index: 4,
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            'Un Pod queda indefinidamente en estado "Pending" y nunca pasa a Running. ¿Qué indica típicamente ese estado?',
+          options: [
+            {
+              label:
+                'El scheduler no pudo asignar el Pod a ningún nodo, por ejemplo por falta de recursos (CPU/memoria) disponibles, o por un problema con un volumen, ConfigMap o Secret referenciado que no existe',
+              value: 'a',
+            },
+            {
+              label: 'El Pod ya terminó su ejecución exitosamente',
+              value: 'b',
+            },
+            {
+              label:
+                'La imagen se descargó pero el contenedor decidió no arrancar',
+              value: 'c',
+            },
+            {
+              label:
+                'Pending es el estado normal y esperado de un Pod saludable',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'a' },
+          explanation:
+            '"Pending" significa que el Pod fue aceptado por la API pero todavía no se pudo programar/arrancar en ningún nodo. kubectl describe pod suele mostrar el motivo exacto en la sección de Events.',
+          points: 4,
+          order_index: 5,
+        },
+        {
+          question_type: 'true_false',
+          prompt:
+            'Un despliegue se considera funcional cuando el manifiesto (o el chart de Helm) se aplica sin errores de sintaxis, aunque los Pods resultantes no lleguen nunca al estado Running.',
+          correct_answer: { value: false },
+          explanation:
+            'Que kubectl apply o helm install no devuelvan un error de sintaxis solo confirma que el YAML es válido, no que la aplicación esté sirviendo tráfico. Un despliegue funcional requiere Pods en estado Running/Ready y el Service respondiendo correctamente.',
+          points: 4,
+          order_index: 6,
+        },
+      ],
+    },
+  ],
+};

--- a/apps/frontend/src/app/assessments/kubernetes-helm-fundamentals/lib/gamification.ts
+++ b/apps/frontend/src/app/assessments/kubernetes-helm-fundamentals/lib/gamification.ts
@@ -1,0 +1,17 @@
+import { createAssessmentGamification } from '../../_shared/lib/gamification';
+
+const gamification = createAssessmentGamification({
+  prefix: 'KUBERNETES_HELM_FUNDAMENTALS',
+  descriptions: {
+    completed: 'Completar el assessment Kubernetes + Helm Fundamentals',
+    passed:
+      'Aprobar el assessment Kubernetes + Helm Fundamentals (score >= 70)',
+    highScore: 'Score sobresaliente en Kubernetes + Helm Fundamentals (>= 90)',
+  },
+});
+
+export const KUBERNETES_HELM_FUNDAMENTALS_GAMIFICATION_RULES =
+  gamification.rules;
+
+export const buildKubernetesHelmFundamentalsGamificationEvents =
+  gamification.buildEvents;

--- a/apps/frontend/src/app/assessments/kubernetes-helm-fundamentals/lib/seed.ts
+++ b/apps/frontend/src/app/assessments/kubernetes-helm-fundamentals/lib/seed.ts
@@ -1,0 +1,12 @@
+import { ensureAssessmentSeeded } from '../../_shared/lib/seed';
+import {
+  KUBERNETES_HELM_FUNDAMENTALS_SEED_VERSION,
+  kubernetesHelmFundamentalsDefinition,
+} from '../data/assessment-definition';
+
+export async function ensureKubernetesHelmFundamentalsSeeded() {
+  return ensureAssessmentSeeded(
+    kubernetesHelmFundamentalsDefinition,
+    KUBERNETES_HELM_FUNDAMENTALS_SEED_VERSION
+  );
+}

--- a/apps/frontend/src/app/assessments/kubernetes-helm-fundamentals/page.tsx
+++ b/apps/frontend/src/app/assessments/kubernetes-helm-fundamentals/page.tsx
@@ -1,0 +1,92 @@
+import { Metadata } from 'next';
+import { kubernetesHelmFundamentalsDefinition } from './data/assessment-definition';
+import AssessmentWelcome from '../_shared/components/AssessmentWelcome';
+
+export const metadata: Metadata = {
+  title: 'Kubernetes + Helm — Fundamentos | AIQUAA',
+  description:
+    'Prueba técnica teórica para bootcamp de desarrollo: manifiestos Deployment/Service, ConfigMaps y Secrets, charts de Helm y despliegue funcional en Minikube.',
+  keywords: [
+    'Kubernetes',
+    'Helm',
+    'Minikube',
+    'Deployment',
+    'Service',
+    'ConfigMap',
+    'Secret',
+    'desarrollo backend',
+    'DevOps',
+    'bootcamp',
+    'AIQUAA',
+    'evaluación técnica',
+  ],
+  openGraph: {
+    title: 'Kubernetes + Helm — Fundamentos | AIQUAA',
+    description:
+      'Prueba técnica teórica sobre manifiestos Kubernetes, ConfigMaps/Secrets, Helm y despliegue en Minikube.',
+    url: 'https://aiquaa.com/assessments/kubernetes-helm-fundamentals',
+    siteName: 'AIQUAA',
+    type: 'website',
+    locale: 'es_PY',
+    images: [
+      {
+        url: '/api/og?title=Kubernetes%20%2B%20Helm%20-%20Fundamentos&subtitle=Manifiestos%2C%20ConfigMaps%20y%20Helm&section=Assessments',
+        width: 1200,
+        height: 630,
+        alt: 'Kubernetes + Helm Fundamentos - AIQUAA',
+      },
+    ],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Kubernetes + Helm — Fundamentos | AIQUAA',
+    description:
+      'Prueba técnica sobre manifiestos Kubernetes, ConfigMaps/Secrets, Helm y despliegue en Minikube.',
+    images: [
+      '/api/og?title=Kubernetes%20%2B%20Helm%20-%20Fundamentos&subtitle=Manifiestos%2C%20ConfigMaps%20y%20Helm&section=Assessments',
+    ],
+    creator: '@stevenayal',
+  },
+  alternates: {
+    canonical: 'https://aiquaa.com/assessments/kubernetes-helm-fundamentals',
+  },
+};
+
+export default function KubernetesHelmFundamentalsPage() {
+  const overview = {
+    assessment: {
+      id: 'static-kubernetes-helm-fundamentals',
+      slug: kubernetesHelmFundamentalsDefinition.slug,
+      title: kubernetesHelmFundamentalsDefinition.title,
+      description: kubernetesHelmFundamentalsDefinition.description,
+      level: kubernetesHelmFundamentalsDefinition.level,
+      type: kubernetesHelmFundamentalsDefinition.type,
+      duration_minutes: kubernetesHelmFundamentalsDefinition.duration_minutes,
+      total_score: kubernetesHelmFundamentalsDefinition.total_score,
+      is_active: kubernetesHelmFundamentalsDefinition.is_active,
+      metadata: kubernetesHelmFundamentalsDefinition.metadata,
+    },
+    sections: kubernetesHelmFundamentalsDefinition.sections.map(
+      (section, index) => ({
+        id: `static-section-${index + 1}`,
+        assessment_id: 'static-kubernetes-helm-fundamentals',
+        slug: section.slug,
+        title: section.title,
+        description: section.description,
+        order_index: section.order_index,
+        max_score: section.max_score,
+        metadata: section.metadata,
+      })
+    ),
+  };
+
+  return (
+    <AssessmentWelcome
+      overview={overview}
+      startHref="/assessments/kubernetes-helm-fundamentals/start"
+      evaluatesCopy="Manifiestos Deployment y Service, selectores de labels y RollingUpdate; ConfigMaps y Secrets para desacoplar configuración sensible del código; charts de Helm, values.yaml y el ciclo de vida de un release; despliegue funcional y diagnóstico de Pods en Minikube."
+      scoringCopy="Automático en las 4 secciones: selección múltiple y verdadero/falso."
+      resultCopy="Score total, score por sección, fortalezas, debilidades y temas a reforzar."
+    />
+  );
+}

--- a/apps/frontend/src/app/assessments/kubernetes-helm-fundamentals/result/page.tsx
+++ b/apps/frontend/src/app/assessments/kubernetes-helm-fundamentals/result/page.tsx
@@ -1,0 +1,19 @@
+import { Suspense } from 'react';
+import AssessmentResultClient from '../../_shared/components/AssessmentResultClient';
+
+export default function KubernetesHelmFundamentalsResultPage() {
+  return (
+    <Suspense
+      fallback={
+        <div className="min-h-screen flex items-center justify-center bg-slate-950">
+          <div className="h-10 w-10 animate-spin rounded-full border-t-2 border-cyan-400" />
+        </div>
+      }
+    >
+      <AssessmentResultClient
+        startHref="/assessments/kubernetes-helm-fundamentals/start"
+        fallbackRecommendation="Repasá la documentación oficial de Kubernetes (Deployments, Services, ConfigMaps, Secrets) y la guía de Helm (charts, values, ciclo de vida de releases), practicando con Minikube en local."
+      />
+    </Suspense>
+  );
+}

--- a/apps/frontend/src/app/assessments/kubernetes-helm-fundamentals/section/[sectionId]/page.tsx
+++ b/apps/frontend/src/app/assessments/kubernetes-helm-fundamentals/section/[sectionId]/page.tsx
@@ -1,0 +1,9 @@
+'use client';
+
+import AssessmentSectionScreen from '../../../_shared/components/AssessmentSectionScreen';
+
+export default function KubernetesHelmFundamentalsSectionPage() {
+  return (
+    <AssessmentSectionScreen basePath="/assessments/kubernetes-helm-fundamentals" />
+  );
+}

--- a/apps/frontend/src/app/assessments/kubernetes-helm-fundamentals/start/page.tsx
+++ b/apps/frontend/src/app/assessments/kubernetes-helm-fundamentals/start/page.tsx
@@ -1,0 +1,137 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { useTheme } from '@/contexts/ThemeContext';
+import { startAssessmentAttemptAction } from '@/actions/assessments';
+import ProcessCodeInput from '@/components/labs/ProcessCodeInput';
+import { KUBERNETES_HELM_FUNDAMENTALS_SLUG } from '../data/assessment-definition';
+
+export default function StartKubernetesHelmFundamentalsPage() {
+  const router = useRouter();
+  const { isDarkMode } = useTheme();
+  const [processCode, setProcessCode] = useState('');
+  const [error, setError] = useState('');
+  const [isStarting, setIsStarting] = useState(false);
+
+  // Pre-fill desde ?code= (links de invitaciones/procesos de empresa)
+  useEffect(() => {
+    const codeParam = new URLSearchParams(window.location.search).get('code');
+    if (codeParam) setProcessCode(codeParam);
+  }, []);
+
+  async function handleStart() {
+    setError('');
+    setIsStarting(true);
+
+    try {
+      const result = await startAssessmentAttemptAction({
+        slug: KUBERNETES_HELM_FUNDAMENTALS_SLUG,
+        processCode,
+      });
+
+      if ('error' in result) {
+        setIsStarting(false);
+        setError(result.error);
+        return;
+      }
+
+      const { attempt, sectionSlug } = result;
+
+      if (!sectionSlug) {
+        setIsStarting(false);
+        setError('No se encontró la primera sección del assessment.');
+        return;
+      }
+
+      setIsStarting(false);
+      router.push(
+        `/assessments/kubernetes-helm-fundamentals/section/${sectionSlug}?attempt=${attempt.id}`
+      );
+    } catch (startError) {
+      setIsStarting(false);
+      setError(
+        startError instanceof Error
+          ? startError.message
+          : 'No se pudo iniciar el assessment.'
+      );
+    }
+  }
+
+  return (
+    <div
+      className={`min-h-screen px-4 py-12 ${
+        isDarkMode ? 'bg-slate-950 text-white' : 'bg-slate-50 text-slate-900'
+      }`}
+    >
+      <div className="mx-auto max-w-3xl rounded-3xl border border-slate-800 bg-slate-900/80 p-8 text-slate-50 shadow-2xl shadow-cyan-950/20">
+        <p className="text-sm font-semibold uppercase tracking-[0.18em] text-cyan-200">
+          Preparación del intento
+        </p>
+        <h1 className="mt-3 text-3xl font-bold">
+          Kubernetes + Helm — Fundamentos
+        </h1>
+        <p className="mt-3 text-slate-300">
+          Vas a completar 4 secciones teóricas con autosave, scoring por sección
+          y resultado final consolidado.
+        </p>
+
+        <div className="mt-8 grid gap-4 rounded-2xl border border-slate-800 bg-slate-950/70 p-5 md:grid-cols-3">
+          <div>
+            <p className="text-xs uppercase tracking-[0.18em] text-slate-400">
+              Duración sugerida
+            </p>
+            <p className="mt-2 text-lg font-semibold">~40 minutos</p>
+          </div>
+          <div>
+            <p className="text-xs uppercase tracking-[0.18em] text-slate-400">
+              Modalidad
+            </p>
+            <p className="mt-2 text-lg font-semibold">Conceptual</p>
+          </div>
+          <div>
+            <p className="text-xs uppercase tracking-[0.18em] text-slate-400">
+              Resultado
+            </p>
+            <p className="mt-2 text-lg font-semibold">Score total sobre 100</p>
+          </div>
+        </div>
+
+        <div className="mt-8">
+          <ProcessCodeInput
+            value={processCode}
+            onChange={setProcessCode}
+            onNormalizedCode={setProcessCode}
+            autoValidate
+          />
+        </div>
+
+        {error ? (
+          <div className="mt-6 rounded-2xl border border-red-500/30 bg-red-500/10 px-4 py-3 text-sm text-red-200">
+            {error}
+          </div>
+        ) : null}
+
+        <div className="mt-8 flex flex-col gap-3 sm:flex-row">
+          <button
+            type="button"
+            onClick={handleStart}
+            disabled={isStarting}
+            className="inline-flex items-center justify-center rounded-2xl bg-cyan-400 px-5 py-3 text-sm font-semibold text-slate-950 transition hover:bg-cyan-300 disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {isStarting ? 'Preparando intento...' : 'Iniciar o reanudar'}
+          </button>
+          <button
+            type="button"
+            onClick={() =>
+              router.push('/assessments/kubernetes-helm-fundamentals')
+            }
+            className="inline-flex items-center justify-center rounded-2xl border border-slate-700 px-5 py-3 text-sm font-semibold text-slate-200 transition hover:bg-slate-800"
+          >
+            Volver al overview
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/src/app/assessments/observability-fundamentals/__tests__/definition.test.ts
+++ b/apps/frontend/src/app/assessments/observability-fundamentals/__tests__/definition.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { assertAssessmentDefinitionConsistency } from '../../_shared/testing/assessment-definition-checks';
+import {
+  OBSERVABILITY_FUNDAMENTALS_SEED_VERSION,
+  OBSERVABILITY_FUNDAMENTALS_SLUG,
+  observabilityFundamentalsDefinition,
+} from '../data/assessment-definition';
+import { ASSESSMENT_REGISTRY } from '../../_shared/registry';
+
+describe('observability-fundamentals definition', () => {
+  it('mantiene presupuestos de puntos y answer keys consistentes', () => {
+    assertAssessmentDefinitionConsistency(observabilityFundamentalsDefinition);
+  });
+
+  it('define 4 secciones teóricas sobre 100 puntos', () => {
+    expect(observabilityFundamentalsDefinition.sections).toHaveLength(4);
+    expect(observabilityFundamentalsDefinition.total_score).toBe(100);
+    expect(observabilityFundamentalsDefinition.slug).toBe(
+      OBSERVABILITY_FUNDAMENTALS_SLUG
+    );
+  });
+
+  it('está registrado con el seedVersion correcto', () => {
+    const entry = ASSESSMENT_REGISTRY[OBSERVABILITY_FUNDAMENTALS_SLUG];
+    expect(entry).toBeDefined();
+    expect(entry.seedVersion).toBe(OBSERVABILITY_FUNDAMENTALS_SEED_VERSION);
+    expect(entry.examType).toBe('observability-fundamentals');
+  });
+});

--- a/apps/frontend/src/app/assessments/observability-fundamentals/data/assessment-definition.ts
+++ b/apps/frontend/src/app/assessments/observability-fundamentals/data/assessment-definition.ts
@@ -1,0 +1,693 @@
+import type { AssessmentSeedDefinition } from '../../_shared/types';
+
+export const OBSERVABILITY_FUNDAMENTALS_SLUG = 'observability-fundamentals';
+
+// Bumpear cuando cambie la definición (secciones/preguntas) para forzar re-seed.
+export const OBSERVABILITY_FUNDAMENTALS_SEED_VERSION = 1;
+
+export const observabilityFundamentalsDefinition: AssessmentSeedDefinition = {
+  slug: OBSERVABILITY_FUNDAMENTALS_SLUG,
+  title: 'Observabilidad — Fundamentos',
+  description:
+    'Evaluación teórica de observabilidad para bootcamp de desarrollo backend: logging estructurado con Serilog, centralización de logs en Seq sobre Kubernetes, uso correcto de niveles de log, y visualización/consulta de logs para diagnosticar problemas en producción.',
+  level: 'Trainee a Junior',
+  type: 'Desarrollo DevOps',
+  duration_minutes: 40,
+  total_score: 100,
+  is_active: true,
+  metadata: {
+    moduleName: 'AIQUAA Assessments / Observability Fundamentals',
+    passingScore: 70,
+    candidateBands: [
+      { min: 0, max: 39, label: 'Inicial' },
+      { min: 40, max: 59, label: 'En formación' },
+      { min: 60, max: 74, label: 'Trainee' },
+      { min: 75, max: 89, label: 'Junior' },
+      { min: 90, max: 100, label: 'Junior avanzado' },
+    ],
+  },
+  sections: [
+    {
+      slug: 'logging-estructurado',
+      title: 'Logging estructurado',
+      description:
+        'Qué es el logging estructurado, cómo lo implementa Serilog con templates y properties, y por qué es superior al texto libre.',
+      order_index: 1,
+      max_score: 32,
+      metadata: {
+        instructions:
+          'Selección múltiple y verdadero/falso sobre logging estructurado con Serilog en aplicaciones .NET.',
+        suggestedMinutes: 13,
+      },
+      questions: [
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            '¿Qué es "logging estructurado" y en qué se diferencia de simplemente escribir texto libre en el log?',
+          options: [
+            {
+              label:
+                'El logging estructurado adjunta a cada evento propiedades como pares clave-valor (por ejemplo UserId, StatusCode) en vez de solo un mensaje de texto plano, permitiendo buscar y filtrar por esos campos en el sistema de logs',
+              value: 'a',
+            },
+            {
+              label: 'Es simplemente escribir los logs en mayúsculas',
+              value: 'b',
+            },
+            {
+              label:
+                'Es un sinónimo de guardar los logs en una base de datos SQL',
+              value: 'c',
+            },
+            {
+              label: 'No existe ninguna diferencia real con el texto libre',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'a' },
+          explanation:
+            'La diferencia clave es que el dato queda como campo consultable (UserId=123), no enterrado dentro de una cadena de texto que hay que parsear con expresiones regulares para extraer información.',
+          points: 4,
+          order_index: 1,
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt: '¿Qué es Serilog?',
+          options: [
+            {
+              label:
+                'Una librería de logging para .NET orientada a logging estructurado, que soporta múltiples destinos (sinks) configurables para enviar los eventos de log',
+              value: 'a',
+            },
+            {
+              label: 'Un servicio en la nube exclusivo de Microsoft Azure',
+              value: 'b',
+            },
+            { label: 'Un ORM para acceso a bases de datos', value: 'c' },
+            { label: 'Un framework de testing unitario', value: 'd' },
+          ],
+          correct_answer: { value: 'a' },
+          explanation:
+            'Serilog es una de las librerías de logging más usadas en el ecosistema .NET precisamente por su soporte de primera clase para eventos estructurados y su ecosistema de sinks (Console, File, Seq, Elasticsearch, etc.).',
+          points: 4,
+          order_index: 2,
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt: 'En Serilog, ¿qué es un "sink"?',
+          options: [
+            {
+              label:
+                'El destino al que se escriben los eventos de log (por ejemplo consola, archivo, Seq, Elasticsearch); una aplicación puede configurar varios sinks al mismo tiempo',
+              value: 'a',
+            },
+            { label: 'Un tipo de excepción especial de .NET', value: 'b' },
+            { label: 'El nivel mínimo de severidad de un log', value: 'c' },
+            { label: 'Un middleware de autenticación', value: 'd' },
+          ],
+          correct_answer: { value: 'a' },
+          explanation:
+            'Es común configurar múltiples sinks a la vez, por ejemplo Console para ver logs en desarrollo local y Seq para centralizarlos en un ambiente compartido, todo desde la misma configuración de Serilog.',
+          points: 4,
+          order_index: 3,
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            '¿Qué ventaja tiene escribir `Log.Information("Usuario {UserId} inició sesión", userId)` en vez de `Log.Information($"Usuario {userId} inició sesión")`?',
+          options: [
+            {
+              label:
+                'La primera forma preserva UserId como una propiedad estructurada y buscable en el backend de logs; la segunda ya interpoló el valor dentro del string, perdiendo esa estructura',
+              value: 'a',
+            },
+            {
+              label:
+                'No hay ninguna diferencia, ambas producen el mismo resultado',
+              value: 'b',
+            },
+            {
+              label:
+                'La segunda forma es más rápida en tiempo de ejecución siempre',
+              value: 'c',
+            },
+            {
+              label: 'La primera forma solo funciona con niveles Error',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'a' },
+          explanation:
+            'Con el template de mensaje ({UserId}), Serilog captura el valor como propiedad estructurada además de renderizarlo en el texto. La interpolación de C# ($"...") solo produce un string final, sin metadata para el sink.',
+          points: 4,
+          order_index: 4,
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            '¿Qué es el "enrichment" (enriquecimiento) de logs en Serilog?',
+          options: [
+            {
+              label:
+                'Agregar automáticamente propiedades contextuales a cada evento de log (por ejemplo ambiente, nombre de máquina, o un correlation/request id) sin tener que pasarlas manualmente en cada llamado a Log.Information',
+              value: 'a',
+            },
+            {
+              label: 'Traducir los mensajes de log a otros idiomas',
+              value: 'b',
+            },
+            {
+              label: 'Comprimir los archivos de log para ahorrar espacio',
+              value: 'c',
+            },
+            {
+              label: 'Cifrar el contenido de los logs automáticamente',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'a' },
+          explanation:
+            'Los enrichers se configuran una vez (por ejemplo con middlewares o `.Enrich.With...`) y agregan contexto a todos los logs generados durante ese scope, evitando repetir código en cada punto de logging.',
+          points: 4,
+          order_index: 5,
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            '¿Por qué es valioso incluir un correlationId (o requestId) en cada log generado durante una request HTTP?',
+          options: [
+            {
+              label:
+                'Permite reconstruir toda la secuencia de eventos de log relacionados a una request específica, incluso a través de múltiples servicios, facilitando enormemente el debugging',
+              value: 'a',
+            },
+            {
+              label:
+                'Es un requisito obligatorio de ASP.NET Core sin el cual la app no arranca',
+              value: 'b',
+            },
+            {
+              label: 'Reemplaza la necesidad de tener niveles de log',
+              value: 'c',
+            },
+            { label: 'Sirve únicamente para cumplir con GDPR', value: 'd' },
+          ],
+          correct_answer: { value: 'a' },
+          explanation:
+            'Sin un identificador común, los logs de una misma request quedan mezclados entre sí y con los de otras requests concurrentes. El correlationId permite filtrar "todo lo que pasó durante esta request" con una sola búsqueda.',
+          points: 4,
+          order_index: 6,
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            '¿Qué problema genera loggear información sensible (contraseñas, tokens completos, números de tarjeta) como propiedad estructurada?',
+          options: [
+            {
+              label:
+                'Esa información queda almacenada en el sistema de logs, a veces durante meses, expuesta a cualquiera con acceso a esos logs; los datos sensibles deben enmascararse u omitirse antes de loggear',
+              value: 'a',
+            },
+            {
+              label:
+                'Serilog rechaza automáticamente loggear cualquier dato sensible',
+              value: 'b',
+            },
+            {
+              label: 'No hay ningún problema, para eso existen los logs',
+              value: 'c',
+            },
+            {
+              label:
+                'Solo afecta el rendimiento de la aplicación, no la seguridad',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'a' },
+          explanation:
+            'Los logs suelen tener retención larga y ser accedidos por más personas que la base de datos de producción. Loggear un dato sensible es, en la práctica, otra forma de exponerlo, igual de grave que hardcodearlo en el código.',
+          points: 4,
+          order_index: 7,
+        },
+        {
+          question_type: 'true_false',
+          prompt:
+            'El logging estructurado permite realizar consultas como "todos los logs donde UserId=123 y StatusCode>=500" directamente sobre las propiedades, sin depender de expresiones regulares sobre texto libre.',
+          correct_answer: { value: true },
+          explanation:
+            'Esa es la ventaja central: como UserId y StatusCode son propiedades reales del evento (no texto embebido), un backend de logs estructurado puede indexarlas y consultarlas como si fueran columnas de una base de datos.',
+          points: 4,
+          order_index: 8,
+        },
+      ],
+    },
+    {
+      slug: 'centralizacion-de-logs',
+      title: 'Centralización de logs',
+      description:
+        'Por qué centralizar logs de múltiples réplicas en Kubernetes y cómo Serilog envía eventos a un servidor Seq.',
+      order_index: 2,
+      max_score: 24,
+      metadata: {
+        instructions:
+          'Preguntas sobre centralización de logs con Seq en un entorno con múltiples réplicas/Pods.',
+        suggestedMinutes: 10,
+      },
+      questions: [
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            'Una API corre replicada en varios Pods de Kubernetes. ¿Qué problema resuelve centralizar sus logs en un sistema como Seq en vez de dejarlos solo en la salida estándar de cada Pod?',
+          options: [
+            {
+              label:
+                'Sin centralización, cada Pod tiene sus propios logs aislados y efímeros; hay que revisar contenedor por contenedor. Centralizar permite buscar y correlacionar logs de todas las réplicas en un solo lugar',
+              value: 'a',
+            },
+            { label: 'Reduce el tiempo de arranque de los Pods', value: 'b' },
+            {
+              label: 'Elimina la necesidad de manejar excepciones en el código',
+              value: 'c',
+            },
+            {
+              label: 'No aporta ninguna ventaja real sobre logs locales',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'a' },
+          explanation:
+            'Con varias réplicas atendiendo tráfico, cualquier request puede haber sido servida por cualquier Pod. Sin centralización, encontrar los logs relevantes implicaría revisar cada Pod manualmente, algo inviable en producción.',
+          points: 4,
+          order_index: 1,
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt: '¿Qué es Seq?',
+          options: [
+            {
+              label:
+                'Un servidor centralizado que recibe, almacena e indexa eventos de log estructurados, con una interfaz web para consultarlos',
+              value: 'a',
+            },
+            { label: 'Un proveedor de Kubernetes administrado', value: 'b' },
+            { label: 'Una librería de testing para .NET', value: 'c' },
+            { label: 'Un tipo de base de datos relacional', value: 'd' },
+          ],
+          correct_answer: { value: 'a' },
+          explanation:
+            'Seq está diseñado específicamente para recibir eventos de log estructurados (como los que produce Serilog) e indexar sus propiedades, habilitando búsquedas rápidas y precisas.',
+          points: 4,
+          order_index: 2,
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            '¿Cómo suele enviar Serilog los eventos de log a un servidor Seq?',
+          options: [
+            {
+              label:
+                'Mediante el sink de Seq configurado con la URL del servidor (por ejemplo `.WriteTo.Seq("http://seq:5341")`), que envía cada evento estructurado por HTTP',
+              value: 'a',
+            },
+            {
+              label:
+                'Copiando manualmente archivos de texto al servidor cada noche',
+              value: 'b',
+            },
+            {
+              label: 'Seq lee directamente la memoria del proceso .NET',
+              value: 'c',
+            },
+            { label: 'No es posible integrar Serilog con Seq', value: 'd' },
+          ],
+          correct_answer: { value: 'a' },
+          explanation:
+            'El sink de Seq es un paquete NuGet (Serilog.Sinks.Seq) que, una vez configurado con la URL del servidor, envía automáticamente cada evento de log generado por la aplicación.',
+          points: 4,
+          order_index: 3,
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            '¿Qué ventaja concreta tiene que los logs sobrevivan aunque el Pod que los generó se reinicie o sea eliminado?',
+          options: [
+            {
+              label:
+                'Permite investigar un incidente después de que el Pod problemático ya no exista; los logs locales de un contenedor se pierden si el Pod es destruido (por ejemplo, en un crash o un reescalado)',
+              value: 'a',
+            },
+            {
+              label: 'Hace que el Pod arranque más rápido la próxima vez',
+              value: 'b',
+            },
+            { label: 'Reduce el consumo de CPU del Pod', value: 'c' },
+            { label: 'No tiene ninguna ventaja real', value: 'd' },
+          ],
+          correct_answer: { value: 'a' },
+          explanation:
+            'Un Pod que crasheó por el mismo error que se quiere investigar puede ya no existir para cuando alguien revisa el problema. Sin centralización, esa evidencia se pierde junto con el Pod.',
+          points: 4,
+          order_index: 4,
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            'Con múltiples réplicas de la misma API corriendo en Kubernetes, ¿por qué es importante que todas envíen logs al mismo servidor Seq centralizado, en vez de cada una a su propio archivo local?',
+          options: [
+            {
+              label:
+                'Para poder correlacionar y buscar eventos relacionados sin importar qué réplica específica atendió cada request, viendo el comportamiento del sistema como un todo',
+              value: 'a',
+            },
+            {
+              label: 'Porque Kubernetes lo exige por configuración',
+              value: 'b',
+            },
+            {
+              label:
+                'Porque cada réplica solo puede escribir logs si hay un servidor central',
+              value: 'c',
+            },
+            { label: 'No hay ninguna razón real para hacerlo', value: 'd' },
+          ],
+          correct_answer: { value: 'a' },
+          explanation:
+            'Un balanceador de carga distribuye requests entre réplicas de forma que el usuario/desarrollador no controla. Si los logs quedaran separados por réplica, reconstruir el comportamiento de un flujo completo sería mucho más difícil.',
+          points: 4,
+          order_index: 5,
+        },
+        {
+          question_type: 'true_false',
+          prompt:
+            'Enviar logs a un servidor centralizado como Seq reemplaza la necesidad de tener niveles de log (Information/Warning/Error), porque después todo se puede filtrar en la UI.',
+          correct_answer: { value: false },
+          explanation:
+            'Los niveles de log siguen siendo esenciales: determinan qué se loggea en primer lugar (volumen, costo, ruido) y permiten configurar alertas por severidad. La centralización ayuda a consultarlos, no a decidir qué merece ser un log.',
+          points: 4,
+          order_index: 6,
+        },
+      ],
+    },
+    {
+      slug: 'niveles-y-tipos-de-log',
+      title: 'Niveles y tipos de log',
+      description:
+        'Uso correcto de Information, Warning, Error y Debug, y por qué el nivel elegido importa tanto como el mensaje.',
+      order_index: 3,
+      max_score: 24,
+      metadata: {
+        instructions:
+          'Preguntas sobre el uso correcto de los niveles de severidad de log.',
+        suggestedMinutes: 10,
+      },
+      questions: [
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            '¿Cuál es la diferencia de propósito entre los niveles Information, Warning y Error?',
+          options: [
+            {
+              label:
+                'Information registra eventos normales del funcionamiento de la aplicación; Warning indica algo inesperado que no interrumpió el flujo; Error indica que algo falló y requiere atención',
+              value: 'a',
+            },
+            {
+              label: 'Son sinónimos, cualquiera puede usarse indistintamente',
+              value: 'b',
+            },
+            {
+              label:
+                'Information es solo para desarrollo y Error solo para producción',
+              value: 'c',
+            },
+            { label: 'Warning es más grave que Error', value: 'd' },
+          ],
+          correct_answer: { value: 'a' },
+          explanation:
+            'La jerarquía de severidad existe justamente para que herramientas de monitoreo y personas puedan priorizar: un Error merece atención inmediata, un Warning se revisa cuando hay tiempo, un Information es contexto normal.',
+          points: 4,
+          order_index: 1,
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt: '¿Cuándo es apropiado usar el nivel Warning en vez de Error?',
+          options: [
+            {
+              label:
+                'Cuando ocurre algo anómalo que la aplicación pudo manejar o recuperar sin interrumpir el flujo (por ejemplo, un reintento que funcionó, o un valor por defecto usado porque faltaba una configuración opcional)',
+              value: 'a',
+            },
+            {
+              label: 'Cuando el sistema completo dejó de funcionar',
+              value: 'b',
+            },
+            {
+              label: 'Nunca, Warning está deprecado y no debería usarse',
+              value: 'c',
+            },
+            {
+              label: 'Solo para logs generados los fines de semana',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'a' },
+          explanation:
+            'Warning comunica "esto merece que alguien lo revise, pero el sistema siguió funcionando correctamente". Confundirlo con Error genera ruido en las alertas de severidad alta.',
+          points: 4,
+          order_index: 2,
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            '¿Por qué loggear cada request HTTP exitosa con nivel Error sería un anti-patrón?',
+          options: [
+            {
+              label:
+                'Error debería reservarse para fallos reales; usarlo indiscriminadamente genera ruido, hace que las alertas basadas en ese nivel pierdan valor (fatiga de alertas) y dificulta encontrar los errores reales entre el volumen',
+              value: 'a',
+            },
+            {
+              label: 'Error consume más CPU que Information al escribirse',
+              value: 'b',
+            },
+            {
+              label: 'ASP.NET Core bloquea las requests si se usa Error',
+              value: 'c',
+            },
+            { label: 'No genera ningún problema real', value: 'd' },
+          ],
+          correct_answer: { value: 'a' },
+          explanation:
+            'Si el equipo recibe una alerta cada vez que hay un log Error y el 99% son requests exitosas mal clasificadas, terminan ignorando las alertas, incluyendo las que sí importan.',
+          points: 4,
+          order_index: 3,
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt: '¿Qué es el nivel Debug/Verbose y cuándo suele habilitarse?',
+          options: [
+            {
+              label:
+                'Es el nivel más detallado, usado para diagnóstico fino durante desarrollo o troubleshooting; normalmente se deja deshabilitado en producción por el volumen que genera, y se habilita temporalmente para investigar un problema puntual',
+              value: 'a',
+            },
+            {
+              label:
+                'Es el nivel usado exclusivamente para errores de seguridad',
+              value: 'b',
+            },
+            { label: 'Reemplaza a Information en producción', value: 'c' },
+            { label: 'Solo existe en versiones antiguas de .NET', value: 'd' },
+          ],
+          correct_answer: { value: 'a' },
+          explanation:
+            'Debug/Verbose registra detalles internos (valores intermedios, flujo de ejecución fino) que son ruido en operación normal pero valiosos cuando hay que reproducir un bug específico paso a paso.',
+          points: 4,
+          order_index: 4,
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            '¿Qué información mínima debería incluir un log de nivel Error para ser útil al investigar un incidente en producción?',
+          options: [
+            {
+              label:
+                'El mensaje/excepción completa con su stack trace, contexto relevante (usuario, request, operación que se estaba ejecutando) y timestamp — suficiente para entender qué pasó sin tener que reproducir el bug en vivo',
+              value: 'a',
+            },
+            {
+              label:
+                'Solo la palabra "Error" sin más detalle, para no saturar el log',
+              value: 'b',
+            },
+            {
+              label: 'Únicamente el código de la línea donde ocurrió',
+              value: 'c',
+            },
+            {
+              label:
+                'La contraseña del usuario afectado, para poder contactarlo',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'a' },
+          explanation:
+            'Un Error sin contexto suficiente obliga a reproducir el problema manualmente, perdiendo tiempo valioso. El objetivo del logging es justamente evitar esa reproducción manual siempre que sea posible.',
+          points: 4,
+          order_index: 5,
+        },
+        {
+          question_type: 'true_false',
+          prompt:
+            'Configurar niveles de log distintos por ambiente (por ejemplo Debug en desarrollo, Information en producción) es una práctica común para controlar el volumen y el ruido de logs sin tener que cambiar el código de la aplicación.',
+          correct_answer: { value: true },
+          explanation:
+            'El nivel mínimo de log suele configurarse externamente (appsettings.json, variable de entorno), no hardcodeado, precisamente para poder ajustar el volumen por ambiente sin recompilar la aplicación.',
+          points: 4,
+          order_index: 6,
+        },
+      ],
+    },
+    {
+      slug: 'visualizacion-en-seq',
+      title: 'Visualización en Seq',
+      description:
+        'Consultar, filtrar y usar los logs centralizados en Seq para diagnosticar el comportamiento de la aplicación.',
+      order_index: 4,
+      max_score: 20,
+      metadata: {
+        instructions:
+          'Preguntas sobre la consulta y visualización de logs en la UI de Seq.',
+        suggestedMinutes: 8,
+      },
+      questions: [
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            '¿Qué permite hacer la interfaz web de Seq con los logs estructurados recibidos?',
+          options: [
+            {
+              label:
+                'Buscar y filtrar por propiedades específicas (por ejemplo UserId, StatusCode) usando un lenguaje de consulta similar a SQL, y visualizar la evolución de eventos en el tiempo',
+              value: 'a',
+            },
+            {
+              label: 'Solo permite descargar los logs como un archivo .zip',
+              value: 'b',
+            },
+            {
+              label: 'Únicamente muestra el último log recibido, sin historial',
+              value: 'c',
+            },
+            {
+              label:
+                'Sirve exclusivamente para editar el código fuente de la aplicación',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'a' },
+          explanation:
+            'La UI de Seq expone las propiedades estructuradas como columnas consultables, lo que la hace mucho más potente que revisar archivos de texto plano para encontrar patrones o eventos específicos.',
+          points: 4,
+          order_index: 1,
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            '¿Para qué sirve guardar una consulta filtrada como "signal" en Seq?',
+          options: [
+            {
+              label:
+                'Para reutilizar rápidamente una vista o filtro frecuente (por ejemplo, "todos los errores del módulo de pagos") sin tener que reescribir la consulta cada vez que se necesita',
+              value: 'a',
+            },
+            {
+              label: 'Para borrar automáticamente los logs antiguos',
+              value: 'b',
+            },
+            { label: 'Para encriptar los logs almacenados', value: 'c' },
+            {
+              label:
+                'Es un requisito obligatorio para poder loggear con Serilog',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'a' },
+          explanation:
+            'Guardar consultas frecuentes ahorra tiempo y estandariza cómo el equipo mira ciertos problemas recurrentes, en vez de que cada persona reconstruya el filtro desde cero.',
+          points: 4,
+          order_index: 2,
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            '¿Por qué visualizar los logs en una herramienta como Seq es generalmente más efectivo que revisar archivos de texto plano manualmente?',
+          options: [
+            {
+              label:
+                'Permite filtrar, ordenar y correlacionar grandes volúmenes de eventos estructurados en segundos, algo poco práctico haciendo búsquedas de texto sobre archivos dispersos entre múltiples Pods',
+              value: 'a',
+            },
+            {
+              label:
+                'Los archivos de texto plano no pueden contener logs de error',
+              value: 'b',
+            },
+            {
+              label: 'No hay ninguna diferencia real en la práctica',
+              value: 'c',
+            },
+            {
+              label: 'Seq elimina automáticamente todos los bugs del código',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'a' },
+          explanation:
+            'Con múltiples réplicas generando miles de líneas de log, grep-ear archivos manualmente escala muy mal comparado con consultas indexadas sobre propiedades estructuradas.',
+          points: 4,
+          order_index: 3,
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            'Después de desplegar un cambio en producción, querés verificar rápidamente si aumentaron los errores. ¿Qué acción en Seq sería la más directa?',
+          options: [
+            {
+              label:
+                'Filtrar por nivel Error acotado al rango de tiempo posterior al despliegue, y comparar el volumen contra el período previo al deploy',
+              value: 'a',
+            },
+            {
+              label: 'Esperar a que un usuario reporte manualmente un problema',
+              value: 'b',
+            },
+            {
+              label: 'Revisar el código fuente línea por línea buscando bugs',
+              value: 'c',
+            },
+            {
+              label: 'Reiniciar todos los Pods para "limpiar" los errores',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'a' },
+          explanation:
+            'Esta es exactamente la clase de verificación rápida post-deploy que la observabilidad habilita: comparar el comportamiento antes/después sin depender de que alguien externo reporte el problema primero.',
+          points: 4,
+          order_index: 4,
+        },
+        {
+          question_type: 'true_false',
+          prompt:
+            'Revisar el dashboard de Seq después de un despliegue es una forma válida de detectar rápidamente si el cambio introdujo nuevos errores, sin necesidad de esperar a que un usuario reporte un problema.',
+          correct_answer: { value: true },
+          explanation:
+            'Esta es una de las razones principales por las que se invierte en observabilidad: detectar problemas de forma proactiva (monitoreo activo) en vez de reactiva (esperar reportes de usuarios).',
+          points: 4,
+          order_index: 5,
+        },
+      ],
+    },
+  ],
+};

--- a/apps/frontend/src/app/assessments/observability-fundamentals/lib/gamification.ts
+++ b/apps/frontend/src/app/assessments/observability-fundamentals/lib/gamification.ts
@@ -1,0 +1,15 @@
+import { createAssessmentGamification } from '../../_shared/lib/gamification';
+
+const gamification = createAssessmentGamification({
+  prefix: 'OBSERVABILITY_FUNDAMENTALS',
+  descriptions: {
+    completed: 'Completar el assessment Observability Fundamentals',
+    passed: 'Aprobar el assessment Observability Fundamentals (score >= 70)',
+    highScore: 'Score sobresaliente en Observability Fundamentals (>= 90)',
+  },
+});
+
+export const OBSERVABILITY_FUNDAMENTALS_GAMIFICATION_RULES = gamification.rules;
+
+export const buildObservabilityFundamentalsGamificationEvents =
+  gamification.buildEvents;

--- a/apps/frontend/src/app/assessments/observability-fundamentals/lib/seed.ts
+++ b/apps/frontend/src/app/assessments/observability-fundamentals/lib/seed.ts
@@ -1,0 +1,12 @@
+import { ensureAssessmentSeeded } from '../../_shared/lib/seed';
+import {
+  OBSERVABILITY_FUNDAMENTALS_SEED_VERSION,
+  observabilityFundamentalsDefinition,
+} from '../data/assessment-definition';
+
+export async function ensureObservabilityFundamentalsSeeded() {
+  return ensureAssessmentSeeded(
+    observabilityFundamentalsDefinition,
+    OBSERVABILITY_FUNDAMENTALS_SEED_VERSION
+  );
+}

--- a/apps/frontend/src/app/assessments/observability-fundamentals/page.tsx
+++ b/apps/frontend/src/app/assessments/observability-fundamentals/page.tsx
@@ -1,0 +1,91 @@
+import { Metadata } from 'next';
+import { observabilityFundamentalsDefinition } from './data/assessment-definition';
+import AssessmentWelcome from '../_shared/components/AssessmentWelcome';
+
+export const metadata: Metadata = {
+  title: 'Observabilidad — Fundamentos | AIQUAA',
+  description:
+    'Prueba técnica teórica para bootcamp de desarrollo: logging estructurado con Serilog, centralización de logs en Seq sobre Kubernetes, niveles de log y visualización para diagnosticar producción.',
+  keywords: [
+    'observabilidad',
+    'Serilog',
+    'Seq',
+    'logging estructurado',
+    'niveles de log',
+    'monitoreo',
+    'desarrollo backend',
+    'DevOps',
+    'bootcamp',
+    'AIQUAA',
+    'evaluación técnica',
+  ],
+  openGraph: {
+    title: 'Observabilidad — Fundamentos | AIQUAA',
+    description:
+      'Prueba técnica teórica sobre logging estructurado, centralización en Seq, niveles de log y visualización.',
+    url: 'https://aiquaa.com/assessments/observability-fundamentals',
+    siteName: 'AIQUAA',
+    type: 'website',
+    locale: 'es_PY',
+    images: [
+      {
+        url: '/api/og?title=Observabilidad%20-%20Fundamentos&subtitle=Serilog%2C%20Seq%20y%20niveles%20de%20log&section=Assessments',
+        width: 1200,
+        height: 630,
+        alt: 'Observabilidad Fundamentos - AIQUAA',
+      },
+    ],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Observabilidad — Fundamentos | AIQUAA',
+    description:
+      'Prueba técnica sobre logging estructurado, Serilog, Seq y niveles de log.',
+    images: [
+      '/api/og?title=Observabilidad%20-%20Fundamentos&subtitle=Serilog%2C%20Seq%20y%20niveles%20de%20log&section=Assessments',
+    ],
+    creator: '@stevenayal',
+  },
+  alternates: {
+    canonical: 'https://aiquaa.com/assessments/observability-fundamentals',
+  },
+};
+
+export default function ObservabilityFundamentalsPage() {
+  const overview = {
+    assessment: {
+      id: 'static-observability-fundamentals',
+      slug: observabilityFundamentalsDefinition.slug,
+      title: observabilityFundamentalsDefinition.title,
+      description: observabilityFundamentalsDefinition.description,
+      level: observabilityFundamentalsDefinition.level,
+      type: observabilityFundamentalsDefinition.type,
+      duration_minutes: observabilityFundamentalsDefinition.duration_minutes,
+      total_score: observabilityFundamentalsDefinition.total_score,
+      is_active: observabilityFundamentalsDefinition.is_active,
+      metadata: observabilityFundamentalsDefinition.metadata,
+    },
+    sections: observabilityFundamentalsDefinition.sections.map(
+      (section, index) => ({
+        id: `static-section-${index + 1}`,
+        assessment_id: 'static-observability-fundamentals',
+        slug: section.slug,
+        title: section.title,
+        description: section.description,
+        order_index: section.order_index,
+        max_score: section.max_score,
+        metadata: section.metadata,
+      })
+    ),
+  };
+
+  return (
+    <AssessmentWelcome
+      overview={overview}
+      startHref="/assessments/observability-fundamentals/start"
+      evaluatesCopy="Logging estructurado con Serilog (templates, properties, sinks, enrichment); centralización de logs de múltiples réplicas en Seq sobre Kubernetes; uso correcto de niveles Information/Warning/Error/Debug; consulta y visualización de logs en Seq para diagnosticar producción."
+      scoringCopy="Automático en las 4 secciones: selección múltiple y verdadero/falso."
+      resultCopy="Score total, score por sección, fortalezas, debilidades y temas a reforzar."
+    />
+  );
+}

--- a/apps/frontend/src/app/assessments/observability-fundamentals/result/page.tsx
+++ b/apps/frontend/src/app/assessments/observability-fundamentals/result/page.tsx
@@ -1,0 +1,19 @@
+import { Suspense } from 'react';
+import AssessmentResultClient from '../../_shared/components/AssessmentResultClient';
+
+export default function ObservabilityFundamentalsResultPage() {
+  return (
+    <Suspense
+      fallback={
+        <div className="min-h-screen flex items-center justify-center bg-slate-950">
+          <div className="h-10 w-10 animate-spin rounded-full border-t-2 border-cyan-400" />
+        </div>
+      }
+    >
+      <AssessmentResultClient
+        startHref="/assessments/observability-fundamentals/start"
+        fallbackRecommendation="Repasá la documentación oficial de Serilog (logging estructurado, sinks, enrichment) y de Seq (ingesta, consultas y signals), practicando con niveles de log correctos en una app .NET."
+      />
+    </Suspense>
+  );
+}

--- a/apps/frontend/src/app/assessments/observability-fundamentals/section/[sectionId]/page.tsx
+++ b/apps/frontend/src/app/assessments/observability-fundamentals/section/[sectionId]/page.tsx
@@ -1,0 +1,9 @@
+'use client';
+
+import AssessmentSectionScreen from '../../../_shared/components/AssessmentSectionScreen';
+
+export default function ObservabilityFundamentalsSectionPage() {
+  return (
+    <AssessmentSectionScreen basePath="/assessments/observability-fundamentals" />
+  );
+}

--- a/apps/frontend/src/app/assessments/observability-fundamentals/start/page.tsx
+++ b/apps/frontend/src/app/assessments/observability-fundamentals/start/page.tsx
@@ -1,0 +1,137 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { useTheme } from '@/contexts/ThemeContext';
+import { startAssessmentAttemptAction } from '@/actions/assessments';
+import ProcessCodeInput from '@/components/labs/ProcessCodeInput';
+import { OBSERVABILITY_FUNDAMENTALS_SLUG } from '../data/assessment-definition';
+
+export default function StartObservabilityFundamentalsPage() {
+  const router = useRouter();
+  const { isDarkMode } = useTheme();
+  const [processCode, setProcessCode] = useState('');
+  const [error, setError] = useState('');
+  const [isStarting, setIsStarting] = useState(false);
+
+  // Pre-fill desde ?code= (links de invitaciones/procesos de empresa)
+  useEffect(() => {
+    const codeParam = new URLSearchParams(window.location.search).get('code');
+    if (codeParam) setProcessCode(codeParam);
+  }, []);
+
+  async function handleStart() {
+    setError('');
+    setIsStarting(true);
+
+    try {
+      const result = await startAssessmentAttemptAction({
+        slug: OBSERVABILITY_FUNDAMENTALS_SLUG,
+        processCode,
+      });
+
+      if ('error' in result) {
+        setIsStarting(false);
+        setError(result.error);
+        return;
+      }
+
+      const { attempt, sectionSlug } = result;
+
+      if (!sectionSlug) {
+        setIsStarting(false);
+        setError('No se encontró la primera sección del assessment.');
+        return;
+      }
+
+      setIsStarting(false);
+      router.push(
+        `/assessments/observability-fundamentals/section/${sectionSlug}?attempt=${attempt.id}`
+      );
+    } catch (startError) {
+      setIsStarting(false);
+      setError(
+        startError instanceof Error
+          ? startError.message
+          : 'No se pudo iniciar el assessment.'
+      );
+    }
+  }
+
+  return (
+    <div
+      className={`min-h-screen px-4 py-12 ${
+        isDarkMode ? 'bg-slate-950 text-white' : 'bg-slate-50 text-slate-900'
+      }`}
+    >
+      <div className="mx-auto max-w-3xl rounded-3xl border border-slate-800 bg-slate-900/80 p-8 text-slate-50 shadow-2xl shadow-cyan-950/20">
+        <p className="text-sm font-semibold uppercase tracking-[0.18em] text-cyan-200">
+          Preparación del intento
+        </p>
+        <h1 className="mt-3 text-3xl font-bold">
+          Observabilidad — Fundamentos
+        </h1>
+        <p className="mt-3 text-slate-300">
+          Vas a completar 4 secciones teóricas con autosave, scoring por sección
+          y resultado final consolidado.
+        </p>
+
+        <div className="mt-8 grid gap-4 rounded-2xl border border-slate-800 bg-slate-950/70 p-5 md:grid-cols-3">
+          <div>
+            <p className="text-xs uppercase tracking-[0.18em] text-slate-400">
+              Duración sugerida
+            </p>
+            <p className="mt-2 text-lg font-semibold">~40 minutos</p>
+          </div>
+          <div>
+            <p className="text-xs uppercase tracking-[0.18em] text-slate-400">
+              Modalidad
+            </p>
+            <p className="mt-2 text-lg font-semibold">Conceptual</p>
+          </div>
+          <div>
+            <p className="text-xs uppercase tracking-[0.18em] text-slate-400">
+              Resultado
+            </p>
+            <p className="mt-2 text-lg font-semibold">Score total sobre 100</p>
+          </div>
+        </div>
+
+        <div className="mt-8">
+          <ProcessCodeInput
+            value={processCode}
+            onChange={setProcessCode}
+            onNormalizedCode={setProcessCode}
+            autoValidate
+          />
+        </div>
+
+        {error ? (
+          <div className="mt-6 rounded-2xl border border-red-500/30 bg-red-500/10 px-4 py-3 text-sm text-red-200">
+            {error}
+          </div>
+        ) : null}
+
+        <div className="mt-8 flex flex-col gap-3 sm:flex-row">
+          <button
+            type="button"
+            onClick={handleStart}
+            disabled={isStarting}
+            className="inline-flex items-center justify-center rounded-2xl bg-cyan-400 px-5 py-3 text-sm font-semibold text-slate-950 transition hover:bg-cyan-300 disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {isStarting ? 'Preparando intento...' : 'Iniciar o reanudar'}
+          </button>
+          <button
+            type="button"
+            onClick={() =>
+              router.push('/assessments/observability-fundamentals')
+            }
+            className="inline-flex items-center justify-center rounded-2xl border border-slate-700 px-5 py-3 text-sm font-semibold text-slate-200 transition hover:bg-slate-800"
+          >
+            Volver al overview
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/src/app/assessments/page.tsx
+++ b/apps/frontend/src/app/assessments/page.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link';
 import { apiDeveloperFundamentalsDefinition } from './api-developer-fundamentals/data/assessment-definition';
 import { apiDotnetFundamentalsDefinition } from './api-dotnet-fundamentals/data/assessment-definition';
+import { cicdFundamentalsDefinition } from './cicd-fundamentals/data/assessment-definition';
 import { apiTestingFundamentalsDefinition } from './api-testing-fundamentals/data/assessment-definition';
 import { databaseFundamentalsDefinition } from './database-fundamentals/data/assessment-definition';
 import { dockerFundamentalsDefinition } from './docker-fundamentals/data/assessment-definition';
@@ -69,6 +70,13 @@ export default function AssessmentsIndexPage() {
       badgeColor: 'text-amber-300',
       accentColor: 'text-teal-200',
       buttonClass: 'bg-teal-500 hover:bg-teal-400',
+    },
+    {
+      definition: cicdFundamentalsDefinition,
+      badge: 'Examen teórico · Auto-corregido · CI/CD',
+      badgeColor: 'text-amber-300',
+      accentColor: 'text-orange-200',
+      buttonClass: 'bg-orange-500 hover:bg-orange-400',
     },
     {
       definition: playwrightFundamentalsDefinition,

--- a/apps/frontend/src/app/assessments/page.tsx
+++ b/apps/frontend/src/app/assessments/page.tsx
@@ -3,6 +3,7 @@ import { apiDeveloperFundamentalsDefinition } from './api-developer-fundamentals
 import { apiDotnetFundamentalsDefinition } from './api-dotnet-fundamentals/data/assessment-definition';
 import { apiTestingFundamentalsDefinition } from './api-testing-fundamentals/data/assessment-definition';
 import { databaseFundamentalsDefinition } from './database-fundamentals/data/assessment-definition';
+import { dockerFundamentalsDefinition } from './docker-fundamentals/data/assessment-definition';
 import { databasePracticeDefinition } from './database-practice/data/assessment-definition';
 import { gherkinFundamentalsDefinition } from './gherkin-fundamentals/data/assessment-definition';
 import { infrastructureFundamentalsDefinition } from './infrastructure-fundamentals/data/assessment-definition';
@@ -45,6 +46,13 @@ export default function AssessmentsIndexPage() {
       badgeColor: 'text-amber-300',
       accentColor: 'text-violet-200',
       buttonClass: 'bg-violet-500 hover:bg-violet-400',
+    },
+    {
+      definition: dockerFundamentalsDefinition,
+      badge: 'Examen teórico · Auto-corregido · Docker',
+      badgeColor: 'text-amber-300',
+      accentColor: 'text-blue-200',
+      buttonClass: 'bg-blue-500 hover:bg-blue-400',
     },
     {
       definition: playwrightFundamentalsDefinition,

--- a/apps/frontend/src/app/assessments/page.tsx
+++ b/apps/frontend/src/app/assessments/page.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link';
 import { apiDeveloperFundamentalsDefinition } from './api-developer-fundamentals/data/assessment-definition';
+import { apiDotnetFundamentalsDefinition } from './api-dotnet-fundamentals/data/assessment-definition';
 import { apiTestingFundamentalsDefinition } from './api-testing-fundamentals/data/assessment-definition';
 import { databaseFundamentalsDefinition } from './database-fundamentals/data/assessment-definition';
 import { databasePracticeDefinition } from './database-practice/data/assessment-definition';
@@ -37,6 +38,13 @@ export default function AssessmentsIndexPage() {
       badgeColor: 'text-amber-300',
       accentColor: 'text-indigo-200',
       buttonClass: 'bg-indigo-500 hover:bg-indigo-400',
+    },
+    {
+      definition: apiDotnetFundamentalsDefinition,
+      badge: 'Examen teórico · Auto-corregido · .NET',
+      badgeColor: 'text-amber-300',
+      accentColor: 'text-violet-200',
+      buttonClass: 'bg-violet-500 hover:bg-violet-400',
     },
     {
       definition: playwrightFundamentalsDefinition,

--- a/apps/frontend/src/app/assessments/page.tsx
+++ b/apps/frontend/src/app/assessments/page.tsx
@@ -7,6 +7,7 @@ import { dockerFundamentalsDefinition } from './docker-fundamentals/data/assessm
 import { databasePracticeDefinition } from './database-practice/data/assessment-definition';
 import { gherkinFundamentalsDefinition } from './gherkin-fundamentals/data/assessment-definition';
 import { infrastructureFundamentalsDefinition } from './infrastructure-fundamentals/data/assessment-definition';
+import { kubernetesHelmFundamentalsDefinition } from './kubernetes-helm-fundamentals/data/assessment-definition';
 import { playwrightFundamentalsDefinition } from './playwright-fundamentals/data/assessment-definition';
 
 export default function AssessmentsIndexPage() {
@@ -53,6 +54,13 @@ export default function AssessmentsIndexPage() {
       badgeColor: 'text-amber-300',
       accentColor: 'text-blue-200',
       buttonClass: 'bg-blue-500 hover:bg-blue-400',
+    },
+    {
+      definition: kubernetesHelmFundamentalsDefinition,
+      badge: 'Examen teórico · Auto-corregido · Kubernetes',
+      badgeColor: 'text-amber-300',
+      accentColor: 'text-sky-200',
+      buttonClass: 'bg-sky-500 hover:bg-sky-400',
     },
     {
       definition: playwrightFundamentalsDefinition,

--- a/apps/frontend/src/app/assessments/page.tsx
+++ b/apps/frontend/src/app/assessments/page.tsx
@@ -8,6 +8,7 @@ import { databasePracticeDefinition } from './database-practice/data/assessment-
 import { gherkinFundamentalsDefinition } from './gherkin-fundamentals/data/assessment-definition';
 import { infrastructureFundamentalsDefinition } from './infrastructure-fundamentals/data/assessment-definition';
 import { kubernetesHelmFundamentalsDefinition } from './kubernetes-helm-fundamentals/data/assessment-definition';
+import { observabilityFundamentalsDefinition } from './observability-fundamentals/data/assessment-definition';
 import { playwrightFundamentalsDefinition } from './playwright-fundamentals/data/assessment-definition';
 
 export default function AssessmentsIndexPage() {
@@ -61,6 +62,13 @@ export default function AssessmentsIndexPage() {
       badgeColor: 'text-amber-300',
       accentColor: 'text-sky-200',
       buttonClass: 'bg-sky-500 hover:bg-sky-400',
+    },
+    {
+      definition: observabilityFundamentalsDefinition,
+      badge: 'Examen teórico · Auto-corregido · Observabilidad',
+      badgeColor: 'text-amber-300',
+      accentColor: 'text-teal-200',
+      buttonClass: 'bg-teal-500 hover:bg-teal-400',
     },
     {
       definition: playwrightFundamentalsDefinition,

--- a/apps/frontend/src/app/dashboard/page.tsx
+++ b/apps/frontend/src/app/dashboard/page.tsx
@@ -86,6 +86,7 @@ export default function DashboardPage() {
     'api-dotnet-fundamentals',
     'docker-fundamentals',
     'kubernetes-helm-fundamentals',
+    'observability-fundamentals',
     'playwright-practico',
     'gherkin-fundamentals',
   ];

--- a/apps/frontend/src/app/dashboard/page.tsx
+++ b/apps/frontend/src/app/dashboard/page.tsx
@@ -83,6 +83,7 @@ export default function DashboardPage() {
     'database-practice',
     'infrastructure-fundamentals',
     'api-developer-fundamentals',
+    'api-dotnet-fundamentals',
     'playwright-practico',
     'gherkin-fundamentals',
   ];

--- a/apps/frontend/src/app/dashboard/page.tsx
+++ b/apps/frontend/src/app/dashboard/page.tsx
@@ -87,6 +87,7 @@ export default function DashboardPage() {
     'docker-fundamentals',
     'kubernetes-helm-fundamentals',
     'observability-fundamentals',
+    'cicd-fundamentals',
     'playwright-practico',
     'gherkin-fundamentals',
   ];

--- a/apps/frontend/src/app/dashboard/page.tsx
+++ b/apps/frontend/src/app/dashboard/page.tsx
@@ -85,6 +85,7 @@ export default function DashboardPage() {
     'api-developer-fundamentals',
     'api-dotnet-fundamentals',
     'docker-fundamentals',
+    'kubernetes-helm-fundamentals',
     'playwright-practico',
     'gherkin-fundamentals',
   ];

--- a/apps/frontend/src/app/dashboard/page.tsx
+++ b/apps/frontend/src/app/dashboard/page.tsx
@@ -84,6 +84,7 @@ export default function DashboardPage() {
     'infrastructure-fundamentals',
     'api-developer-fundamentals',
     'api-dotnet-fundamentals',
+    'docker-fundamentals',
     'playwright-practico',
     'gherkin-fundamentals',
   ];

--- a/apps/frontend/src/lib/exams.ts
+++ b/apps/frontend/src/lib/exams.ts
@@ -17,6 +17,7 @@ export type ExamType =
   | 'api-dotnet-fundamentals'
   | 'docker-fundamentals'
   | 'kubernetes-helm-fundamentals'
+  | 'observability-fundamentals'
   | 'playwright-practico'
   | 'playwright-fundamentals'
   | 'gherkin-fundamentals';
@@ -90,6 +91,11 @@ export const EXAM_META: Record<ExamType, ExamMeta> = {
     label: 'Kubernetes + Helm — Fundamentos',
     href: '/assessments/kubernetes-helm-fundamentals',
   },
+  'observability-fundamentals': {
+    emoji: '📈',
+    label: 'Observabilidad — Fundamentos',
+    href: '/assessments/observability-fundamentals',
+  },
   'playwright-practico': {
     emoji: '🎭',
     label: 'Playwright — Prueba práctica',
@@ -121,6 +127,7 @@ export const POINTS_BASED_TYPES = new Set<ExamType>([
   'api-dotnet-fundamentals',
   'docker-fundamentals',
   'kubernetes-helm-fundamentals',
+  'observability-fundamentals',
   'playwright-practico',
   'playwright-fundamentals',
   'gherkin-fundamentals',

--- a/apps/frontend/src/lib/exams.ts
+++ b/apps/frontend/src/lib/exams.ts
@@ -14,6 +14,7 @@ export type ExamType =
   | 'database-practice'
   | 'infrastructure-fundamentals'
   | 'api-developer-fundamentals'
+  | 'api-dotnet-fundamentals'
   | 'playwright-practico'
   | 'playwright-fundamentals'
   | 'gherkin-fundamentals';
@@ -72,6 +73,11 @@ export const EXAM_META: Record<ExamType, ExamMeta> = {
     label: 'APIs para Desarrolladores — Fundamentos',
     href: '/assessments/api-developer-fundamentals',
   },
+  'api-dotnet-fundamentals': {
+    emoji: '🟣',
+    label: 'API .NET — Fundamentos',
+    href: '/assessments/api-dotnet-fundamentals',
+  },
   'playwright-practico': {
     emoji: '🎭',
     label: 'Playwright — Prueba práctica',
@@ -100,6 +106,7 @@ export const POINTS_BASED_TYPES = new Set<ExamType>([
   'database-practice',
   'infrastructure-fundamentals',
   'api-developer-fundamentals',
+  'api-dotnet-fundamentals',
   'playwright-practico',
   'playwright-fundamentals',
   'gherkin-fundamentals',

--- a/apps/frontend/src/lib/exams.ts
+++ b/apps/frontend/src/lib/exams.ts
@@ -16,6 +16,7 @@ export type ExamType =
   | 'api-developer-fundamentals'
   | 'api-dotnet-fundamentals'
   | 'docker-fundamentals'
+  | 'kubernetes-helm-fundamentals'
   | 'playwright-practico'
   | 'playwright-fundamentals'
   | 'gherkin-fundamentals';
@@ -84,6 +85,11 @@ export const EXAM_META: Record<ExamType, ExamMeta> = {
     label: 'Docker — Fundamentos',
     href: '/assessments/docker-fundamentals',
   },
+  'kubernetes-helm-fundamentals': {
+    emoji: '☸️',
+    label: 'Kubernetes + Helm — Fundamentos',
+    href: '/assessments/kubernetes-helm-fundamentals',
+  },
   'playwright-practico': {
     emoji: '🎭',
     label: 'Playwright — Prueba práctica',
@@ -114,6 +120,7 @@ export const POINTS_BASED_TYPES = new Set<ExamType>([
   'api-developer-fundamentals',
   'api-dotnet-fundamentals',
   'docker-fundamentals',
+  'kubernetes-helm-fundamentals',
   'playwright-practico',
   'playwright-fundamentals',
   'gherkin-fundamentals',

--- a/apps/frontend/src/lib/exams.ts
+++ b/apps/frontend/src/lib/exams.ts
@@ -15,6 +15,7 @@ export type ExamType =
   | 'infrastructure-fundamentals'
   | 'api-developer-fundamentals'
   | 'api-dotnet-fundamentals'
+  | 'docker-fundamentals'
   | 'playwright-practico'
   | 'playwright-fundamentals'
   | 'gherkin-fundamentals';
@@ -78,6 +79,11 @@ export const EXAM_META: Record<ExamType, ExamMeta> = {
     label: 'API .NET — Fundamentos',
     href: '/assessments/api-dotnet-fundamentals',
   },
+  'docker-fundamentals': {
+    emoji: '🐋',
+    label: 'Docker — Fundamentos',
+    href: '/assessments/docker-fundamentals',
+  },
   'playwright-practico': {
     emoji: '🎭',
     label: 'Playwright — Prueba práctica',
@@ -107,6 +113,7 @@ export const POINTS_BASED_TYPES = new Set<ExamType>([
   'infrastructure-fundamentals',
   'api-developer-fundamentals',
   'api-dotnet-fundamentals',
+  'docker-fundamentals',
   'playwright-practico',
   'playwright-fundamentals',
   'gherkin-fundamentals',

--- a/apps/frontend/src/lib/exams.ts
+++ b/apps/frontend/src/lib/exams.ts
@@ -18,6 +18,7 @@ export type ExamType =
   | 'docker-fundamentals'
   | 'kubernetes-helm-fundamentals'
   | 'observability-fundamentals'
+  | 'cicd-fundamentals'
   | 'playwright-practico'
   | 'playwright-fundamentals'
   | 'gherkin-fundamentals';
@@ -96,6 +97,11 @@ export const EXAM_META: Record<ExamType, ExamMeta> = {
     label: 'Observabilidad — Fundamentos',
     href: '/assessments/observability-fundamentals',
   },
+  'cicd-fundamentals': {
+    emoji: '🔁',
+    label: 'CI/CD — Fundamentos',
+    href: '/assessments/cicd-fundamentals',
+  },
   'playwright-practico': {
     emoji: '🎭',
     label: 'Playwright — Prueba práctica',
@@ -128,6 +134,7 @@ export const POINTS_BASED_TYPES = new Set<ExamType>([
   'docker-fundamentals',
   'kubernetes-helm-fundamentals',
   'observability-fundamentals',
+  'cicd-fundamentals',
   'playwright-practico',
   'playwright-fundamentals',
   'gherkin-fundamentals',

--- a/apps/frontend/src/lib/labsCatalog.ts
+++ b/apps/frontend/src/lib/labsCatalog.ts
@@ -195,6 +195,17 @@ export const toolCategories: LabCategory[] = [
         featured: true,
         implementedDate: 'Ago 2026',
       },
+      {
+        id: 'docker-fundamentals',
+        name: 'Docker — Fundamentos',
+        description:
+          'Prueba técnica para bootcamp de desarrollo: Dockerfiles multistage e imágenes livianas, variables de entorno sin hardcode y ejecución/reproducibilidad local — auto-corregido, 100 pts',
+        icon: '🐋',
+        color: 'from-blue-500 to-cyan-600',
+        href: '/assessments/docker-fundamentals',
+        featured: true,
+        implementedDate: 'Ago 2026',
+      },
     ],
   },
   {

--- a/apps/frontend/src/lib/labsCatalog.ts
+++ b/apps/frontend/src/lib/labsCatalog.ts
@@ -206,6 +206,17 @@ export const toolCategories: LabCategory[] = [
         featured: true,
         implementedDate: 'Ago 2026',
       },
+      {
+        id: 'kubernetes-helm-fundamentals',
+        name: 'Kubernetes + Helm — Fundamentos',
+        description:
+          'Prueba técnica para bootcamp de desarrollo: manifiestos Deployment/Service, ConfigMaps y Secrets, charts de Helm y despliegue funcional en Minikube — auto-corregido, 100 pts',
+        icon: '☸️',
+        color: 'from-sky-500 to-blue-700',
+        href: '/assessments/kubernetes-helm-fundamentals',
+        featured: true,
+        implementedDate: 'Ago 2026',
+      },
     ],
   },
   {

--- a/apps/frontend/src/lib/labsCatalog.ts
+++ b/apps/frontend/src/lib/labsCatalog.ts
@@ -217,6 +217,17 @@ export const toolCategories: LabCategory[] = [
         featured: true,
         implementedDate: 'Ago 2026',
       },
+      {
+        id: 'observability-fundamentals',
+        name: 'Observabilidad — Fundamentos',
+        description:
+          'Prueba técnica para bootcamp de desarrollo: logging estructurado con Serilog, centralización en Seq, niveles de log y visualización — auto-corregido, 100 pts',
+        icon: '📈',
+        color: 'from-teal-500 to-emerald-600',
+        href: '/assessments/observability-fundamentals',
+        featured: true,
+        implementedDate: 'Ago 2026',
+      },
     ],
   },
   {

--- a/apps/frontend/src/lib/labsCatalog.ts
+++ b/apps/frontend/src/lib/labsCatalog.ts
@@ -184,6 +184,17 @@ export const toolCategories: LabCategory[] = [
         featured: true,
         implementedDate: 'Jul 2026',
       },
+      {
+        id: 'api-dotnet-fundamentals',
+        name: 'API .NET — Fundamentos',
+        description:
+          'Prueba técnica para bootcamp de desarrollo backend: diseño REST y versionado, contrato OpenAPI/Swagger, Clean Architecture y manejo de errores en .NET — auto-corregido, 100 pts',
+        icon: '🟣',
+        color: 'from-violet-500 to-purple-600',
+        href: '/assessments/api-dotnet-fundamentals',
+        featured: true,
+        implementedDate: 'Ago 2026',
+      },
     ],
   },
   {

--- a/apps/frontend/src/lib/labsCatalog.ts
+++ b/apps/frontend/src/lib/labsCatalog.ts
@@ -228,6 +228,17 @@ export const toolCategories: LabCategory[] = [
         featured: true,
         implementedDate: 'Ago 2026',
       },
+      {
+        id: 'cicd-fundamentals',
+        name: 'CI/CD — Fundamentos',
+        description:
+          'Prueba técnica para bootcamp de desarrollo: pipelines de integración continua, despliegue continuo automatizado y buenas prácticas de versionado — auto-corregido, 100 pts',
+        icon: '🔁',
+        color: 'from-orange-500 to-red-600',
+        href: '/assessments/cicd-fundamentals',
+        featured: true,
+        implementedDate: 'Ago 2026',
+      },
     ],
   },
   {

--- a/apps/frontend/src/lib/ranking-achievements.ts
+++ b/apps/frontend/src/lib/ranking-achievements.ts
@@ -51,6 +51,7 @@ const RANKED_EXAM_TYPES: ExamType[] = [
   'api-dotnet-fundamentals',
   'docker-fundamentals',
   'kubernetes-helm-fundamentals',
+  'observability-fundamentals',
   'playwright-practico',
   'playwright-fundamentals',
   'gherkin-fundamentals',
@@ -64,6 +65,7 @@ const ASSESSMENT_RANKING_TYPES = new Set<ExamType>([
   'api-dotnet-fundamentals',
   'docker-fundamentals',
   'kubernetes-helm-fundamentals',
+  'observability-fundamentals',
   'playwright-fundamentals',
   'gherkin-fundamentals',
 ]);

--- a/apps/frontend/src/lib/ranking-achievements.ts
+++ b/apps/frontend/src/lib/ranking-achievements.ts
@@ -52,6 +52,7 @@ const RANKED_EXAM_TYPES: ExamType[] = [
   'docker-fundamentals',
   'kubernetes-helm-fundamentals',
   'observability-fundamentals',
+  'cicd-fundamentals',
   'playwright-practico',
   'playwright-fundamentals',
   'gherkin-fundamentals',
@@ -66,6 +67,7 @@ const ASSESSMENT_RANKING_TYPES = new Set<ExamType>([
   'docker-fundamentals',
   'kubernetes-helm-fundamentals',
   'observability-fundamentals',
+  'cicd-fundamentals',
   'playwright-fundamentals',
   'gherkin-fundamentals',
 ]);

--- a/apps/frontend/src/lib/ranking-achievements.ts
+++ b/apps/frontend/src/lib/ranking-achievements.ts
@@ -48,6 +48,7 @@ const RANKED_EXAM_TYPES: ExamType[] = [
   'database-practice',
   'infrastructure-fundamentals',
   'api-developer-fundamentals',
+  'api-dotnet-fundamentals',
   'playwright-practico',
   'playwright-fundamentals',
   'gherkin-fundamentals',
@@ -58,6 +59,7 @@ const ASSESSMENT_RANKING_TYPES = new Set<ExamType>([
   'database-practice',
   'infrastructure-fundamentals',
   'api-developer-fundamentals',
+  'api-dotnet-fundamentals',
   'playwright-fundamentals',
   'gherkin-fundamentals',
 ]);

--- a/apps/frontend/src/lib/ranking-achievements.ts
+++ b/apps/frontend/src/lib/ranking-achievements.ts
@@ -49,6 +49,7 @@ const RANKED_EXAM_TYPES: ExamType[] = [
   'infrastructure-fundamentals',
   'api-developer-fundamentals',
   'api-dotnet-fundamentals',
+  'docker-fundamentals',
   'playwright-practico',
   'playwright-fundamentals',
   'gherkin-fundamentals',
@@ -60,6 +61,7 @@ const ASSESSMENT_RANKING_TYPES = new Set<ExamType>([
   'infrastructure-fundamentals',
   'api-developer-fundamentals',
   'api-dotnet-fundamentals',
+  'docker-fundamentals',
   'playwright-fundamentals',
   'gherkin-fundamentals',
 ]);

--- a/apps/frontend/src/lib/ranking-achievements.ts
+++ b/apps/frontend/src/lib/ranking-achievements.ts
@@ -50,6 +50,7 @@ const RANKED_EXAM_TYPES: ExamType[] = [
   'api-developer-fundamentals',
   'api-dotnet-fundamentals',
   'docker-fundamentals',
+  'kubernetes-helm-fundamentals',
   'playwright-practico',
   'playwright-fundamentals',
   'gherkin-fundamentals',
@@ -62,6 +63,7 @@ const ASSESSMENT_RANKING_TYPES = new Set<ExamType>([
   'api-developer-fundamentals',
   'api-dotnet-fundamentals',
   'docker-fundamentals',
+  'kubernetes-helm-fundamentals',
   'playwright-fundamentals',
   'gherkin-fundamentals',
 ]);


### PR DESCRIPTION
## Summary
5 pruebas técnicas nuevas en el catálogo público `/assessments`, derivadas de la rúbrica `Evaluacion Proyecto Final.xlsx` (proyecto final de bootcamp: API .NET + Docker + Kubernetes/Helm + Observabilidad + CI/CD). El excel es una rúbrica de evaluación de proyecto, no un banco de preguntas — el contenido de cada prueba se autoró desde cero usando cada área del rubric como temario, con enfoque de **bootcamp de desarrollo backend/DevOps** (no QA), siguiendo `api-developer-fundamentals` como precedente de `type`/`level`.

| Slug | Título | Secciones | Preguntas |
|---|---|---|---|
| `api-dotnet-fundamentals` | API .NET — Fundamentos | 4 | 25 |
| `docker-fundamentals` | Docker — Fundamentos | 3 | 25 |
| `kubernetes-helm-fundamentals` | Kubernetes + Helm — Fundamentos | 4 | 25 |
| `observability-fundamentals` | Observabilidad — Fundamentos | 4 | 25 |
| `cicd-fundamentals` | CI/CD — Fundamentos | 3 | 25 |

Cada una: 100 puntos, `type: 'Desarrollo Backend .NET'` / `'Desarrollo DevOps'`, `level: 'Trainee a Junior'`, `passingScore: 70`, bandas de nota alineadas a los cortes del excel (0-39/40-59/60-74/75-89/90-100).

`kubernetes-helm-fundamentals` queda **independiente** de `infrastructure-fundamentals` (que ya cubre Docker+K8s conceptual sin Helm) — decisión tomada explícitamente para no fusionarlas.

Wiring completo por cada prueba: registry (`_shared/registry.ts`), catálogo `/assessments`, `lib/exams.ts`, `actions/exams.ts`, ranking (`lib/ranking-achievements.ts`), catálogo de labs (`lib/labsCatalog.ts`, categoría "💻 Desarrollo"), recomendación de próximo examen en `/dashboard`.

## Test plan
- [x] `pnpm --filter @aiquaa/frontend test -- assessments` — 19 archivos / 77 tests OK (incluye los 15 nuevos de las 5 pruebas)
- [x] `pnpm --filter @aiquaa/frontend exec tsc --noEmit` — 0 errores
- [x] `eslint` sobre archivos nuevos/tocados — 0 errores (1 warning preexistente no relacionado en registry.ts)
- [ ] Recorrido manual en navegador (start → responder → result) por cada prueba — no ejecutado en este entorno por falta de credenciales Supabase locales (`.env.local` no configurado en el worktree)

🤖 Generated with [Claude Code](https://claude.com/claude-code)