### PR TITLE
feat(empresa): habilita prueba Gherkin y BDD en procesos de contratacion

### DIFF
--- a/apps/frontend/src/app/empresa/procesos/nuevo/page.tsx
+++ b/apps/frontend/src/app/empresa/procesos/nuevo/page.tsx
@@ -108,6 +108,12 @@ const EXAM_OPTIONS = [
       'Pipelines de integración continua, despliegue continuo automatizado y buenas prácticas de versionado — auto-corregido, 3 secciones',
   },
   {
+    id: 'gherkin-fundamentals',
+    label: 'Gherkin y BDD — Fundamentos (Examen teórico)',
+    description:
+      'Fundamentos de BDD, sintaxis Gherkin (Given/When/Then) y escenarios avanzados aplicados a testing — auto-corregido, 3 niveles',
+  },
+  {
     id: 'test-app',
     label: 'Test App — Exploratory Testing & Bug Hunt',
     description:


### PR DESCRIPTION
## Summary
- La prueba tecnica de esta semana, **Gherkin y BDD — Fundamentos**, ya existia completa (registry, exams.ts, labsCatalog, dashboard, ranking) y ya contaba en `PROCESS_ASSESSMENT_SLUGS`, pero no aparecia como opcion seleccionable al crear un proceso desde `/empresa/procesos/nuevo`, porque ese formulario usa su propia lista hardcodeada (`EXAM_OPTIONS`) separada del registry de assessments.
- Mismo problema corregido en #307 para las otras 5 pruebas tecnicas (API .NET, Docker, Kubernetes+Helm, Observabilidad, CI/CD). Se agrega Gherkin a la misma lista.

## Test plan
- [x] `tsc --noEmit` limpio (via type-check de pre-push hook)
- [ ] Verificar visualmente en `/empresa/procesos/nuevo` que la opcion "Gherkin y BDD — Fundamentos (Examen teorico)" aparece en el checklist (no se pudo probar en este entorno por falta de credenciales de empresa/DB local)

🤖 Generated with [Claude Code](https://claude.com/claude-code)