### PR TITLE
fix(labs): grade ISTQB exam server-side, stop shipping answer key to client (#225)

### DIFF
--- a/apps/frontend/src/actions/__tests__/istqb-exam.test.ts
+++ b/apps/frontend/src/actions/__tests__/istqb-exam.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from 'vitest';
+import {
+  checkAnswerAction,
+  getExamConfigAction,
+  startExamAction,
+  submitExamAction,
+} from '../istqb-exam';
+
+describe('istqb-exam actions (#225 - server-side grading)', () => {
+  it('getExamConfigAction never exposes questions or answers', async () => {
+    const config = await getExamConfigAction('es-model-a');
+
+    expect(config.examInfo.totalQuestions).toBeGreaterThan(0);
+    expect(config.availableQuestions).toBeGreaterThan(0);
+    expect(config).not.toHaveProperty('questions');
+  });
+
+  it('startExamAction strips correctAnswer and explanations from every question', async () => {
+    const { questions } = await startExamAction({
+      examId: 'es-model-a',
+      count: 10,
+    });
+
+    expect(questions.length).toBe(10);
+    for (const question of questions) {
+      expect(question).not.toHaveProperty('correctAnswer');
+      expect(question).not.toHaveProperty('explanations');
+      expect(typeof question.answerCount).toBe('number');
+      expect(question.answerCount).toBeGreaterThan(0);
+    }
+  });
+
+  it('checkAnswerAction grades a single question without revealing the rest of the bank', async () => {
+    const { questions } = await startExamAction({
+      examId: 'es-model-a',
+      count: 1,
+    });
+    const question = questions[0];
+
+    const wrongLabel = question.options.find(
+      (opt) => opt.label !== question.options[0].label
+    );
+
+    const feedback = await checkAnswerAction({
+      examId: 'es-model-a',
+      questionId: question.id,
+      userAnswer: [question.options[0].label],
+    });
+
+    expect(feedback).not.toBeNull();
+    expect(feedback?.correctAnswer.length).toBe(question.answerCount);
+    expect(typeof feedback?.isCorrect).toBe('boolean');
+    expect(wrongLabel).toBeDefined();
+  });
+
+  it('checkAnswerAction returns null for an unknown question id', async () => {
+    const feedback = await checkAnswerAction({
+      examId: 'es-model-a',
+      questionId: -1,
+      userAnswer: ['A'],
+    });
+
+    expect(feedback).toBeNull();
+  });
+
+  it('submitExamAction grades using only the submitted question ids, matching per-question checks', async () => {
+    const { questions } = await startExamAction({
+      examId: 'es-model-a',
+      count: 3,
+    });
+
+    const answers: Record<number, string[]> = {};
+    const questionDurations: Record<number, number> = {};
+    let expectedCorrect = 0;
+
+    for (const question of questions) {
+      const guess = [question.options[0].label];
+      answers[question.id] = guess;
+      questionDurations[question.id] = 12;
+
+      const feedback = await checkAnswerAction({
+        examId: 'es-model-a',
+        questionId: question.id,
+        userAnswer: guess,
+      });
+      if (feedback?.isCorrect) expectedCorrect += 1;
+    }
+
+    const result = await submitExamAction({
+      examId: 'es-model-a',
+      participantName: 'QA Tester',
+      questionIds: questions.map((q) => q.id),
+      answers,
+      questionDurations,
+      timeSpent: 90,
+    });
+
+    expect(result.totalQuestions).toBe(3);
+    expect(result.correctAnswers).toBe(expectedCorrect);
+    expect(result.answers.every((a) => a.correctAnswer.length > 0)).toBe(true);
+  });
+
+  it('submitExamAction ignores question ids that do not belong to the requested bank', async () => {
+    const result = await submitExamAction({
+      examId: 'es-model-a',
+      participantName: 'QA Tester',
+      questionIds: [-1, -2],
+      answers: {},
+      questionDurations: {},
+      timeSpent: 10,
+    });
+
+    expect(result.totalQuestions).toBe(0);
+    expect(result.answers).toEqual([]);
+  });
+});

--- a/apps/frontend/src/actions/istqb-exam.ts
+++ b/apps/frontend/src/actions/istqb-exam.ts
@@ -1,0 +1,106 @@
+'use server';
+
+import type {
+  ExamQuestion,
+  ExamResult,
+  Explanation,
+  PublicExamQuestion,
+} from '@/app/labs/istqb/types';
+import {
+  generateExamResult,
+  prepareExamQuestions,
+} from '@/app/labs/istqb/utils';
+import { loadExamData } from '@/app/labs/istqb/exam-data.server';
+
+function toPublicQuestion(question: ExamQuestion): PublicExamQuestion {
+  // eslint-disable-next-line no-unused-vars
+  const { correctAnswer, explanations, ...rest } = question;
+  return { ...rest, answerCount: correctAnswer.length };
+}
+
+export async function getExamConfigAction(examId: string) {
+  const examData = loadExamData(examId);
+  return {
+    examInfo: examData.examInfo,
+    availableQuestions: examData.questions.length,
+  };
+}
+
+export async function startExamAction(params: {
+  examId: string;
+  count: number;
+  shuffleOptions?: boolean;
+}) {
+  const examData = loadExamData(params.examId);
+  const prepared = prepareExamQuestions(
+    examData.questions,
+    params.count,
+    params.shuffleOptions ?? true
+  );
+
+  return {
+    questions: prepared.map(toPublicQuestion),
+    examInfo: examData.examInfo,
+  };
+}
+
+export async function checkAnswerAction(params: {
+  examId: string;
+  questionId: number;
+  userAnswer: string[];
+}): Promise<{
+  isCorrect: boolean;
+  correctAnswer: string[];
+  explanations: Record<string, Explanation>;
+} | null> {
+  const examData = loadExamData(params.examId);
+  const question = examData.questions.find((q) => q.id === params.questionId);
+  if (!question) return null;
+
+  const sortedUser = [...params.userAnswer].sort();
+  const sortedCorrect = [...question.correctAnswer].sort();
+  const isCorrect =
+    sortedUser.length === sortedCorrect.length &&
+    sortedUser.every((ans, idx) => ans === sortedCorrect[idx]);
+
+  return {
+    isCorrect,
+    correctAnswer: question.correctAnswer,
+    explanations: question.explanations,
+  };
+}
+
+export async function submitExamAction(params: {
+  examId: string;
+  participantName: string;
+  questionIds: number[];
+  answers: Record<number, string[]>;
+  questionDurations: Record<number, number>;
+  timeSpent: number;
+}): Promise<ExamResult> {
+  const examData = loadExamData(params.examId);
+  const byId = new Map(examData.questions.map((q) => [q.id, q]));
+
+  const orderedQuestions = params.questionIds
+    .map((id) => byId.get(id))
+    .filter((q): q is ExamQuestion => Boolean(q));
+
+  const answers = new Map<number, string[]>(
+    Object.entries(params.answers).map(([id, value]) => [Number(id), value])
+  );
+  const questionDurations = new Map<number, number>(
+    Object.entries(params.questionDurations).map(([id, value]) => [
+      Number(id),
+      Number(value),
+    ])
+  );
+
+  return generateExamResult(
+    params.participantName,
+    orderedQuestions,
+    answers,
+    params.timeSpent,
+    examData.examInfo.passingScore,
+    questionDurations
+  );
+}

--- a/apps/frontend/src/actions/lib/legacy-exam-scoring.ts
+++ b/apps/frontend/src/actions/lib/legacy-exam-scoring.ts
@@ -2,10 +2,8 @@ import {
   generateExamResult as generateGitExamResult,
   loadExamData as loadGitExamData,
 } from '@/app/labs/git/utils';
-import {
-  generateExamResult as generateIstqbExamResult,
-  loadExamData as loadIstqbExamData,
-} from '@/app/labs/istqb/utils';
+import { generateExamResult as generateIstqbExamResult } from '@/app/labs/istqb/utils';
+import { loadExamData as loadIstqbExamData } from '@/app/labs/istqb/exam-data.server';
 import {
   generateExamResult as generatePerformanceExamResult,
   loadExamData as loadPerformanceExamData,

--- a/apps/frontend/src/app/labs/istqb/ISTQBClient.tsx
+++ b/apps/frontend/src/app/labs/istqb/ISTQBClient.tsx
@@ -2,12 +2,13 @@
 
 export const dynamic = 'force-dynamic';
 
-import { useState, useEffect, useMemo } from 'react';
+import { useState, useEffect } from 'react';
 import { useSearchParams } from 'next/navigation';
 import { useTheme } from '@/contexts/ThemeContext';
 import { Alert } from '@/components/common';
 import ExamSimulator from './components/ExamSimulator';
-import { loadExamData } from './utils';
+import type { ExamInfo } from './types';
+import { getExamConfigAction } from '@/actions/istqb-exam';
 import { SuruFloating } from '@/components/Suru';
 import ExamAuthGate from '@/components/labs/ExamAuthGate';
 import { useSupabaseAuth } from '@/contexts/SupabaseAuthContext';
@@ -37,10 +38,37 @@ export default function ISTQBClient() {
 
   const examId = `${language}-model-${model.toLowerCase()}`;
   const finalExamId = examId === 'es-model-a' ? 'es-model-a' : examId;
-  const examData = useMemo(() => loadExamData(finalExamId), [finalExamId]);
-  const availableQuestions = examData.questions.length;
-  const isModelIncomplete =
-    availableQuestions < examData.examInfo.totalQuestions;
+
+  // La configuración (metadata, sin preguntas) se obtiene vía server action:
+  // el banco de preguntas completo (con `correctAnswer`) nunca debe llegar
+  // al cliente antes de que el usuario responda (#225).
+  const [examInfo, setExamInfo] = useState<ExamInfo | null>(null);
+  const [availableQuestions, setAvailableQuestions] = useState(0);
+  const [configError, setConfigError] = useState(false);
+
+  useEffect(() => {
+    let active = true;
+    setExamInfo(null);
+    setConfigError(false);
+
+    getExamConfigAction(finalExamId)
+      .then((config) => {
+        if (!active) return;
+        setExamInfo(config.examInfo);
+        setAvailableQuestions(config.availableQuestions);
+      })
+      .catch(() => {
+        if (active) setConfigError(true);
+      });
+
+    return () => {
+      active = false;
+    };
+  }, [finalExamId]);
+
+  const isModelIncomplete = examInfo
+    ? availableQuestions < examInfo.totalQuestions
+    : false;
 
   const t = {
     es: {
@@ -82,7 +110,7 @@ export default function ISTQBClient() {
       ],
       startExam: 'Iniciar Modo Examen',
       comingSoon: 'Próximamente',
-      incompleteModelWarning: `Este modelo solo tiene ${availableQuestions} pregunta(s) disponible(s) de ${examData.examInfo.totalQuestions}. Selecciona Modelo A en Español para el banco completo.`,
+      incompleteModelWarning: `Este modelo solo tiene ${availableQuestions} pregunta(s) disponible(s) de ${examInfo?.totalQuestions ?? 0}. Selecciona Modelo A en Español para el banco completo.`,
       trainingModeTitle: 'Modo Entrenamiento',
       trainingModeSubtitle: 'Practica con feedback inmediato en cada pregunta',
       trainingModeFeatures: [
@@ -132,7 +160,7 @@ export default function ISTQBClient() {
       ],
       startExam: 'Start Exam Mode',
       comingSoon: 'Coming Soon',
-      incompleteModelWarning: `This model only has ${availableQuestions} question(s) available out of ${examData.examInfo.totalQuestions}. Select Model A in Spanish for the full question bank.`,
+      incompleteModelWarning: `This model only has ${availableQuestions} question(s) available out of ${examInfo?.totalQuestions ?? 0}. Select Model A in Spanish for the full question bank.`,
       trainingModeTitle: 'Training Mode',
       trainingModeSubtitle: 'Practice with immediate feedback on each question',
       trainingModeFeatures: [
@@ -152,6 +180,7 @@ export default function ISTQBClient() {
       setError(text.enterNameError);
       return;
     }
+    if (!examInfo) return;
 
     setError('');
     setExamMode(mode);
@@ -166,17 +195,43 @@ export default function ISTQBClient() {
     setError('');
   };
 
-  if (hasStarted && examMode) {
+  if (hasStarted && examMode && examInfo) {
     return (
       <ExamSimulator
         participantName={participantName}
         mode={examMode}
-        examData={examData}
+        examId={finalExamId}
+        examInfo={examInfo}
         onReset={handleReset}
         model={model}
         processCode={processCode}
         language={language}
       />
+    );
+  }
+
+  if (configError) {
+    return (
+      <div className="flex items-center justify-center min-h-screen px-4">
+        <Alert
+          type="error"
+          message={
+            language === 'es'
+              ? 'No pudimos cargar la configuración del examen. Intenta recargar la página.'
+              : 'We could not load the exam configuration. Please reload the page.'
+          }
+        />
+      </div>
+    );
+  }
+
+  if (!examInfo) {
+    return (
+      <div className="flex items-center justify-center min-h-screen">
+        <p className="text-lg">
+          {language === 'es' ? 'Cargando...' : 'Loading...'}
+        </p>
+      </div>
     );
   }
 
@@ -209,7 +264,7 @@ export default function ISTQBClient() {
               <p
                 className={`text-sm ${isDarkMode ? 'text-slate-400' : 'text-gray-600'}`}
               >
-                {examData.examInfo.title} - {examData.examInfo.version}
+                {examInfo.title} - {examInfo.version}
               </p>
             </div>
             <div className="p-6 border-b border-gray-200 dark:border-gray-700">
@@ -305,7 +360,7 @@ export default function ISTQBClient() {
                       {text.totalQuestions}
                     </p>
                     <p className="text-2xl font-bold">
-                      {examData.examInfo.totalQuestions}
+                      {examInfo.totalQuestions}
                     </p>
                   </div>
                 </div>
@@ -317,7 +372,7 @@ export default function ISTQBClient() {
                       {text.timeLimit}
                     </p>
                     <p className="text-2xl font-bold">
-                      {examData.examInfo.timeLimit} {text.minutes}
+                      {examInfo.timeLimit} {text.minutes}
                     </p>
                   </div>
                 </div>
@@ -329,7 +384,7 @@ export default function ISTQBClient() {
                       {text.pointsPerQuestion}
                     </p>
                     <p className="text-2xl font-bold">
-                      {examData.examInfo.pointsPerQuestion}
+                      {examInfo.pointsPerQuestion}
                     </p>
                   </div>
                 </div>
@@ -341,8 +396,7 @@ export default function ISTQBClient() {
                       {text.passingScore}
                     </p>
                     <p className="text-2xl font-bold">
-                      {examData.examInfo.passingScore}/
-                      {examData.examInfo.totalQuestions}
+                      {examInfo.passingScore}/{examInfo.totalQuestions}
                     </p>
                   </div>
                 </div>

--- a/apps/frontend/src/app/labs/istqb/components/ExamSimulator.tsx
+++ b/apps/frontend/src/app/labs/istqb/components/ExamSimulator.tsx
@@ -2,15 +2,32 @@
 
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { useTheme } from '@/contexts/ThemeContext';
-import type { ExamData, ExamQuestion } from '../types';
-import { prepareExamQuestions, formatTime, generateExamResult } from '../utils';
+import type {
+  ExamInfo,
+  ExamResult,
+  PublicExamQuestion,
+  Explanation,
+} from '../types';
+import { formatTime } from '../utils';
+import {
+  startExamAction,
+  checkAnswerAction,
+  submitExamAction,
+} from '@/actions/istqb-exam';
 import QuestionCard from './QuestionCard';
 import ResultsScreen from './ResultsScreen';
+
+export interface QuestionFeedback {
+  isCorrect: boolean;
+  correctAnswer: string[];
+  explanations: Record<string, Explanation>;
+}
 
 interface ExamSimulatorProps {
   participantName: string;
   mode: 'exam' | 'training';
-  examData: ExamData;
+  examId: string;
+  examInfo: ExamInfo;
   onReset: () => void;
   model?: string;
   processCode?: string;
@@ -20,25 +37,31 @@ interface ExamSimulatorProps {
 export default function ExamSimulator({
   participantName,
   mode,
-  examData,
+  examId,
+  examInfo,
   onReset,
   model,
   processCode,
   language,
 }: ExamSimulatorProps) {
   const { isDarkMode } = useTheme();
-  const [questions, setQuestions] = useState<ExamQuestion[]>([]);
+  const [questions, setQuestions] = useState<PublicExamQuestion[]>([]);
   const [currentQuestionIndex, setCurrentQuestionIndex] = useState(0);
   const [answers, setAnswers] = useState<Map<number, string[]>>(new Map());
+  const [feedbackMap, setFeedbackMap] = useState<Map<number, QuestionFeedback>>(
+    new Map()
+  );
   const [markedForReview, setMarkedForReview] = useState<Set<number>>(
     new Set()
   );
   const [timeRemaining, setTimeRemaining] = useState(
-    mode === 'exam' ? examData.examInfo.timeLimit * 60 : 0
+    mode === 'exam' ? examInfo.timeLimit * 60 : 0
   );
   const [isRunning, setIsRunning] = useState(mode === 'exam');
   const [showSubmitDialog, setShowSubmitDialog] = useState(false);
   const [hasSubmitted, setHasSubmitted] = useState(false);
+  const [finalResult, setFinalResult] = useState<ExamResult | null>(null);
+  const [gradingError, setGradingError] = useState(false);
   const [startTime] = useState(Date.now());
   const questionsInitialized = useRef(false);
   // eslint-disable-next-line no-unused-vars
@@ -153,8 +176,37 @@ export default function ExamSimulator({
         newAnswers.set(questionId, selectedAnswers);
         return newAnswers;
       });
+
+      if (mode !== 'training') return;
+
+      const question = questions.find((q) => q.id === questionId);
+      if (!question) return;
+
+      const isComplete =
+        question.type === 'multiple'
+          ? selectedAnswers.length === question.answerCount
+          : selectedAnswers.length > 0;
+
+      if (!isComplete) {
+        setFeedbackMap((prev) => {
+          if (!prev.has(questionId)) return prev;
+          const next = new Map(prev);
+          next.delete(questionId);
+          return next;
+        });
+        return;
+      }
+
+      checkAnswerAction({
+        examId,
+        questionId,
+        userAnswer: selectedAnswers,
+      }).then((feedback) => {
+        if (!feedback) return;
+        setFeedbackMap((prev) => new Map(prev).set(questionId, feedback));
+      });
     },
-    []
+    [mode, questions, examId]
   );
 
   const toggleMarkForReview = useCallback(() => {
@@ -189,13 +241,53 @@ export default function ExamSimulator({
   useEffect(() => {
     if (questionsInitialized.current) return;
     questionsInitialized.current = true;
-    const preparedQuestions = prepareExamQuestions(
-      examData.questions,
-      examData.examInfo.totalQuestions,
-      true
-    );
-    setQuestions(preparedQuestions);
-  }, [examData]);
+    startExamAction({
+      examId,
+      count: examInfo.totalQuestions,
+      shuffleOptions: true,
+    })
+      .then((res) => setQuestions(res.questions))
+      .catch(() => setQuestions([]));
+  }, [examId, examInfo.totalQuestions]);
+
+  useEffect(() => {
+    if (!hasSubmitted || questions.length === 0) return;
+    let active = true;
+
+    const submissionTimeSpent =
+      mode === 'exam'
+        ? examInfo.timeLimit * 60 - timeRemaining
+        : Math.floor((Date.now() - startTime) / 1000);
+
+    const answersRecord: Record<number, string[]> = {};
+    answers.forEach((value, key) => {
+      answersRecord[key] = value;
+    });
+    const durationsRecord: Record<number, number> = {};
+    questionDurationsRef.current.forEach((value, key) => {
+      durationsRecord[key] = value;
+    });
+
+    submitExamAction({
+      examId,
+      participantName,
+      questionIds: questions.map((q) => q.id),
+      answers: answersRecord,
+      questionDurations: durationsRecord,
+      timeSpent: submissionTimeSpent,
+    })
+      .then((result) => {
+        if (active) setFinalResult(result);
+      })
+      .catch(() => {
+        if (active) setGradingError(true);
+      });
+
+    return () => {
+      active = false;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [hasSubmitted]);
 
   useEffect(() => {
     if (mode !== 'exam' || !isRunning) return;
@@ -241,24 +333,30 @@ export default function ExamSimulator({
     );
   }
 
-  if (hasSubmitted) {
-    const timeSpent =
-      mode === 'exam'
-        ? examData.examInfo.timeLimit * 60 - timeRemaining
-        : Math.floor((Date.now() - startTime) / 1000);
-
-    const result = generateExamResult(
-      participantName,
-      questions,
-      answers,
-      timeSpent,
-      examData.examInfo.passingScore,
-      questionDurationsRef.current
+  if (hasSubmitted && gradingError) {
+    return (
+      <div className="flex items-center justify-center min-h-screen px-4">
+        <p className="text-lg text-red-600 dark:text-red-400">
+          {language === 'es'
+            ? 'No pudimos calificar el examen. Por favor, recarga la página e intenta de nuevo.'
+            : 'We could not grade the exam. Please reload the page and try again.'}
+        </p>
+      </div>
     );
+  }
 
+  if (hasSubmitted && !finalResult) {
+    return (
+      <div className="flex items-center justify-center min-h-screen">
+        <p className="text-lg">{text.loading}</p>
+      </div>
+    );
+  }
+
+  if (hasSubmitted && finalResult) {
     return (
       <ResultsScreen
-        result={result}
+        result={finalResult}
         onReset={onReset}
         mode={mode}
         model={model}
@@ -381,6 +479,7 @@ export default function ExamSimulator({
           onAnswerChange={handleAnswerChange}
           isMarked={isMarked}
           showFeedback={mode === 'training'}
+          feedback={feedbackMap.get(currentQuestion.id) ?? null}
           language={language}
         />
 

--- a/apps/frontend/src/app/labs/istqb/components/QuestionCard.tsx
+++ b/apps/frontend/src/app/labs/istqb/components/QuestionCard.tsx
@@ -1,15 +1,16 @@
 'use client';
 
 import { useTheme } from '@/contexts/ThemeContext';
-import type { ExamQuestion } from '../types';
-import { checkAnswer } from '../utils';
+import type { PublicExamQuestion } from '../types';
+import type { QuestionFeedback } from './ExamSimulator';
 
 interface QuestionCardProps {
-  question: ExamQuestion;
+  question: PublicExamQuestion;
   selectedAnswers: string[];
   onAnswerChange: (questionId: number, selectedAnswers: string[]) => void;
   isMarked: boolean;
   showFeedback: boolean;
+  feedback: QuestionFeedback | null;
   language: 'es' | 'en';
 }
 
@@ -19,6 +20,7 @@ export default function QuestionCard({
   onAnswerChange,
   isMarked,
   showFeedback,
+  feedback,
   language,
 }: QuestionCardProps) {
   const { isDarkMode } = useTheme();
@@ -68,18 +70,17 @@ export default function QuestionCard({
 
   // Para preguntas múltiples, solo evaluar cuando se haya seleccionado el número correcto de opciones
   const isSelectionComplete = isMultiple
-    ? selectedAnswers.length === question.correctAnswer.length
+    ? selectedAnswers.length === question.answerCount
     : hasAnswered;
 
-  const isCorrect =
-    isSelectionComplete && checkAnswer(selectedAnswers, question.correctAnswer);
+  const isCorrect = feedback?.isCorrect ?? false;
 
   const handleSingleAnswer = (value: string) => {
     onAnswerChange(question.id, [value]);
   };
 
   const handleMultipleAnswer = (label: string, checked: boolean) => {
-    if (checked && selectedAnswers.length >= question.correctAnswer.length) return;
+    if (checked && selectedAnswers.length >= question.answerCount) return;
     const newAnswers = checked
       ? [...selectedAnswers, label]
       : selectedAnswers.filter((a) => a !== label);
@@ -87,11 +88,13 @@ export default function QuestionCard({
   };
 
   const getOptionFeedback = (label: string) => {
-    // Para preguntas múltiples, solo mostrar feedback cuando la selección esté completa
-    if (!showFeedback || !isSelectionComplete) return null;
+    // El feedback (con la respuesta correcta) llega vía server action recién
+    // cuando la selección está completa — antes de eso el cliente no conoce
+    // `correctAnswer` (#225).
+    if (!showFeedback || !feedback) return null;
 
     const isSelected = selectedAnswers.includes(label);
-    const isCorrectAnswer = question.correctAnswer.includes(label);
+    const isCorrectAnswer = feedback.correctAnswer.includes(label);
 
     if (isSelected && isCorrectAnswer) {
       return 'correct-selected';
@@ -104,7 +107,8 @@ export default function QuestionCard({
   };
 
   const getOptionClassName = (feedback: string | null) => {
-    const baseClass = 'flex items-start space-x-3 p-4 rounded-lg border-2 transition-colors';
+    const baseClass =
+      'flex items-start space-x-3 p-4 rounded-lg border-2 transition-colors';
 
     if (!feedback) {
       return `${baseClass} ${isDarkMode ? 'border-slate-600 bg-slate-800/50 hover:border-amber-500 hover:bg-slate-700/50' : 'border-gray-300 bg-white hover:border-amber-500 hover:bg-gray-50'}`;
@@ -123,20 +127,34 @@ export default function QuestionCard({
   };
 
   return (
-    <div className={`rounded-lg shadow-lg ${isDarkMode ? 'bg-slate-800' : 'bg-white'}`}>
-      <div className={`p-6 border-b ${isDarkMode ? 'border-slate-700' : 'border-gray-200'}`}>
+    <div
+      className={`rounded-lg shadow-lg ${isDarkMode ? 'bg-slate-800' : 'bg-white'}`}
+    >
+      <div
+        className={`p-6 border-b ${isDarkMode ? 'border-slate-700' : 'border-gray-200'}`}
+      >
         <div className="flex justify-between items-start gap-4">
-          <h2 className={`text-lg font-bold ${isDarkMode ? 'text-slate-100' : 'text-gray-900'}`}>
+          <h2
+            className={`text-lg font-bold ${isDarkMode ? 'text-slate-100' : 'text-gray-900'}`}
+          >
             {text.question} {question.id}
             {isMarked && (
-              <span className={`ml-2 text-sm font-semibold ${isDarkMode ? 'text-amber-400' : 'text-amber-600'}`}>{text.marked}</span>
+              <span
+                className={`ml-2 text-sm font-semibold ${isDarkMode ? 'text-amber-400' : 'text-amber-600'}`}
+              >
+                {text.marked}
+              </span>
             )}
           </h2>
           <div className="flex gap-2 text-sm flex-shrink-0">
-            <span className={`px-3 py-1 rounded-full font-semibold ${isDarkMode ? 'bg-amber-900/40 text-amber-300 border border-amber-700' : 'bg-amber-100 text-amber-800 border border-amber-200'}`}>
+            <span
+              className={`px-3 py-1 rounded-full font-semibold ${isDarkMode ? 'bg-amber-900/40 text-amber-300 border border-amber-700' : 'bg-amber-100 text-amber-800 border border-amber-200'}`}
+            >
               {question.kLevel}
             </span>
-            <span className={`px-3 py-1 rounded-full font-medium ${isDarkMode ? 'bg-blue-900/40 text-blue-300 border border-blue-700' : 'bg-blue-100 text-blue-800 border border-blue-200'}`}>
+            <span
+              className={`px-3 py-1 rounded-full font-medium ${isDarkMode ? 'bg-blue-900/40 text-blue-300 border border-blue-700' : 'bg-blue-100 text-blue-800 border border-blue-200'}`}
+            >
               {question.learningObjective}
             </span>
           </div>
@@ -144,23 +162,39 @@ export default function QuestionCard({
       </div>
       <div className="p-6 space-y-6">
         <div>
-          <p className={`text-base mb-4 ${isDarkMode ? 'text-white' : 'text-gray-900'}`}>{question.questionText}</p>
-          <div className={`p-4 rounded-lg ${isDarkMode ? 'bg-blue-900/20 border-blue-800' : 'bg-blue-50 border-blue-200'} border`}>
+          <p
+            className={`text-base mb-4 ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
+          >
+            {question.questionText}
+          </p>
+          <div
+            className={`p-4 rounded-lg ${isDarkMode ? 'bg-blue-900/20 border-blue-800' : 'bg-blue-50 border-blue-200'} border`}
+          >
             <div className="flex items-center justify-between gap-2">
               <div className="flex items-center gap-2">
                 <span className="text-blue-600 dark:text-blue-400">ℹ️</span>
-                <p className={`font-semibold ${isDarkMode ? 'text-blue-300' : 'text-blue-900'}`}>
+                <p
+                  className={`font-semibold ${isDarkMode ? 'text-blue-300' : 'text-blue-900'}`}
+                >
                   {isMultiple
-                    ? text.selectMultiple(question.correctAnswer.length)
+                    ? text.selectMultiple(question.answerCount)
                     : text.selectOne}
                 </p>
               </div>
               {isMultiple && hasAnswered && !showFeedback && (
-                <span className={`text-sm font-medium px-3 py-1 rounded-full ${isSelectionComplete
-                  ? isDarkMode ? 'bg-green-900/40 text-green-300 border border-green-700' : 'bg-green-100 text-green-800 border border-green-200'
-                  : isDarkMode ? 'bg-amber-900/40 text-amber-300 border border-amber-700' : 'bg-amber-100 text-amber-800 border border-amber-200'
-                  }`}>
-                  {selectedAnswers.length} {text.of} {question.correctAnswer.length} {text.selected}
+                <span
+                  className={`text-sm font-medium px-3 py-1 rounded-full ${
+                    isSelectionComplete
+                      ? isDarkMode
+                        ? 'bg-green-900/40 text-green-300 border border-green-700'
+                        : 'bg-green-100 text-green-800 border border-green-200'
+                      : isDarkMode
+                        ? 'bg-amber-900/40 text-amber-300 border border-amber-700'
+                        : 'bg-amber-100 text-amber-800 border border-amber-200'
+                  }`}
+                >
+                  {selectedAnswers.length} {text.of} {question.answerCount}{' '}
+                  {text.selected}
                 </span>
               )}
             </div>
@@ -168,161 +202,199 @@ export default function QuestionCard({
         </div>
 
         <div className="space-y-3">
-          {isMultiple ? (
-            question.options.map((option) => {
-              const feedback = getOptionFeedback(option.label);
-              const isSelected = selectedAnswers.includes(option.label);
+          {isMultiple
+            ? question.options.map((option) => {
+                const optionFeedback = getOptionFeedback(option.label);
+                const isSelected = selectedAnswers.includes(option.label);
 
-              return (
-                <div
-                  key={option.label}
-                  className={getOptionClassName(feedback)}
-                >
-                  <input
-                    type="checkbox"
-                    id={`${question.id}-${option.label}`}
-                    checked={isSelected}
-                    onChange={(e) => handleMultipleAnswer(option.label, e.target.checked)}
-                    disabled={showFeedback && isSelectionComplete}
-                    className={`mt-1 h-5 w-5 text-amber-600 focus:ring-amber-500 rounded transition-colors ${isDarkMode
-                      ? 'bg-slate-700 border-slate-500 checked:bg-amber-600 checked:border-amber-600'
-                      : 'bg-white border-gray-300'
+                return (
+                  <div
+                    key={option.label}
+                    className={getOptionClassName(optionFeedback)}
+                  >
+                    <input
+                      type="checkbox"
+                      id={`${question.id}-${option.label}`}
+                      checked={isSelected}
+                      onChange={(e) =>
+                        handleMultipleAnswer(option.label, e.target.checked)
+                      }
+                      disabled={showFeedback && isSelectionComplete}
+                      className={`mt-1 h-5 w-5 text-amber-600 focus:ring-amber-500 rounded transition-colors ${
+                        isDarkMode
+                          ? 'bg-slate-700 border-slate-500 checked:bg-amber-600 checked:border-amber-600'
+                          : 'bg-white border-gray-300'
                       }`}
-                  />
-                  <div className="flex-1">
-                    <label
-                      htmlFor={`${question.id}-${option.label}`}
-                      className={`cursor-pointer ${isDarkMode ? 'text-slate-100' : 'text-gray-900'}`}
-                    >
-                      <span className="font-semibold">{option.label})</span>{' '}
-                      {option.text}
-                    </label>
-                    {showFeedback && isSelectionComplete && (
-                      <div className="mt-2 text-sm">
-                        {feedback === 'correct-selected' && (
-                          <div className="flex items-start gap-2 text-green-700 dark:text-green-300">
-                            <span className="flex-shrink-0">✓</span>
-                            <span>
-                              <strong>{text.correct}</strong>{' '}
-                              {question.explanations[option.label]?.explanation}
-                            </span>
-                          </div>
-                        )}
-                        {feedback === 'incorrect-selected' && (
-                          <div className="flex items-start gap-2 text-red-700 dark:text-red-300">
-                            <span className="flex-shrink-0">✗</span>
-                            <span>
-                              <strong>{text.incorrect}</strong>{' '}
-                              {question.explanations[option.label]?.explanation}
-                            </span>
-                          </div>
-                        )}
-                        {feedback === 'correct-not-selected' && (
-                          <div className="flex items-start gap-2 text-green-700 dark:text-green-300">
-                            <span className="flex-shrink-0">ℹ️</span>
-                            <span>
-                              <strong>{text.wasCorrect}</strong>{' '}
-                              {question.explanations[option.label]?.explanation}
-                            </span>
-                          </div>
-                        )}
-                      </div>
-                    )}
+                    />
+                    <div className="flex-1">
+                      <label
+                        htmlFor={`${question.id}-${option.label}`}
+                        className={`cursor-pointer ${isDarkMode ? 'text-slate-100' : 'text-gray-900'}`}
+                      >
+                        <span className="font-semibold">{option.label})</span>{' '}
+                        {option.text}
+                      </label>
+                      {showFeedback && feedback && (
+                        <div className="mt-2 text-sm">
+                          {optionFeedback === 'correct-selected' && (
+                            <div className="flex items-start gap-2 text-green-700 dark:text-green-300">
+                              <span className="flex-shrink-0">✓</span>
+                              <span>
+                                <strong>{text.correct}</strong>{' '}
+                                {
+                                  feedback.explanations[option.label]
+                                    ?.explanation
+                                }
+                              </span>
+                            </div>
+                          )}
+                          {optionFeedback === 'incorrect-selected' && (
+                            <div className="flex items-start gap-2 text-red-700 dark:text-red-300">
+                              <span className="flex-shrink-0">✗</span>
+                              <span>
+                                <strong>{text.incorrect}</strong>{' '}
+                                {
+                                  feedback.explanations[option.label]
+                                    ?.explanation
+                                }
+                              </span>
+                            </div>
+                          )}
+                          {optionFeedback === 'correct-not-selected' && (
+                            <div className="flex items-start gap-2 text-green-700 dark:text-green-300">
+                              <span className="flex-shrink-0">ℹ️</span>
+                              <span>
+                                <strong>{text.wasCorrect}</strong>{' '}
+                                {
+                                  feedback.explanations[option.label]
+                                    ?.explanation
+                                }
+                              </span>
+                            </div>
+                          )}
+                        </div>
+                      )}
+                    </div>
                   </div>
-                </div>
-              );
-            })
-          ) : (
-            question.options.map((option) => {
-              const feedback = getOptionFeedback(option.label);
-              const isSelected = selectedAnswers.includes(option.label);
+                );
+              })
+            : question.options.map((option) => {
+                const optionFeedback = getOptionFeedback(option.label);
+                const isSelected = selectedAnswers.includes(option.label);
 
-              return (
-                <div
-                  key={option.label}
-                  className={getOptionClassName(feedback)}
-                >
-                  <input
-                    type="radio"
-                    id={`${question.id}-${option.label}`}
-                    name={`question-${question.id}`}
-                    value={option.label}
-                    checked={isSelected}
-                    onChange={() => handleSingleAnswer(option.label)}
-                    disabled={showFeedback && isSelectionComplete}
-                    className={`mt-1 h-5 w-5 text-amber-600 focus:ring-amber-500 transition-colors ${isDarkMode
-                      ? 'bg-slate-700 border-slate-500 checked:bg-amber-600 checked:border-amber-600'
-                      : 'bg-white border-gray-300'
+                return (
+                  <div
+                    key={option.label}
+                    className={getOptionClassName(optionFeedback)}
+                  >
+                    <input
+                      type="radio"
+                      id={`${question.id}-${option.label}`}
+                      name={`question-${question.id}`}
+                      value={option.label}
+                      checked={isSelected}
+                      onChange={() => handleSingleAnswer(option.label)}
+                      disabled={showFeedback && isSelectionComplete}
+                      className={`mt-1 h-5 w-5 text-amber-600 focus:ring-amber-500 transition-colors ${
+                        isDarkMode
+                          ? 'bg-slate-700 border-slate-500 checked:bg-amber-600 checked:border-amber-600'
+                          : 'bg-white border-gray-300'
                       }`}
-                  />
-                  <div className="flex-1">
-                    <label
-                      htmlFor={`${question.id}-${option.label}`}
-                      className={`cursor-pointer ${isDarkMode ? 'text-slate-100' : 'text-gray-900'}`}
-                    >
-                      <span className="font-semibold">{option.label})</span>{' '}
-                      {option.text}
-                    </label>
-                    {showFeedback && isSelectionComplete && (
-                      <div className="mt-2 text-sm">
-                        {feedback === 'correct-selected' && (
-                          <div className="flex items-start gap-2 text-green-700 dark:text-green-300">
-                            <span className="flex-shrink-0">✓</span>
-                            <span>
-                              <strong>{text.correct}</strong>{' '}
-                              {question.explanations[option.label]?.explanation}
-                            </span>
-                          </div>
-                        )}
-                        {feedback === 'incorrect-selected' && (
-                          <div className="flex items-start gap-2 text-red-700 dark:text-red-300">
-                            <span className="flex-shrink-0">✗</span>
-                            <span>
-                              <strong>{text.incorrect}</strong>{' '}
-                              {question.explanations[option.label]?.explanation}
-                            </span>
-                          </div>
-                        )}
-                        {feedback === 'correct-not-selected' && (
-                          <div className="flex items-start gap-2 text-green-700 dark:text-green-300">
-                            <span className="flex-shrink-0">ℹ️</span>
-                            <span>
-                              <strong>{text.correctAnswerWas}</strong>{' '}
-                              {question.explanations[option.label]?.explanation}
-                            </span>
-                          </div>
-                        )}
-                      </div>
-                    )}
+                    />
+                    <div className="flex-1">
+                      <label
+                        htmlFor={`${question.id}-${option.label}`}
+                        className={`cursor-pointer ${isDarkMode ? 'text-slate-100' : 'text-gray-900'}`}
+                      >
+                        <span className="font-semibold">{option.label})</span>{' '}
+                        {option.text}
+                      </label>
+                      {showFeedback && feedback && (
+                        <div className="mt-2 text-sm">
+                          {optionFeedback === 'correct-selected' && (
+                            <div className="flex items-start gap-2 text-green-700 dark:text-green-300">
+                              <span className="flex-shrink-0">✓</span>
+                              <span>
+                                <strong>{text.correct}</strong>{' '}
+                                {
+                                  feedback.explanations[option.label]
+                                    ?.explanation
+                                }
+                              </span>
+                            </div>
+                          )}
+                          {optionFeedback === 'incorrect-selected' && (
+                            <div className="flex items-start gap-2 text-red-700 dark:text-red-300">
+                              <span className="flex-shrink-0">✗</span>
+                              <span>
+                                <strong>{text.incorrect}</strong>{' '}
+                                {
+                                  feedback.explanations[option.label]
+                                    ?.explanation
+                                }
+                              </span>
+                            </div>
+                          )}
+                          {optionFeedback === 'correct-not-selected' && (
+                            <div className="flex items-start gap-2 text-green-700 dark:text-green-300">
+                              <span className="flex-shrink-0">ℹ️</span>
+                              <span>
+                                <strong>{text.correctAnswerWas}</strong>{' '}
+                                {
+                                  feedback.explanations[option.label]
+                                    ?.explanation
+                                }
+                              </span>
+                            </div>
+                          )}
+                        </div>
+                      )}
+                    </div>
                   </div>
-                </div>
-              );
-            })
-          )}
+                );
+              })}
         </div>
 
-        {showFeedback && isSelectionComplete && (
-          <div className={`p-4 rounded-lg border-2 ${isCorrect
-            ? isDarkMode
-              ? 'bg-green-900/30 border-green-700'
-              : 'bg-green-50 border-green-300'
-            : isDarkMode
-              ? 'bg-red-900/30 border-red-700'
-              : 'bg-red-50 border-red-300'
-            }`}>
+        {showFeedback && feedback && (
+          <div
+            className={`p-4 rounded-lg border-2 ${
+              isCorrect
+                ? isDarkMode
+                  ? 'bg-green-900/30 border-green-700'
+                  : 'bg-green-50 border-green-300'
+                : isDarkMode
+                  ? 'bg-red-900/30 border-red-700'
+                  : 'bg-red-50 border-red-300'
+            }`}
+          >
             <div className="flex items-center gap-3">
               {isCorrect ? (
                 <>
-                  <span className={`text-2xl ${isDarkMode ? 'text-green-400' : 'text-green-600'}`}>✓</span>
-                  <strong className={`text-base ${isDarkMode ? 'text-green-200' : 'text-green-900'}`}>{text.correctTitle}</strong>
+                  <span
+                    className={`text-2xl ${isDarkMode ? 'text-green-400' : 'text-green-600'}`}
+                  >
+                    ✓
+                  </span>
+                  <strong
+                    className={`text-base ${isDarkMode ? 'text-green-200' : 'text-green-900'}`}
+                  >
+                    {text.correctTitle}
+                  </strong>
                 </>
               ) : (
                 <>
-                  <span className={`text-2xl ${isDarkMode ? 'text-red-400' : 'text-red-600'}`}>✗</span>
+                  <span
+                    className={`text-2xl ${isDarkMode ? 'text-red-400' : 'text-red-600'}`}
+                  >
+                    ✗
+                  </span>
                   <div className={isDarkMode ? 'text-red-200' : 'text-red-900'}>
-                    <strong className="text-base block mb-1">{text.incorrectTitle}</strong>
+                    <strong className="text-base block mb-1">
+                      {text.incorrectTitle}
+                    </strong>
                     <span className="text-sm">
-                      {text.correctAnswers} <strong>{question.correctAnswer.join(', ')}</strong>
+                      {text.correctAnswers}{' '}
+                      <strong>{feedback.correctAnswer.join(', ')}</strong>
                     </span>
                   </div>
                 </>

--- a/apps/frontend/src/app/labs/istqb/exam-data.server.ts
+++ b/apps/frontend/src/app/labs/istqb/exam-data.server.ts
@@ -1,0 +1,33 @@
+import type { ExamData } from './types';
+
+import questionsModelA from './data/questions-modelo-a.json';
+import questionsEnModelA from './data/questions-en-model-a.json';
+import questionsEnModelB from './data/questions-en-model-b.json';
+import questionsEnModelC from './data/questions-en-model-c.json';
+import questionsEsModelB from './data/questions-es-model-b.json';
+import questionsEsModelC from './data/questions-es-model-c.json';
+
+// SEC-HIGH (#225): este módulo importa el banco de preguntas completo
+// (con `correctAnswer`/`explanations`). SOLO debe importarse desde código
+// que corre en el servidor (server actions, `src/actions/lib/*`). Si algún
+// componente 'use client' llega a importarlo (directa o transitivamente),
+// Next.js volverá a empaquetar las respuestas correctas en el JS que se
+// envía al navegador antes de que el usuario responda.
+export function loadExamData(examId: string = 'es-model-a'): ExamData {
+  switch (examId) {
+    case 'es-model-a':
+      return questionsModelA as unknown as ExamData;
+    case 'es-model-b':
+      return questionsEsModelB as unknown as ExamData;
+    case 'es-model-c':
+      return questionsEsModelC as unknown as ExamData;
+    case 'en-model-a':
+      return questionsEnModelA as unknown as ExamData;
+    case 'en-model-b':
+      return questionsEnModelB as unknown as ExamData;
+    case 'en-model-c':
+      return questionsEnModelC as unknown as ExamData;
+    default:
+      return questionsModelA as unknown as ExamData;
+  }
+}

--- a/apps/frontend/src/app/labs/istqb/types.ts
+++ b/apps/frontend/src/app/labs/istqb/types.ts
@@ -34,6 +34,16 @@ export interface ExamData {
   questions: ExamQuestion[];
 }
 
+// Forma pública de una pregunta: sin `correctAnswer` ni `explanations`.
+// Es lo único que debe viajar al cliente antes de que el usuario responda
+// (ver #225 — las respuestas correctas no deben ir en el bundle del cliente).
+export type PublicExamQuestion = Omit<
+  ExamQuestion,
+  'correctAnswer' | 'explanations'
+> & {
+  answerCount: number;
+};
+
 export interface UserAnswer {
   questionId: number;
   selectedAnswers: string[];

--- a/apps/frontend/src/app/labs/istqb/utils.ts
+++ b/apps/frontend/src/app/labs/istqb/utils.ts
@@ -1,36 +1,17 @@
 import type {
-  ExamData,
   ExamQuestion,
   ExamResult,
   AnswerDetail,
   LearningObjectiveResult,
 } from './types';
 
-import questionsModelA from './data/questions-modelo-a.json';
-import questionsEnModelA from './data/questions-en-model-a.json';
-import questionsEnModelB from './data/questions-en-model-b.json';
-import questionsEnModelC from './data/questions-en-model-c.json';
-import questionsEsModelB from './data/questions-es-model-b.json';
-import questionsEsModelC from './data/questions-es-model-c.json';
-
-export function loadExamData(examId: string = 'es-model-a'): ExamData {
-  switch (examId) {
-    case 'es-model-a':
-      return questionsModelA as unknown as ExamData;
-    case 'es-model-b':
-      return questionsEsModelB as unknown as ExamData;
-    case 'es-model-c':
-      return questionsEsModelC as unknown as ExamData;
-    case 'en-model-a':
-      return questionsEnModelA as unknown as ExamData;
-    case 'en-model-b':
-      return questionsEnModelB as unknown as ExamData;
-    case 'en-model-c':
-      return questionsEnModelC as unknown as ExamData;
-    default:
-      return questionsModelA as unknown as ExamData;
-  }
-}
+// IMPORTANTE (#225 - SEC-HIGH): este archivo es importado por componentes
+// 'use client' (QuestionCard, ExamSimulator, ISTQBClient). NUNCA agregues
+// aquí un `loadExamData`/`require(...json)` que importe el banco de
+// preguntas completo (con `correctAnswer`/`explanations`) — Next.js
+// empaquetaría las respuestas correctas en el JS enviado al navegador
+// antes de que el usuario responda. Esa carga vive únicamente en
+// `@/actions/istqb-exam.ts` ('use server').
 
 export function shuffleArray<T>(array: T[]): T[] {
   const shuffled = [...array];


### PR DESCRIPTION
## Summary

Closes the core code path of #225 (SEC-HIGH, open 40+ days) for the **ISTQB** lab: the simulator no longer ships the full question bank — including `correctAnswer`/`explanations` — to the browser before the user answers.

**Root cause:** `ISTQBClient.tsx` (`'use client'`) called `loadExamData()` at the top of the component, which statically imports the question-bank JSON. Next.js bundles that import into the JS sent to the browser regardless of which mode (exam/training) the user picks or whether they've started — anyone could open devtools → Sources and read every correct answer before starting "Exam Mode".

**Fix:**
- Question bank JSON (with answers) now lives only in a genuinely server-only module: `apps/frontend/src/app/labs/istqb/exam-data.server.ts`. It is never imported by a `'use client'` file, directly or transitively.
- New server actions in `apps/frontend/src/actions/istqb-exam.ts`:
  - `getExamConfigAction` — exam metadata only (title, time limit, passing score) for the landing screen.
  - `startExamAction` — returns the selected/shuffled question set with `correctAnswer`/`explanations` stripped (`PublicExamQuestion`).
  - `checkAnswerAction` — training-mode immediate feedback, grades **one** question server-side on demand instead of the client holding the whole answer key up front.
  - `submitExamAction` — exam-mode final grading, fully server-side, using the existing (unchanged) `generateExamResult`/`calculateScore` pure functions from `utils.ts`.
- `ISTQBClient.tsx`, `ExamSimulator.tsx`, `QuestionCard.tsx` updated to consume the redacted flow instead of a locally-held `ExamData`.
- Reused `apps/frontend/src/actions/lib/legacy-exam-scoring.ts` (the existing server-side score-recalculation safety net for `saveExamResultAction`) now points at the same server-only data module instead of the client-reachable `utils.ts`, which no longer exports `loadExamData` at all — so the leak can't come back by accident.

**Not in scope / explicit follow-up:** `apps/frontend/src/app/labs/performance/` and `apps/frontend/src/app/labs/git/` have the *identical* pattern (`loadExamData()` called directly inside a `'use client'` component) and are equally affected by #225, but are not touched by this PR. They should get the same treatment next — the file layout is close enough to this PR's that it should be a fast follow, not a redesign.

## Why this needs human review before merge

This changes exam grading — a user-trust-sensitive path — and this PR was authored by an unattended scheduled QA-cycle session with no live human watching. It has not been exercised against a running app with a real login (network egress to `aiquaa.com` is blocked from this environment, and `ExamAuthGate` requires Supabase auth), only against the local test suite. Please smoke-test the exam flow (both exam and training mode) locally before merging.

## Test plan

- [x] `pnpm --filter @aiquaa/frontend test -- src/app/labs/istqb` — existing `utils.test.ts` (2 tests) still passes unmodified.
- [x] New `apps/frontend/src/actions/__tests__/istqb-exam.test.ts` (6 tests): confirms `startExamAction` output never contains `correctAnswer`/`explanations`, `checkAnswerAction` grades a single question correctly and returns `null` for unknown ids, `submitExamAction` grading matches per-question `checkAnswerAction` results, and unknown `questionIds` are safely ignored.
- [x] `pnpm --filter @aiquaa/frontend type-check` (`tsc --noEmit`) — clean.
- [x] `pnpm exec eslint` on all touched files — clean (only a pre-existing unrelated warning on an untouched line).
- [x] Full `pnpm --filter @aiquaa/frontend test` — same 33 pre-existing failures as on `main` (verified via `git stash`; unrelated `window.matchMedia`/jsdom issues in Auth/Forum tests), no new failures.
- [ ] Manual smoke test of `/labs/istqb` exam + training mode against a real Supabase session (not possible from this environment).

---
_Generated by [Claude Code](https://claude.ai/code/session_01EW2jE3394B28jkV1gfUcK5)_