### PR TITLE
fix(frontend): stop double-submit on register, fix stale RegisterForm mocks

### DIFF
--- a/apps/frontend/src/components/auth/RegisterForm.tsx
+++ b/apps/frontend/src/components/auth/RegisterForm.tsx
@@ -1,7 +1,11 @@
 'use client';
 
-import React, { useRef, useState, useTransition } from 'react';
-import { registerAction, resendConfirmationAction, checkEmailTakenAction } from '@/actions/auth';
+import React, { useRef, useState } from 'react';
+import {
+  registerAction,
+  resendConfirmationAction,
+  checkEmailTakenAction,
+} from '@/actions/auth';
 import AuthForm from './AuthForm';
 import EmailVerificationModal from './EmailVerificationModal';
 import { Audience } from './AudienceToggle';
@@ -12,7 +16,7 @@ interface RegisterFormProps {
 }
 
 export default function RegisterForm({ lockedAudience }: RegisterFormProps) {
-  const [isPending, startTransition] = useTransition();
+  const [isSubmitting, setIsSubmitting] = useState(false);
   const [errors, setErrors] = useState<{ [key: string]: string }>({});
   const [showAlert, setShowAlert] = useState(false);
   const [alertMessage, setAlertMessage] = useState('');
@@ -66,7 +70,8 @@ export default function RegisterForm({ lockedAudience }: RegisterFormProps) {
       data.set('role', formData.role);
     }
 
-    startTransition(async () => {
+    setIsSubmitting(true);
+    try {
       const result = await registerAction(data);
       if (result?.error) {
         if (result.error.includes('already registered')) {
@@ -82,7 +87,9 @@ export default function RegisterForm({ lockedAudience }: RegisterFormProps) {
       } else if (result?.success) {
         setShowVerifyModal(true);
       }
-    });
+    } finally {
+      setIsSubmitting(false);
+    }
   };
 
   const handleEmailBlur = async () => {
@@ -148,39 +155,39 @@ export default function RegisterForm({ lockedAudience }: RegisterFormProps) {
 
   return (
     <>
-    {showVerifyModal && (
-      <EmailVerificationModal
-        email={formData.email}
-        context="post-register"
-        onClose={() => setShowVerifyModal(false)}
-        onResend={handleResend}
+      {showVerifyModal && (
+        <EmailVerificationModal
+          email={formData.email}
+          context="post-register"
+          onClose={() => setShowVerifyModal(false)}
+          onResend={handleResend}
+        />
+      )}
+      <AuthForm
+        mode="register"
+        onSubmit={handleSubmit}
+        isLoading={isSubmitting}
+        errors={errors}
+        formData={formData}
+        onFieldChange={handleChange}
+        onPasswordChange={handlePasswordChange}
+        onRoleChange={handleRoleChange}
+        onAudienceChange={lockedAudience ? undefined : handleAudienceChange}
+        onClearErrors={() => {
+          setErrors({});
+          setShowAlert(false);
+        }}
+        socialLoginError={socialLoginError}
+        onSocialError={() => {}}
+        showAlert={showAlert}
+        alertMessage={alertMessage}
+        alertType={alertType}
+        showResend={false}
+        onEmailBlur={handleEmailBlur}
+        emailChecking={emailChecking}
+        passwordRef={passwordRef}
+        confirmPasswordRef={confirmPasswordRef}
       />
-    )}
-    <AuthForm
-      mode="register"
-      onSubmit={handleSubmit}
-      isLoading={isPending}
-      errors={errors}
-      formData={formData}
-      onFieldChange={handleChange}
-      onPasswordChange={handlePasswordChange}
-      onRoleChange={handleRoleChange}
-      onAudienceChange={lockedAudience ? undefined : handleAudienceChange}
-      onClearErrors={() => {
-        setErrors({});
-        setShowAlert(false);
-      }}
-      socialLoginError={socialLoginError}
-      onSocialError={() => {}}
-      showAlert={showAlert}
-      alertMessage={alertMessage}
-      alertType={alertType}
-      showResend={false}
-      onEmailBlur={handleEmailBlur}
-      emailChecking={emailChecking}
-      passwordRef={passwordRef}
-      confirmPasswordRef={confirmPasswordRef}
-    />
     </>
   );
 }

--- a/apps/frontend/test/components/auth/RegisterForm.real.test.tsx
+++ b/apps/frontend/test/components/auth/RegisterForm.real.test.tsx
@@ -1,5 +1,11 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import RegisterForm from '@/components/auth/RegisterForm';
 
@@ -25,10 +31,17 @@ vi.mock('@/components/auth/AuthForm', () => ({
     errors,
     formData,
     onFieldChange,
+    onPasswordChange,
+    onRoleChange,
+    passwordRef,
+    confirmPasswordRef,
     showAlert,
     alertMessage,
   }: any) => (
     <form onSubmit={onSubmit}>
+      <button type="button" onClick={() => onRoleChange?.('estudiante')}>
+        Estudiante
+      </button>
       <input
         aria-label="Nombre completo"
         name="name"
@@ -47,15 +60,17 @@ vi.mock('@/components/auth/AuthForm', () => ({
         aria-label="Contraseña"
         name="password"
         placeholder="Contraseña"
-        value={formData.password || ''}
-        onChange={onFieldChange}
+        ref={passwordRef}
+        defaultValue=""
+        onChange={onPasswordChange ?? onFieldChange}
       />
       <input
         aria-label="Confirmar contraseña"
         name="confirmPassword"
         placeholder="Confirmar contraseña"
-        value={formData.confirmPassword || ''}
-        onChange={onFieldChange}
+        ref={confirmPasswordRef}
+        defaultValue=""
+        onChange={onPasswordChange ?? onFieldChange}
       />
       <button type="submit">Crear cuenta</button>
       {errors.name && <p>{errors.name}</p>}
@@ -89,7 +104,9 @@ describe('RegisterForm real flow', () => {
     expect(await screen.findByText('Nombre obligatorio')).toBeInTheDocument();
     expect(screen.getByText('Correo obligatorio')).toBeInTheDocument();
     expect(screen.getByText('Contraseña obligatoria')).toBeInTheDocument();
-    expect(screen.getByText('Confirmar contraseña obligatorio')).toBeInTheDocument();
+    expect(
+      screen.getByText('Confirmar contraseña obligatorio')
+    ).toBeInTheDocument();
     expect(mockRegister).not.toHaveBeenCalled();
   });
 
@@ -97,13 +114,21 @@ describe('RegisterForm real flow', () => {
     const user = userEvent.setup();
     render(<RegisterForm />);
 
-    await user.type(screen.getByPlaceholderText('Nombre completo'), 'QA Aiquaa');
+    await user.type(
+      screen.getByPlaceholderText('Nombre completo'),
+      'QA Aiquaa'
+    );
     await user.type(screen.getByPlaceholderText('Email'), 'qa@aiquaa.com');
     await user.type(screen.getByPlaceholderText('Contraseña'), 'Password123');
-    await user.type(screen.getByPlaceholderText('Confirmar contraseña'), 'Password456');
+    await user.type(
+      screen.getByPlaceholderText('Confirmar contraseña'),
+      'Password456'
+    );
     await user.click(getSubmitButton());
 
-    expect(await screen.findByText('Las contraseñas no coinciden')).toBeInTheDocument();
+    expect(
+      await screen.findByText('Las contraseñas no coinciden')
+    ).toBeInTheDocument();
     expect(mockRegister).not.toHaveBeenCalled();
   });
 
@@ -116,10 +141,16 @@ describe('RegisterForm real flow', () => {
 
     render(<RegisterForm />);
 
-    await user.type(screen.getByPlaceholderText('Nombre completo'), 'QA Aiquaa');
+    await user.type(
+      screen.getByPlaceholderText('Nombre completo'),
+      'QA Aiquaa'
+    );
     await user.type(screen.getByPlaceholderText('Email'), 'qa@aiquaa.com');
     await user.type(screen.getByPlaceholderText('Contraseña'), 'Password123');
-    await user.type(screen.getByPlaceholderText('Confirmar contraseña'), 'Password123');
+    await user.type(
+      screen.getByPlaceholderText('Confirmar contraseña'),
+      'Password123'
+    );
     await user.click(getSubmitButton());
 
     await waitFor(() => {
@@ -132,7 +163,9 @@ describe('RegisterForm real flow', () => {
     });
 
     expect(
-      await screen.findByText('Este email ya está registrado. Intenta iniciar sesión o usa otro email.')
+      await screen.findByText(
+        'Este email ya está registrado. Intenta iniciar sesión o usa otro email.'
+      )
     ).toBeInTheDocument();
   });
 
@@ -171,7 +204,9 @@ describe('RegisterForm real flow', () => {
       confirmPassword: 'Password123',
     });
     expect(
-      screen.getByText('Registro exitoso. Revisa tu email para verificar tu cuenta.')
+      screen.getByText(
+        'Registro exitoso. Revisa tu email para verificar tu cuenta.'
+      )
     ).toBeInTheDocument();
     expect(setTimeoutSpy).toHaveBeenCalledOnce();
     expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), 2000);

--- a/apps/frontend/test/components/auth/RegisterForm.test.tsx
+++ b/apps/frontend/test/components/auth/RegisterForm.test.tsx
@@ -9,6 +9,7 @@ import { LanguageProvider } from '@/contexts/LanguageContext';
 vi.mock('@/actions/auth', () => ({
   registerAction: vi.fn(),
   resendConfirmationAction: vi.fn(),
+  checkEmailTakenAction: vi.fn().mockResolvedValue({ taken: false }),
 }));
 
 // Mock del SessionProvider de next-auth
@@ -416,6 +417,14 @@ describe('RegisterForm', () => {
 
     it('deshabilita botón durante el envío', async () => {
       const user = userEvent.setup();
+      // registerAction se resuelve en el siguiente tick (no de forma síncrona)
+      // para poder observar el estado "disabled" intermedio del botón.
+      vi.mocked(registerAction).mockImplementation(
+        () =>
+          new Promise((resolve) =>
+            setTimeout(() => resolve({ success: true }), 10)
+          )
+      );
 
       renderWithProviders(<RegisterForm />);
 

--- a/apps/frontend/test/setup.ts
+++ b/apps/frontend/test/setup.ts
@@ -50,6 +50,23 @@ if (typeof globalThis.crypto === 'undefined') {
 // Mock de fetch global
 global.fetch = vi.fn();
 
+// Polyfill para window.matchMedia (no implementado en jsdom)
+if (typeof window !== 'undefined' && !window.matchMedia) {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+}
+
 // Establecer handlers de MSW
 beforeAll(() => server.listen({ onUnhandledRequest: 'warn' }));
 


### PR DESCRIPTION
## Summary

Found while chasing the "Lint & Unit Tests" CI failures tracked in #314 — specifically the `RegisterForm.test.tsx` file, flagged there as "parece ser el de mayor impacto y más fácil de diagnosticar."

- **Real product bug, not just tests**: `RegisterForm.tsx` used `useTransition`'s `isPending` to disable the submit button during `registerAction`. React 18 does not track pending state across an `await` inside an async transition callback (that support lands in React 19) — `isPending` flips back to `false` the instant `registerAction` is *called*, not when it *resolves*. The submit button silently re-enables mid-request, so a user can double-submit registration on a slow connection. Fixed by replacing it with explicit `isSubmitting` state set/cleared around the `await`.
- **Stale test mocks**, both surfaced by the above fix once the real timing was testable:
  - `RegisterForm.test.tsx`'s `@/actions/auth` mock was missing `checkEmailTakenAction`, which `RegisterForm.tsx` calls on email blur — this alone was silently failing every test in the file via an unhandled rejection.
  - `RegisterForm.real.test.tsx`'s `AuthForm` mock didn't forward `passwordRef`/`confirmPasswordRef`, so the real component (which reads password/confirmPassword via refs, not controlled state) always saw them as empty, and it had no role selector even though the real form requires a role for `candidato` audience.
- Reused the `window.matchMedia` jsdom polyfill from unmerged PR #312 in `test/setup.ts` (still needed — this branch predates that PR since main hasn't merged it yet).

`RegisterForm.test.tsx` is now fully green (20/20). `RegisterForm.real.test.tsx` still has 2 failing assertions expecting a `mockRegister` (`useNextAuth().register`) that the current `registerAction`-based implementation never calls — that's a deeper test-vs-implementation mismatch from an earlier refactor (the component moved from a NextAuth-context register call to a server action), not something a mock fix resolves. Filed separately, not attempted here.

Net effect on the frontend suite: 14 failing test files → 13, 12 failing tests → 10 (measured against a clean `origin/main` checkout with #312's `matchMedia` polyfill applied, since main doesn't have it yet).

## Test plan

- [x] `pnpm --filter @aiquaa/frontend test -- RegisterForm.test.tsx` — 20/20 pass
- [x] `pnpm --filter @aiquaa/frontend test` — full suite run, no new failures vs. baseline (see above)
- [x] `eslint` clean on all changed files
- [x] `tsc --noEmit` clean (pre-existing `@aiquaa/allpairs-core` errors unrelated to this change, present on main)

---

*Hallado y corregido en ciclo de mejora continua automatizado (QA-CYCLE), 2026-08-16. Sin acceso de red a `aiquaa.com` en esta sesión (mismo bloqueo `EGRESS_BLOCKED` de ~40 ciclos previos) — todo el trabajo de este PR es lectura de código y ejecución real de la suite de tests contra un checkout local. Sesión sin humano viendo en vivo (rutina programada).*

🤖 Generated with [Claude Code](https://claude.ai/code)

Claude-Session: https://claude.ai/code/session_01RN6awqCU4mFzkwYfif8Qqr

---
_Generated by [Claude Code](https://claude.ai/code/session_01RN6awqCU4mFzkwYfif8Qqr)_