### PR TITLE
feat(empresa): habilita las 5 pruebas nuevas en procesos de contratacion

### DIFF
--- a/apps/frontend/src/actions/lib/assessment-slugs.ts
+++ b/apps/frontend/src/actions/lib/assessment-slugs.ts
@@ -10,4 +10,9 @@ export const PROCESS_ASSESSMENT_SLUGS = [
   'infrastructure-fundamentals',
   'api-developer-fundamentals',
   'gherkin-fundamentals',
+  'api-dotnet-fundamentals',
+  'docker-fundamentals',
+  'kubernetes-helm-fundamentals',
+  'observability-fundamentals',
+  'cicd-fundamentals',
 ];

--- a/apps/frontend/src/app/empresa/procesos/nuevo/page.tsx
+++ b/apps/frontend/src/app/empresa/procesos/nuevo/page.tsx
@@ -78,6 +78,36 @@ const EXAM_OPTIONS = [
       'Contenedores Docker, conceptos de Kubernetes y arquitectura de clúster — auto-corregido, 3 niveles',
   },
   {
+    id: 'api-dotnet-fundamentals',
+    label: 'API .NET — Fundamentos (Examen teórico)',
+    description:
+      'Diseño REST y versionado, contrato OpenAPI/Swagger, Clean Architecture y manejo de errores en .NET — auto-corregido, 4 secciones',
+  },
+  {
+    id: 'docker-fundamentals',
+    label: 'Docker — Fundamentos (Examen teórico)',
+    description:
+      'Dockerfiles multistage e imágenes livianas, variables de entorno sin hardcode y ejecución/reproducibilidad local — auto-corregido, 3 secciones',
+  },
+  {
+    id: 'kubernetes-helm-fundamentals',
+    label: 'Kubernetes + Helm — Fundamentos (Examen teórico)',
+    description:
+      'Manifiestos Deployment/Service, ConfigMaps y Secrets, charts de Helm y despliegue funcional en Minikube — auto-corregido, 4 secciones',
+  },
+  {
+    id: 'observability-fundamentals',
+    label: 'Observabilidad — Fundamentos (Examen teórico)',
+    description:
+      'Logging estructurado con Serilog, centralización en Seq, niveles de log y visualización — auto-corregido, 4 secciones',
+  },
+  {
+    id: 'cicd-fundamentals',
+    label: 'CI/CD — Fundamentos (Examen teórico)',
+    description:
+      'Pipelines de integración continua, despliegue continuo automatizado y buenas prácticas de versionado — auto-corregido, 3 secciones',
+  },
+  {
     id: 'test-app',
     label: 'Test App — Exploratory Testing & Bug Hunt',
     description:


### PR DESCRIPTION
## Summary
- Las 5 pruebas técnicas agregadas en #306 (`api-dotnet-fundamentals`, `docker-fundamentals`, `kubernetes-helm-fundamentals`, `observability-fundamentals`, `cicd-fundamentals`) ya estaban en el catálogo público `/assessments` y en `/labs`, pero **no eran seleccionables** al crear un proceso de contratación desde `/empresa/procesos/nuevo`.
- Causa: ese formulario usa su propia lista hardcodeada `EXAM_OPTIONS` (`apps/frontend/src/app/empresa/procesos/nuevo/page.tsx`), completamente separada del `ASSESSMENT_REGISTRY` — nunca se sincronizó con las pruebas nuevas.
- Además, `PROCESS_ASSESSMENT_SLUGS` (`apps/frontend/src/actions/lib/assessment-slugs.ts`) tampoco las tenía, por lo que aunque un proceso las incluyera, los intentos aprobados no se contarían en los dashboards de progreso/resultados de empresa (`employer.ts`, `candidate-events.ts`).
- Se agregan las 5 a ambas listas.

Nota: la validación del código de proceso (`validateProcessCodeAction` / `startAssessmentAttemptAction`) no depende de ninguna de estas dos listas — ya funcionaba para cualquier slug del registry. El único bloqueo real era el checkbox faltante en el form de creación.

## Test plan
- [x] `pnpm --filter @aiquaa/frontend exec tsc --noEmit` — sin errores
- [x] `eslint` sobre los 2 archivos tocados — sin errores ni warnings
- [ ] Recorrido manual: crear proceso seleccionando una de las 5 pruebas nuevas, generar código, iniciar el assessment como candidato — no ejecutado en este entorno por falta de credenciales Supabase locales

🤖 Generated with [Claude Code](https://claude.com/claude-code)