### PR TITLE
fix(frontend): polyfill window.matchMedia in test setup

### DIFF
--- a/apps/frontend/test/setup.ts
+++ b/apps/frontend/test/setup.ts
@@ -50,6 +50,23 @@ if (typeof globalThis.crypto === 'undefined') {
 // Mock de fetch global
 global.fetch = vi.fn();
 
+// Polyfill para window.matchMedia (no implementado en jsdom)
+if (typeof window !== 'undefined' && !window.matchMedia) {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+}
+
 // Establecer handlers de MSW
 beforeAll(() => server.listen({ onUnhandledRequest: 'warn' }));
 


### PR DESCRIPTION
## Summary

- `jsdom` (the test DOM used by Vitest) does not implement `window.matchMedia`. `LogoMark.tsx` calls it directly in a `useEffect` to respect `prefers-reduced-motion`, and `LogoMark` is rendered by `Header`/`Footer`/`AuthForm`, so any test that mounts those components throws `TypeError: window.matchMedia is not a function`.
- This is the exact failure documented in PR #309's "Lint & Unit Tests" required check (`window.matchMedia is not a function in LogoMark.tsx:77`), which has been blocking merge of the #225 (SEC-HIGH) fix for 2 days, and was previously flagged as a pre-existing, unrelated failure in QA-cycle issues #310/#311.
- Adds a minimal `matchMedia` polyfill to `apps/frontend/test/setup.ts` (standard jsdom mock shape: `matches`, `media`, `addEventListener`/`removeEventListener`, etc., defaulting `matches: false`).

## Verification

- Before: this class of failure occurred wherever `LogoMark` was mounted (Header/Footer/AuthForm-adjacent tests).
- After: `grep -c matchMedia` on a full `pnpm --filter @aiquaa/frontend test` run returns `0` — no more matchMedia-related failures anywhere in the suite.
- Full suite went from the previously-reported 33 pre-existing failures to 14 (all unrelated — separate pre-existing mock/timing issues in `RegisterForm`/`LoginForm` real-flow tests, e.g. `checkEmailTakenAction` not exported from a `vi.mock`). Those are a separate, deeper issue and out of scope here.
- `pnpm --filter @aiquaa/frontend type-check` and `eslint --fix` (via lint-staged pre-commit hook) pass clean on the changed file.
- Change is additive-only (one new polyfill block), touches no other logic, so it carries no regression risk to passing tests.

## Context

Found and fixed during an automated, unattended QA-cycle session (no live human watching) while investigating why PR #309 has sat with a red required check for 2 days despite the check being unrelated to its diff. Fixing the shared test-infra issue is lower-risk and higher-leverage than special-casing it in #309.


---
_Generated by [Claude Code](https://claude.ai/code/session_013e1A5yUtBqp8oxW71tJ3WC)_