### PR TITLE
feat(assessments): agrega 5 pruebas tecnicas del bootcamp y un proyecto final de desarrollo

### DIFF
--- a/apps/frontend/src/actions/exam-review.ts
+++ b/apps/frontend/src/actions/exam-review.ts
@@ -10,7 +10,9 @@ type BugReviewItem = {
 };
 
 type ReviewData = {
-  bugs: Record<string, BugReviewItem>;
+  // Sólo aplica al bug hunt de test-app; las pruebas de desarrollo se corrigen
+  // con un puntaje global y no tienen items individuales.
+  bugs?: Record<string, BugReviewItem>;
   overallNotes: string;
   adjustedScore: number | null;
 };
@@ -45,30 +47,41 @@ export type ExamDetail = {
   review_status: string;
   reviewed_at: string | null;
   reviewed_by: string | null;
-  metadata: {
-    bugs: Array<{
-      id: string;
-      title: string;
-      description: string;
-      stepsToReproduce: string[];
-      expectedResult: string;
-      actualResult: string;
-      severity: 'Critical' | 'High' | 'Medium' | 'Low';
-      category: string;
-      evidence: string;
-      images?: BugImageEvidence[];
-      foundAt: string;
-    }>;
-    exploredSections: string[];
-    bugCount: number;
-    severityCounts: {
-      critical: number;
-      high: number;
-      medium: number;
-      low: number;
-    };
-  } | null;
+  metadata: BugHuntMetadata | DesarrolloMetadata | null;
   review_data: ReviewData | null;
+};
+
+/** Entrega de una prueba de desarrollo: el candidato manda el link del repo. */
+export type DesarrolloMetadata = {
+  challengeId: string;
+  repoUrl: string;
+  githubUser?: string;
+  notes?: string;
+  submittedAt?: string;
+};
+
+type BugHuntMetadata = {
+  bugs: Array<{
+    id: string;
+    title: string;
+    description: string;
+    stepsToReproduce: string[];
+    expectedResult: string;
+    actualResult: string;
+    severity: 'Critical' | 'High' | 'Medium' | 'Low';
+    category: string;
+    evidence: string;
+    images?: BugImageEvidence[];
+    foundAt: string;
+  }>;
+  exploredSections: string[];
+  bugCount: number;
+  severityCounts: {
+    critical: number;
+    high: number;
+    medium: number;
+    low: number;
+  };
 };
 
 export async function getExamDetailAction(
@@ -96,7 +109,8 @@ export async function getExamDetailAction(
   if (!data) return { data: null, error: 'Resultado no encontrado' };
 
   const detail = data as unknown as ExamDetail;
-  const bugs = detail.metadata?.bugs ?? [];
+  const bugs =
+    detail.metadata && 'bugs' in detail.metadata ? detail.metadata.bugs : [];
   const images = bugs.flatMap((bug) => bug.images ?? []);
   const storageImages = images.filter(
     (image) => image.storageBucket && image.storagePath

--- a/apps/frontend/src/actions/exams.ts
+++ b/apps/frontend/src/actions/exams.ts
@@ -29,7 +29,17 @@ interface SaveExamResultPayload {
     | 'cicd-fundamentals'
     | 'playwright-practico'
     | 'playwright-fundamentals'
-    | 'gherkin-fundamentals';
+    | 'gherkin-fundamentals'
+    | 'clase3-data-persistencia'
+    | 'clase5-kubernetes'
+    | 'clase6-config-kubernetes'
+    | 'clase7-8-seq-logging'
+    | 'clase9-cicd-github-actions'
+    | 'dev-persistencia'
+    | 'dev-kubernetes'
+    | 'dev-config-kubernetes'
+    | 'dev-seq-logging'
+    | 'dev-cicd-actions';
   exam_mode: 'exam' | 'training';
   participant_name?: string;
   participant_email?: string;
@@ -72,6 +82,13 @@ interface SaveExamResultPayload {
 const NEEDS_MANUAL_CORRECTION_EXAM_TYPES = new Set([
   'test-app',
   'playwright-practico',
+  // Pruebas de desarrollo: se entregan con el link del repositorio y no
+  // tienen score automático — el evaluador carga el puntaje global.
+  'dev-persistencia',
+  'dev-kubernetes',
+  'dev-config-kubernetes',
+  'dev-seq-logging',
+  'dev-cicd-actions',
 ]);
 
 export async function saveExamResultAction(payload: SaveExamResultPayload) {
@@ -198,7 +215,12 @@ export async function getLeaderboardAction(
     | 'api-developer-fundamentals'
     | 'playwright-practico'
     | 'playwright-fundamentals'
-    | 'gherkin-fundamentals',
+    | 'gherkin-fundamentals'
+    | 'clase3-data-persistencia'
+    | 'clase5-kubernetes'
+    | 'clase6-config-kubernetes'
+    | 'clase7-8-seq-logging'
+    | 'clase9-cicd-github-actions',
   limit = 20
 ) {
   const supabase = createClient();

--- a/apps/frontend/src/actions/exams.ts
+++ b/apps/frontend/src/actions/exams.ts
@@ -35,11 +35,7 @@ interface SaveExamResultPayload {
     | 'clase6-config-kubernetes'
     | 'clase7-8-seq-logging'
     | 'clase9-cicd-github-actions'
-    | 'dev-persistencia'
-    | 'dev-kubernetes'
-    | 'dev-config-kubernetes'
-    | 'dev-seq-logging'
-    | 'dev-cicd-actions';
+    | 'dev-proyecto-final';
   exam_mode: 'exam' | 'training';
   participant_name?: string;
   participant_email?: string;
@@ -82,13 +78,9 @@ interface SaveExamResultPayload {
 const NEEDS_MANUAL_CORRECTION_EXAM_TYPES = new Set([
   'test-app',
   'playwright-practico',
-  // Pruebas de desarrollo: se entregan con el link del repositorio y no
-  // tienen score automático — el evaluador carga el puntaje global.
-  'dev-persistencia',
-  'dev-kubernetes',
-  'dev-config-kubernetes',
-  'dev-seq-logging',
-  'dev-cicd-actions',
+  // Proyecto final de desarrollo: se entrega con el link del repositorio y
+  // no tiene score automático — el evaluador carga el puntaje global.
+  'dev-proyecto-final',
 ]);
 
 export async function saveExamResultAction(payload: SaveExamResultPayload) {

--- a/apps/frontend/src/actions/lib/assessment-slugs.ts
+++ b/apps/frontend/src/actions/lib/assessment-slugs.ts
@@ -15,4 +15,9 @@ export const PROCESS_ASSESSMENT_SLUGS = [
   'kubernetes-helm-fundamentals',
   'observability-fundamentals',
   'cicd-fundamentals',
+  'clase3-data-persistencia',
+  'clase5-kubernetes',
+  'clase6-config-kubernetes',
+  'clase7-8-seq-logging',
+  'clase9-cicd-github-actions',
 ];

--- a/apps/frontend/src/app/assessments/_shared/components/AssessmentSectionScreen.tsx
+++ b/apps/frontend/src/app/assessments/_shared/components/AssessmentSectionScreen.tsx
@@ -13,6 +13,7 @@ import ApiDocCard from './ApiDocCard';
 import AssessmentProgress from './AssessmentProgress';
 import AssessmentTimer from './AssessmentTimer';
 import MultipleChoiceQuestion from './MultipleChoiceQuestion';
+import MultipleSelectQuestion from './MultipleSelectQuestion';
 import PlaywrightCodeBlock from './PlaywrightCodeBlock';
 import RequestResponseBlock from './RequestResponseBlock';
 import SectionNavigator from './SectionNavigator';
@@ -328,6 +329,19 @@ export default function AssessmentSectionScreen({
                         (answer as { value?: string } | undefined)?.value ?? ''
                       )}
                       onChange={(value) => updateAnswer(question.id, { value })}
+                    />
+                  ) : null}
+
+                  {question.question_type === 'multiple_select' ? (
+                    <MultipleSelectQuestion
+                      question={question}
+                      value={
+                        (answer as { values?: string[] } | undefined)?.values ??
+                        []
+                      }
+                      onChange={(values) =>
+                        updateAnswer(question.id, { values })
+                      }
                     />
                   ) : null}
 

--- a/apps/frontend/src/app/assessments/_shared/components/MultipleSelectQuestion.tsx
+++ b/apps/frontend/src/app/assessments/_shared/components/MultipleSelectQuestion.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import type { AssessmentQuestion } from '../types';
+
+// Espejo de MultipleChoiceQuestion pero con selección múltiple: el valor es un
+// array de `option.value` y cada click alterna una opción.
+export default function MultipleSelectQuestion({
+  question,
+  value,
+  onChange,
+}: {
+  question: AssessmentQuestion;
+  value: string[];
+  onChange: (value: string[]) => void;
+}) {
+  function toggle(optionValue: string) {
+    const next = value.includes(optionValue)
+      ? value.filter((item) => item !== optionValue)
+      : [...value, optionValue];
+    onChange(next);
+  }
+
+  return (
+    <div className="space-y-3">
+      <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-400">
+        Marcá todas las opciones correctas
+      </p>
+
+      {question.options?.map((option) => {
+        const checked = value.includes(option.value);
+
+        return (
+          <button
+            key={option.value}
+            type="button"
+            aria-pressed={checked}
+            onClick={() => toggle(option.value)}
+            className={`flex w-full items-start gap-3 rounded-2xl border px-4 py-3 text-left transition ${
+              checked
+                ? 'border-cyan-400/40 bg-cyan-400/10 text-cyan-50'
+                : 'border-slate-800 bg-slate-950/70 text-slate-200 hover:bg-slate-900'
+            }`}
+          >
+            <span
+              className={`mt-0.5 inline-flex h-5 w-5 shrink-0 items-center justify-center rounded-md border text-xs ${
+                checked
+                  ? 'border-cyan-300 bg-cyan-300 text-slate-950'
+                  : 'border-slate-700'
+              }`}
+            >
+              {checked ? '✓' : ''}
+            </span>
+            <span className="text-sm">{option.label}</span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/frontend/src/app/assessments/_shared/lib/__tests__/scoring-multiple-select.test.ts
+++ b/apps/frontend/src/app/assessments/_shared/lib/__tests__/scoring-multiple-select.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+import { scoreAssessmentQuestion } from '../scoring';
+import type { AssessmentQuestion } from '../../types';
+
+// Pregunta espejo de las de "varias respuestas" de los Excel del bootcamp:
+// 3 correctas de 4 opciones, 10 puntos.
+const question: AssessmentQuestion = {
+  id: 'q1',
+  section_id: 's1',
+  question_type: 'multiple_select',
+  prompt: '¿Cuáles prácticas forman parte de la seguridad fundamental?',
+  options: [
+    { label: 'Contraseñas robustas', value: 'a' },
+    { label: 'Limitar exposición de red', value: 'b' },
+    { label: 'Actualizaciones regulares', value: 'c' },
+    { label: 'Publicar el servicio sin restricciones', value: 'd' },
+  ],
+  correct_answer: { values: ['a', 'b', 'c'] },
+  points: 10,
+  order_index: 1,
+};
+
+function score(answer: unknown) {
+  return scoreAssessmentQuestion(question, answer);
+}
+
+describe('scoreAssessmentQuestion — multiple_select', () => {
+  it('da el puntaje completo con la selección exacta', () => {
+    const result = score({ values: ['a', 'b', 'c'] });
+    expect(result.score).toBe(10);
+    expect(result.isCorrect).toBe(true);
+  });
+
+  it('ignora el orden de las opciones', () => {
+    expect(score({ values: ['c', 'a', 'b'] }).score).toBe(10);
+  });
+
+  it('da crédito parcial cuando faltan opciones', () => {
+    const result = score({ values: ['a', 'b'] });
+    expect(result.score).toBe(7); // round(10 * 2/3)
+    expect(result.isCorrect).toBe(false);
+  });
+
+  it('penaliza cada distractor marcado', () => {
+    // 3 aciertos - 1 extra = 2 netos sobre 3
+    const result = score({ values: ['a', 'b', 'c', 'd'] });
+    expect(result.score).toBe(7);
+    expect(result.isCorrect).toBe(false);
+  });
+
+  it('no baja de cero cuando hay más distractores que aciertos', () => {
+    const result = score({ values: ['d'] });
+    expect(result.score).toBe(0);
+    expect(result.isCorrect).toBe(false);
+  });
+
+  it('marca como vacía la respuesta sin selección', () => {
+    expect(score({ values: [] }).score).toBe(0);
+    expect(score(undefined).score).toBe(0);
+    expect(score({ values: [] }).feedback).toMatch(/ninguna opción/i);
+  });
+
+  it('acepta un array plano como respuesta', () => {
+    expect(score(['a', 'b', 'c']).score).toBe(10);
+  });
+
+  it('deduplica las opciones repetidas', () => {
+    expect(score({ values: ['a', 'a', 'b', 'c'] }).score).toBe(10);
+  });
+
+  it('devuelve cero si la pregunta no tiene answer key', () => {
+    const broken = { ...question, correct_answer: {} } as AssessmentQuestion;
+    expect(scoreAssessmentQuestion(broken, { values: ['a'] }).score).toBe(0);
+  });
+});

--- a/apps/frontend/src/app/assessments/_shared/lib/scoring.ts
+++ b/apps/frontend/src/app/assessments/_shared/lib/scoring.ts
@@ -121,6 +121,94 @@ function compareSimpleAnswer(
   };
 }
 
+/** Respuesta del candidato para `multiple_select`: `{ values: string[] }`. */
+function parseValuesAnswer(answer: unknown): string[] {
+  const raw = Array.isArray(answer)
+    ? answer
+    : answer && typeof answer === 'object' && 'values' in answer
+      ? ((answer as { values?: unknown }).values ?? [])
+      : [];
+  if (!Array.isArray(raw)) return [];
+  return Array.from(
+    new Set(
+      raw
+        .filter((item): item is string => typeof item === 'string')
+        .map((item) => item.trim())
+        .filter(Boolean)
+    )
+  );
+}
+
+// Crédito parcial con penalización por opción de más: cada distractor marcado
+// cancela un acierto. Marcar las 4 opciones de una pregunta con 3 correctas da
+// 0, no puntaje casi completo.
+function scoreMultipleSelect(
+  question: AssessmentQuestion,
+  answer: unknown
+): ScoreResult {
+  const correct = Array.isArray(
+    (question.correct_answer as { values?: unknown } | undefined)?.values
+  )
+    ? ((question.correct_answer as { values: string[] }).values ?? [])
+    : [];
+
+  if (correct.length === 0) {
+    return {
+      score: 0,
+      isCorrect: false,
+      feedback: 'La pregunta no tiene respuestas correctas configuradas.',
+    };
+  }
+
+  const picked = parseValuesAnswer(answer);
+
+  if (picked.length === 0) {
+    return {
+      score: 0,
+      isCorrect: false,
+      feedback: 'No seleccionaste ninguna opción.',
+    };
+  }
+
+  const hits = picked.filter((value) => correct.includes(value)).length;
+  const extras = picked.length - hits;
+  const net = Math.max(0, hits - extras);
+  const score = Math.round((question.points * net) / correct.length);
+  const isCorrect = hits === correct.length && extras === 0;
+
+  if (isCorrect) {
+    return {
+      score: question.points,
+      isCorrect: true,
+      feedback: 'Seleccionaste exactamente las opciones correctas.',
+    };
+  }
+
+  if (extras > 0 && hits < correct.length) {
+    return {
+      score,
+      isCorrect: false,
+      feedback:
+        'Faltan opciones correctas y además marcaste alguna que no corresponde.',
+    };
+  }
+
+  if (extras > 0) {
+    return {
+      score,
+      isCorrect: false,
+      feedback:
+        'Identificaste las opciones correctas, pero marcaste además alguna que no corresponde.',
+    };
+  }
+
+  return {
+    score,
+    isCorrect: false,
+    feedback: 'La selección es parcial: faltan opciones correctas.',
+  };
+}
+
 function scoreShortText(
   question: AssessmentQuestion,
   answer: unknown
@@ -215,6 +303,8 @@ export function scoreAssessmentQuestion(
     case 'true_false':
     case 'doc_analysis':
       return compareSimpleAnswer(question, answer);
+    case 'multiple_select':
+      return scoreMultipleSelect(question, answer);
     case 'short_text':
       return scoreShortText(question, answer);
     case 'response_analysis':

--- a/apps/frontend/src/app/assessments/_shared/registry.ts
+++ b/apps/frontend/src/app/assessments/_shared/registry.ts
@@ -106,12 +106,62 @@ import {
   buildPlaywrightFundamentalsGamificationEvents,
 } from '../playwright-fundamentals/lib/gamification';
 import { ensurePlaywrightFundamentalsSeeded } from '../playwright-fundamentals/lib/seed';
+import {
+  CLASE3_DATA_PERSISTENCIA_SEED_VERSION,
+  CLASE3_DATA_PERSISTENCIA_SLUG,
+} from '../clase3-data-persistencia/data/assessment-definition';
+import {
+  CLASE3_DATA_PERSISTENCIA_GAMIFICATION_RULES,
+  buildClase3DataPersistenciaGamificationEvents,
+} from '../clase3-data-persistencia/lib/gamification';
+import { ensureClase3DataPersistenciaSeeded } from '../clase3-data-persistencia/lib/seed';
+import {
+  CLASE5_KUBERNETES_SEED_VERSION,
+  CLASE5_KUBERNETES_SLUG,
+} from '../clase5-kubernetes/data/assessment-definition';
+import {
+  CLASE5_KUBERNETES_GAMIFICATION_RULES,
+  buildClase5KubernetesGamificationEvents,
+} from '../clase5-kubernetes/lib/gamification';
+import { ensureClase5KubernetesSeeded } from '../clase5-kubernetes/lib/seed';
+import {
+  CLASE6_CONFIG_KUBERNETES_SEED_VERSION,
+  CLASE6_CONFIG_KUBERNETES_SLUG,
+} from '../clase6-config-kubernetes/data/assessment-definition';
+import {
+  CLASE6_CONFIG_KUBERNETES_GAMIFICATION_RULES,
+  buildClase6ConfigKubernetesGamificationEvents,
+} from '../clase6-config-kubernetes/lib/gamification';
+import { ensureClase6ConfigKubernetesSeeded } from '../clase6-config-kubernetes/lib/seed';
+import {
+  CLASE7_8_SEQ_LOGGING_SEED_VERSION,
+  CLASE7_8_SEQ_LOGGING_SLUG,
+} from '../clase7-8-seq-logging/data/assessment-definition';
+import {
+  CLASE7_8_SEQ_LOGGING_GAMIFICATION_RULES,
+  buildClase78SeqLoggingGamificationEvents,
+} from '../clase7-8-seq-logging/lib/gamification';
+import { ensureClase78SeqLoggingSeeded } from '../clase7-8-seq-logging/lib/seed';
+import {
+  CLASE9_CICD_GITHUB_ACTIONS_SEED_VERSION,
+  CLASE9_CICD_GITHUB_ACTIONS_SLUG,
+} from '../clase9-cicd-github-actions/data/assessment-definition';
+import {
+  CLASE9_CICD_GITHUB_ACTIONS_GAMIFICATION_RULES,
+  buildClase9CicdGithubActionsGamificationEvents,
+} from '../clase9-cicd-github-actions/lib/gamification';
+import { ensureClase9CicdGithubActionsSeeded } from '../clase9-cicd-github-actions/lib/seed';
 import type {
   AssessmentGamificationEvent,
   AssessmentGamificationRule,
 } from './lib/gamification';
 
 export type AssessmentExamType =
+  | 'clase3-data-persistencia'
+  | 'clase5-kubernetes'
+  | 'clase6-config-kubernetes'
+  | 'clase7-8-seq-logging'
+  | 'clase9-cicd-github-actions'
   | 'api-developer-fundamentals'
   | 'api-dotnet-fundamentals'
   | 'api-testing-fundamentals'
@@ -149,6 +199,51 @@ export interface AssessmentRegistryEntry {
 export const DEFAULT_ASSESSMENT_SLUG = API_TESTING_FUNDAMENTALS_SLUG;
 
 export const ASSESSMENT_REGISTRY: Record<string, AssessmentRegistryEntry> = {
+  [CLASE3_DATA_PERSISTENCIA_SLUG]: {
+    slug: CLASE3_DATA_PERSISTENCIA_SLUG,
+    seedVersion: CLASE3_DATA_PERSISTENCIA_SEED_VERSION,
+    ensureSeeded: ensureClase3DataPersistenciaSeeded,
+    examType: 'clase3-data-persistencia',
+    gamificationSource: 'CLASE3_DATA_PERSISTENCIA',
+    gamificationRules: CLASE3_DATA_PERSISTENCIA_GAMIFICATION_RULES,
+    buildGamificationEvents: buildClase3DataPersistenciaGamificationEvents,
+  },
+  [CLASE5_KUBERNETES_SLUG]: {
+    slug: CLASE5_KUBERNETES_SLUG,
+    seedVersion: CLASE5_KUBERNETES_SEED_VERSION,
+    ensureSeeded: ensureClase5KubernetesSeeded,
+    examType: 'clase5-kubernetes',
+    gamificationSource: 'CLASE5_KUBERNETES',
+    gamificationRules: CLASE5_KUBERNETES_GAMIFICATION_RULES,
+    buildGamificationEvents: buildClase5KubernetesGamificationEvents,
+  },
+  [CLASE6_CONFIG_KUBERNETES_SLUG]: {
+    slug: CLASE6_CONFIG_KUBERNETES_SLUG,
+    seedVersion: CLASE6_CONFIG_KUBERNETES_SEED_VERSION,
+    ensureSeeded: ensureClase6ConfigKubernetesSeeded,
+    examType: 'clase6-config-kubernetes',
+    gamificationSource: 'CLASE6_CONFIG_KUBERNETES',
+    gamificationRules: CLASE6_CONFIG_KUBERNETES_GAMIFICATION_RULES,
+    buildGamificationEvents: buildClase6ConfigKubernetesGamificationEvents,
+  },
+  [CLASE7_8_SEQ_LOGGING_SLUG]: {
+    slug: CLASE7_8_SEQ_LOGGING_SLUG,
+    seedVersion: CLASE7_8_SEQ_LOGGING_SEED_VERSION,
+    ensureSeeded: ensureClase78SeqLoggingSeeded,
+    examType: 'clase7-8-seq-logging',
+    gamificationSource: 'CLASE7_8_SEQ_LOGGING',
+    gamificationRules: CLASE7_8_SEQ_LOGGING_GAMIFICATION_RULES,
+    buildGamificationEvents: buildClase78SeqLoggingGamificationEvents,
+  },
+  [CLASE9_CICD_GITHUB_ACTIONS_SLUG]: {
+    slug: CLASE9_CICD_GITHUB_ACTIONS_SLUG,
+    seedVersion: CLASE9_CICD_GITHUB_ACTIONS_SEED_VERSION,
+    ensureSeeded: ensureClase9CicdGithubActionsSeeded,
+    examType: 'clase9-cicd-github-actions',
+    gamificationSource: 'CLASE9_CICD_GITHUB_ACTIONS',
+    gamificationRules: CLASE9_CICD_GITHUB_ACTIONS_GAMIFICATION_RULES,
+    buildGamificationEvents: buildClase9CicdGithubActionsGamificationEvents,
+  },
   [API_DEVELOPER_FUNDAMENTALS_SLUG]: {
     slug: API_DEVELOPER_FUNDAMENTALS_SLUG,
     seedVersion: API_DEVELOPER_FUNDAMENTALS_SEED_VERSION,

--- a/apps/frontend/src/app/assessments/_shared/testing/assessment-definition-checks.ts
+++ b/apps/frontend/src/app/assessments/_shared/testing/assessment-definition-checks.ts
@@ -35,6 +35,24 @@ export function assertAssessmentDefinitionConsistency(
         ).toBe(true);
       }
 
+      if (question.question_type === 'multiple_select') {
+        const correctValues = (
+          question.correct_answer as { values?: string[] } | undefined
+        )?.values;
+        expect(Array.isArray(correctValues)).toBe(true);
+        expect(correctValues!.length).toBeGreaterThanOrEqual(2);
+        expect(new Set(correctValues).size).toBe(correctValues!.length);
+        correctValues!.forEach((value) => {
+          expect(
+            question.options?.some((option) => option.value === value)
+          ).toBe(true);
+        });
+        // Si todas las opciones fueran correctas la pregunta no discrimina.
+        expect(correctValues!.length).toBeLessThan(
+          question.options?.length ?? 0
+        );
+      }
+
       if (question.question_type === 'true_false') {
         const correctValue = (
           question.correct_answer as { value?: unknown } | undefined

--- a/apps/frontend/src/app/assessments/_shared/types.ts
+++ b/apps/frontend/src/app/assessments/_shared/types.ts
@@ -13,6 +13,7 @@ export interface CandidateBand {
 
 export type AssessmentQuestionType =
   | 'multiple_choice'
+  | 'multiple_select'
   | 'true_false'
   | 'short_text'
   | 'doc_analysis'

--- a/apps/frontend/src/app/assessments/clase3-data-persistencia/__tests__/definition.test.ts
+++ b/apps/frontend/src/app/assessments/clase3-data-persistencia/__tests__/definition.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import { assertAssessmentDefinitionConsistency } from '../../_shared/testing/assessment-definition-checks';
+import {
+  CLASE3_DATA_PERSISTENCIA_SEED_VERSION,
+  CLASE3_DATA_PERSISTENCIA_SLUG,
+  clase3DataPersistenciaDefinition,
+} from '../data/assessment-definition';
+import { ASSESSMENT_REGISTRY } from '../../_shared/registry';
+
+const questions = clase3DataPersistenciaDefinition.sections.flatMap(
+  (section) => section.questions
+);
+
+describe('clase3-data-persistencia definition', () => {
+  it('mantiene presupuestos de puntos y answer keys consistentes', () => {
+    assertAssessmentDefinitionConsistency(clase3DataPersistenciaDefinition);
+  });
+
+  it('define 3 secciones sobre 100 puntos', () => {
+    expect(clase3DataPersistenciaDefinition.sections).toHaveLength(3);
+    expect(clase3DataPersistenciaDefinition.total_score).toBe(100);
+    expect(clase3DataPersistenciaDefinition.slug).toBe(
+      CLASE3_DATA_PERSISTENCIA_SLUG
+    );
+  });
+
+  it('reproduce el banco del bootcamp: 10 preguntas, 9 de respuesta única y 1 de varias', () => {
+    expect(questions).toHaveLength(10);
+    expect(
+      questions.filter((q) => q.question_type === 'multiple_choice')
+    ).toHaveLength(9);
+    expect(
+      questions.filter((q) => q.question_type === 'multiple_select')
+    ).toHaveLength(1);
+    questions.forEach((q) => {
+      expect(q.points).toBe(10);
+      expect(q.options).toHaveLength(4);
+      expect(q.explanation).toBeTruthy();
+      expect(q.metadata?.paginasPdf).toBeTruthy();
+    });
+  });
+
+  it('está registrado con el seedVersion correcto', () => {
+    const entry = ASSESSMENT_REGISTRY[CLASE3_DATA_PERSISTENCIA_SLUG];
+    expect(entry).toBeDefined();
+    expect(entry.seedVersion).toBe(CLASE3_DATA_PERSISTENCIA_SEED_VERSION);
+    expect(entry.examType).toBe(CLASE3_DATA_PERSISTENCIA_SLUG);
+  });
+});

--- a/apps/frontend/src/app/assessments/clase3-data-persistencia/data/assessment-definition.ts
+++ b/apps/frontend/src/app/assessments/clase3-data-persistencia/data/assessment-definition.ts
@@ -1,0 +1,419 @@
+import type { AssessmentSeedDefinition } from '../../_shared/types';
+
+export const CLASE3_DATA_PERSISTENCIA_SLUG = 'clase3-data-persistencia';
+
+// Bumpear cuando cambie la definición (secciones/preguntas) para forzar re-seed.
+export const CLASE3_DATA_PERSISTENCIA_SEED_VERSION = 1;
+
+// Preguntas, opciones, claves y justificaciones transcritas literalmente del
+// banco de preguntas del bootcamp (Clase 3 Data Persistencia.xlsx).
+// La trazabilidad al PDF de origen vive en metadata.paginasPdf de cada pregunta.
+export const clase3DataPersistenciaDefinition: AssessmentSeedDefinition = {
+  slug: CLASE3_DATA_PERSISTENCIA_SLUG,
+  title: 'Clase 3 — Data Persistencia',
+  description:
+    'Evaluación teórica de la Clase 3 del bootcamp: persistencia de datos, ADO.NET frente a Entity Framework Core, migraciones, PostgreSQL con Npgsql, despliegue en contenedor, DTOs y validación con FluentValidation.',
+  level: 'Trainee a Junior',
+  type: 'Desarrollo backend',
+  duration_minutes: 20,
+  total_score: 100,
+  is_active: true,
+  metadata: {
+    moduleName: 'AIQUAA Assessments / Clase 3 Data Persistencia',
+    passingScore: 70,
+    candidateBands: [
+      { min: 0, max: 39, label: 'Inicial' },
+      { min: 40, max: 59, label: 'En formación' },
+      { min: 60, max: 74, label: 'Trainee' },
+      { min: 75, max: 89, label: 'Junior' },
+      { min: 90, max: 100, label: 'Junior avanzado' },
+    ],
+  },
+  sections: [
+    {
+      slug: 'persistencia-y-acceso-a-datos',
+      title: 'Persistencia y acceso a datos',
+      description:
+        'Qué es la persistencia, el paradigma de ADO.NET frente a Entity Framework Core y la seguridad integrada del ORM.',
+      order_index: 1,
+      max_score: 40,
+      metadata: {
+        instructions:
+          'Selección múltiple sobre los fundamentos de la persistencia y las dos formas de acceder a los datos desde .NET.',
+        suggestedMinutes: 8,
+      },
+      questions: [
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            '¿Qué característica define la persistencia según el material?',
+          options: [
+            {
+              label:
+                'Los datos permanecen únicamente mientras la aplicación está en ejecución.',
+              value: 'a',
+            },
+            {
+              label:
+                'Los datos sobreviven al ciclo de vida de la aplicación y quedan disponibles entre ejecuciones.',
+              value: 'b',
+            },
+            {
+              label:
+                'Los datos se convierten automáticamente en copias de seguridad externas.',
+              value: 'c',
+            },
+            {
+              label:
+                'Los datos solo pueden almacenarse en la memoria volátil del proceso.',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'b' },
+          explanation:
+            'La diapositiva distingue el tiempo de ejecución volátil de la continuidad permanente y afirma que la persistencia conserva los datos entre ejecuciones.',
+          points: 10,
+          order_index: 1,
+          metadata: {
+            tema: 'Fundamento de la persistencia',
+            dificultad: 'Media',
+            conceptoEvaluado: 'Persistencia y continuidad de los datos',
+            paginasPdf: '2',
+          },
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            '¿Qué paradigma de acceso a datos atribuye el material a ADO.NET?',
+          options: [
+            {
+              label:
+                'Mapeo objeto-relacional basado exclusivamente en entidades de dominio.',
+              value: 'a',
+            },
+            {
+              label:
+                'Migraciones automáticas y consultas LINQ como mecanismo principal.',
+              value: 'b',
+            },
+            { label: 'SQL directo y manual.', value: 'c' },
+            { label: 'Persistencia sin gestión de conexiones.', value: 'd' },
+          ],
+          correct_answer: { value: 'c' },
+          explanation:
+            'La tabla comparativa describe el paradigma de ADO.NET como acceso mediante SQL directo y manual.',
+          points: 10,
+          order_index: 2,
+          metadata: {
+            tema: 'ADO.NET',
+            dificultad: 'Media',
+            conceptoEvaluado: 'Acceso directo con ADO.NET',
+            paginasPdf: '3',
+          },
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            '¿Cuál comparación reproduce correctamente las características asignadas a ADO.NET y Entity Framework Core?',
+          options: [
+            {
+              label:
+                'ADO.NET: SQL directo, gestión manual de conexiones y control total; EF Core: mapeo objeto-relacional, migraciones y LINQ.',
+              value: 'a',
+            },
+            {
+              label:
+                'ADO.NET: mapeo objeto-relacional y migraciones; EF Core: SQL directo y gestión manual de conexiones.',
+              value: 'b',
+            },
+            {
+              label:
+                'ADO.NET: abstracción mediante objetos y desarrollo multiplataforma; EF Core: alto volumen de código repetitivo y control manual.',
+              value: 'c',
+            },
+            {
+              label:
+                'ADO.NET y EF Core: ambos requieren el mismo volumen de código y la misma gestión manual de conexiones.',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'a' },
+          explanation:
+            'La tabla asigna a ADO.NET SQL directo, código repetitivo, gestión manual y control total; a EF Core le asigna mapeo objeto-relacional, abstracción mediante objetos, migraciones, LINQ y desarrollo ágil multiplataforma.',
+          points: 10,
+          order_index: 3,
+          metadata: {
+            tema: 'ADO.NET vs. Entity Framework Core',
+            dificultad: 'Extra',
+            conceptoEvaluado: 'Diferencias entre acceso directo y ORM',
+            paginasPdf: '3',
+            motivoDificultadExtra:
+              'Es Extra porque los distractores intercambian rasgos reales de ambas tecnologías; exige relacionar correctamente paradigma, mantenimiento y forma de acceso, no solo reconocer términos aislados.',
+          },
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            '¿Qué combinación presenta el material como parte de la seguridad integrada de Entity Framework Core?',
+          options: [
+            {
+              label:
+                'Exposición pública de la base y desactivación de transacciones.',
+              value: 'a',
+            },
+            {
+              label:
+                'Parametrización contra inyección SQL y soporte nativo para transacciones ACID.',
+              value: 'b',
+            },
+            {
+              label:
+                'Construcción manual obligatoria de cada consulta y conexión.',
+              value: 'c',
+            },
+            {
+              label:
+                'Sustitución de la validación de datos por el seguimiento de cambios.',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'b' },
+          explanation:
+            'La sección Seguridad Integrada menciona protección automática contra inyección SQL mediante parametrización y soporte nativo para transacciones ACID.',
+          points: 10,
+          order_index: 4,
+          metadata: {
+            tema: 'Seguridad en Entity Framework Core',
+            dificultad: 'Media',
+            conceptoEvaluado: 'Parametrización y transacciones ACID',
+            paginasPdf: '4',
+          },
+        },
+      ],
+    },
+    {
+      slug: 'ef-core-y-postgresql',
+      title: 'EF Core y PostgreSQL en producción',
+      description:
+        'Migraciones de Entity Framework Core, el proveedor Npgsql con connection pooling y el endurecimiento básico de PostgreSQL.',
+      order_index: 2,
+      max_score: 30,
+      metadata: {
+        instructions:
+          'Selección múltiple y selección de varias respuestas sobre migraciones, rendimiento y seguridad del motor.',
+        suggestedMinutes: 6,
+      },
+      questions: [
+        {
+          question_type: 'multiple_choice',
+          prompt: '¿Qué comando aparece asociado al pilar de Migraciones?',
+          options: [
+            { label: 'sudo apt-get install postgresql', value: 'a' },
+            { label: 'services.AddValidatorsFromAssembly()', value: 'b' },
+            { label: 'Install-Package FluentValidation', value: 'c' },
+            { label: 'dotnet ef database update', value: 'd' },
+          ],
+          correct_answer: { value: 'd' },
+          explanation:
+            'En el esquema de los cuatro pilares, el bloque Migraciones muestra el comando dotnet ef database update.',
+          points: 10,
+          order_index: 1,
+          metadata: {
+            tema: 'Migraciones en EF Core',
+            dificultad: 'Media',
+            conceptoEvaluado: 'Aplicación de migraciones',
+            paginasPdf: '5',
+          },
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            '¿Qué mecanismo utiliza Npgsql para maximizar el rendimiento en producción según el material?',
+          options: [
+            { label: 'Deshabilitar las conexiones simultáneas.', value: 'a' },
+            {
+              label: 'Crear una base de datos nueva por cada petición.',
+              value: 'b',
+            },
+            { label: 'Connection Pooling.', value: 'c' },
+            { label: 'Exponer el motor a todas las redes.', value: 'd' },
+          ],
+          correct_answer: { value: 'c' },
+          explanation:
+            'La diapositiva indica que Npgsql gestiona la comunicación eficientemente mediante Connection Pooling para maximizar el rendimiento en producción.',
+          points: 10,
+          order_index: 2,
+          metadata: {
+            tema: 'PostgreSQL y Npgsql',
+            dificultad: 'Media',
+            conceptoEvaluado: 'Proveedor Npgsql y pool de conexiones',
+            paginasPdf: '6',
+          },
+        },
+        {
+          question_type: 'multiple_select',
+          prompt:
+            '¿Cuáles de las siguientes prácticas forman parte de la seguridad fundamental de PostgreSQL indicada en el material?',
+          options: [
+            {
+              label: 'Usar obligatoriamente contraseñas robustas.',
+              value: 'a',
+            },
+            { label: 'Limitar la exposición de red.', value: 'b' },
+            {
+              label: 'Realizar actualizaciones regulares del motor.',
+              value: 'c',
+            },
+            {
+              label:
+                'Publicar el servicio sin restricciones para simplificar el acceso.',
+              value: 'd',
+            },
+          ],
+          correct_answer: { values: ['a', 'b', 'c'] },
+          explanation:
+            'El material enumera expresamente contraseñas robustas, exposición de red limitada y actualizaciones regulares del motor como medidas de seguridad fundamental.',
+          points: 10,
+          order_index: 3,
+          metadata: {
+            tema: 'Seguridad de PostgreSQL',
+            dificultad: 'Media',
+            conceptoEvaluado: 'Endurecimiento básico de PostgreSQL',
+            paginasPdf: '6',
+          },
+        },
+      ],
+    },
+    {
+      slug: 'despliegue-dtos-y-validacion',
+      title: 'Despliegue, DTOs y validación',
+      description:
+        'PostgreSQL en Docker con credenciales por variables, el viaje del dato a través de los DTOs y las reglas de FluentValidation.',
+      order_index: 3,
+      max_score: 30,
+      metadata: {
+        instructions:
+          'Selección múltiple sobre despliegue del motor, frontera de la aplicación y validación de entrada.',
+        suggestedMinutes: 6,
+      },
+      questions: [
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            'Se busca un entorno aislado para PostgreSQL y que las credenciales se proporcionen mediante variables. ¿Qué alternativa coincide con la presentada en el material?',
+          options: [
+            {
+              label:
+                'Instalar PostgreSQL directamente con apt-get, porque así se eliminan los posibles conflictos de versión del anfitrión.',
+              value: 'a',
+            },
+            {
+              label:
+                'Usar únicamente una cadena JDBC, porque una cadena de conexión crea por sí sola un entorno aislado.',
+              value: 'b',
+            },
+            {
+              label:
+                'Instalar FluentValidation, porque sus reglas administran las credenciales del motor.',
+              value: 'c',
+            },
+            {
+              label:
+                'Ejecutar PostgreSQL en Docker con POSTGRES_PASSWORD como variable de entorno.',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'd' },
+          explanation:
+            'La diapositiva muestra un contenedor Docker con POSTGRES_PASSWORD y señala como ventajas el entorno aislado y el uso de variables para proteger credenciales; la instalación local presenta riesgo de conflictos de versión.',
+          points: 10,
+          order_index: 1,
+          metadata: {
+            tema: 'Despliegue de PostgreSQL',
+            dificultad: 'Extra',
+            conceptoEvaluado: 'Instalación local frente a contenedor Docker',
+            paginasPdf: '7',
+            motivoDificultadExtra:
+              'Es Extra porque los distractores usan elementos reales del material (instalación local, cadena JDBC y validación) pero les atribuyen efectos que no cumplen el escenario; exige relacionar necesidad, riesgo y mecanismo de despliegue.',
+          },
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            '¿Qué función cumplen los DTOs en el viaje del dato presentado?',
+          options: [
+            {
+              label:
+                'Reemplazan a la base de datos y almacenan los registros permanentemente.',
+              value: 'a',
+            },
+            {
+              label:
+                'Exponen directamente las entidades internas para evitar transformaciones.',
+              value: 'b',
+            },
+            {
+              label:
+                'Evitan exponer entidades internas y permiten una transformación segura.',
+              value: 'c',
+            },
+            {
+              label:
+                'Sustituyen a las entidades de dominio y contienen toda la lógica de negocio.',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'c' },
+          explanation:
+            'El diagrama explica que los DTOs evitan exponer entidades internas y permiten una transformación segura en la frontera de la aplicación.',
+          points: 10,
+          order_index: 2,
+          metadata: {
+            tema: 'Viaje del dato en la API',
+            dificultad: 'Media',
+            conceptoEvaluado: 'Separación entre DTOs y entidades internas',
+            paginasPdf: '8',
+          },
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            '¿Cuál combinación corresponde a la estructura base y a una regla mostradas para FluentValidation?',
+          options: [
+            {
+              label:
+                'UserValidator hereda de DbContext y la regla usa database update.',
+              value: 'a',
+            },
+            {
+              label:
+                'UserValidator hereda de AbstractValidator<User> y el email se valida con NotEmpty() y EmailAddress().',
+              value: 'b',
+            },
+            {
+              label:
+                'UserValidator hereda de DbSet<User> y la regla configura Connection Pooling.',
+              value: 'c',
+            },
+            {
+              label:
+                'UserValidator hereda de Npgsql y la regla registra migraciones automáticas.',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'b' },
+          explanation:
+            'La diapositiva muestra public class UserValidator : AbstractValidator<User> y la regla RuleFor(x => x.Email).NotEmpty().EmailAddress().',
+          points: 10,
+          order_index: 3,
+          metadata: {
+            tema: 'FluentValidation',
+            dificultad: 'Media',
+            conceptoEvaluado: 'Validador y definición de reglas',
+            paginasPdf: '9',
+          },
+        },
+      ],
+    },
+  ],
+};

--- a/apps/frontend/src/app/assessments/clase3-data-persistencia/lib/gamification.ts
+++ b/apps/frontend/src/app/assessments/clase3-data-persistencia/lib/gamification.ts
@@ -1,0 +1,15 @@
+import { createAssessmentGamification } from '../../_shared/lib/gamification';
+
+const gamification = createAssessmentGamification({
+  prefix: 'CLASE3_DATA_PERSISTENCIA',
+  descriptions: {
+    completed: 'Completar el assessment Clase 3 Data Persistencia',
+    passed: 'Aprobar el assessment Clase 3 Data Persistencia (score >= 70)',
+    highScore: 'Score sobresaliente en Clase 3 Data Persistencia (>= 90)',
+  },
+});
+
+export const CLASE3_DATA_PERSISTENCIA_GAMIFICATION_RULES = gamification.rules;
+
+export const buildClase3DataPersistenciaGamificationEvents =
+  gamification.buildEvents;

--- a/apps/frontend/src/app/assessments/clase3-data-persistencia/lib/seed.ts
+++ b/apps/frontend/src/app/assessments/clase3-data-persistencia/lib/seed.ts
@@ -1,0 +1,12 @@
+import { ensureAssessmentSeeded } from '../../_shared/lib/seed';
+import {
+  CLASE3_DATA_PERSISTENCIA_SEED_VERSION,
+  clase3DataPersistenciaDefinition,
+} from '../data/assessment-definition';
+
+export async function ensureClase3DataPersistenciaSeeded() {
+  return ensureAssessmentSeeded(
+    clase3DataPersistenciaDefinition,
+    CLASE3_DATA_PERSISTENCIA_SEED_VERSION
+  );
+}

--- a/apps/frontend/src/app/assessments/clase3-data-persistencia/page.tsx
+++ b/apps/frontend/src/app/assessments/clase3-data-persistencia/page.tsx
@@ -1,0 +1,92 @@
+import { Metadata } from 'next';
+import { clase3DataPersistenciaDefinition } from './data/assessment-definition';
+import AssessmentWelcome from '../_shared/components/AssessmentWelcome';
+
+export const metadata: Metadata = {
+  title: 'Clase 3 — Data Persistencia | AIQUAA',
+  description:
+    'Prueba técnica teórica sobre persistencia de datos: ADO.NET vs Entity Framework Core, migraciones, PostgreSQL/Npgsql, DTOs y FluentValidation.',
+  keywords: [
+    'persistencia de datos',
+    'Entity Framework Core',
+    'ADO.NET',
+    'PostgreSQL',
+    'Npgsql',
+    'migraciones',
+    'DTOs',
+    'FluentValidation',
+    'bootcamp',
+    'AIQUAA',
+  ],
+  openGraph: {
+    title: 'Clase 3 — Data Persistencia | AIQUAA',
+    description:
+      'Prueba técnica teórica sobre persistencia de datos: ADO.NET vs Entity Framework Core, migraciones, PostgreSQL/Npgsql, DTOs y FluentValidation.',
+    url: 'https://aiquaa.com/assessments/clase3-data-persistencia',
+    siteName: 'AIQUAA',
+    type: 'website',
+    locale: 'es_PY',
+    images: [
+      {
+        url: '/api/og?title=Clase%203%20-%20Data%20Persistencia&subtitle=Persistencia%2C%20EF%20Core%20y%20PostgreSQL&section=Assessments',
+        width: 1200,
+        height: 630,
+        alt: 'Clase 3 — Data Persistencia - AIQUAA',
+      },
+    ],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Clase 3 — Data Persistencia | AIQUAA',
+    description:
+      'Prueba técnica teórica sobre persistencia de datos: ADO.NET vs Entity Framework Core, migraciones, PostgreSQL/Npgsql, DTOs y FluentValidation.',
+    images: [
+      '/api/og?title=Clase%203%20-%20Data%20Persistencia&subtitle=Persistencia%2C%20EF%20Core%20y%20PostgreSQL&section=Assessments',
+    ],
+    creator: '@stevenayal',
+  },
+  alternates: {
+    canonical: 'https://aiquaa.com/assessments/clase3-data-persistencia',
+  },
+};
+
+export default function Clase3DataPersistenciaPage() {
+  const overview = {
+    assessment: {
+      id: 'static-clase3-data-persistencia',
+      slug: clase3DataPersistenciaDefinition.slug,
+      title: clase3DataPersistenciaDefinition.title,
+      description: clase3DataPersistenciaDefinition.description,
+      level: clase3DataPersistenciaDefinition.level,
+      type: clase3DataPersistenciaDefinition.type,
+      duration_minutes: clase3DataPersistenciaDefinition.duration_minutes,
+      total_score: clase3DataPersistenciaDefinition.total_score,
+      is_active: clase3DataPersistenciaDefinition.is_active,
+      metadata: clase3DataPersistenciaDefinition.metadata,
+    },
+    sections: clase3DataPersistenciaDefinition.sections.map(
+      (section, index) => ({
+        id: `static-section-${index + 1}`,
+        assessment_id: 'static-clase3-data-persistencia',
+        slug: section.slug,
+        title: section.title,
+        description: section.description,
+        order_index: section.order_index,
+        max_score: section.max_score,
+        metadata: section.metadata,
+      })
+    ),
+  };
+
+  return (
+    <AssessmentWelcome
+      overview={overview}
+      startHref="/assessments/clase3-data-persistencia/start"
+      evaluatesCopy={
+        'Qué significa que un dato persista; el contraste entre el acceso directo de ADO.NET y el mapeo objeto-relacional de Entity Framework Core; seguridad integrada y migraciones de EF Core; PostgreSQL con Npgsql y connection pooling; despliegue en contenedor con credenciales por variables de entorno; el rol de los DTOs frente a las entidades de dominio; y la definición de reglas con FluentValidation.'
+      }
+      scoringCopy="Automático en las 3 secciones: 9 preguntas de respuesta única y 1 de varias respuestas, con crédito parcial."
+      resultCopy="Score total, score por sección, fortalezas, debilidades y temas a reforzar."
+    />
+  );
+}

--- a/apps/frontend/src/app/assessments/clase3-data-persistencia/result/page.tsx
+++ b/apps/frontend/src/app/assessments/clase3-data-persistencia/result/page.tsx
@@ -1,0 +1,21 @@
+import { Suspense } from 'react';
+import AssessmentResultClient from '../../_shared/components/AssessmentResultClient';
+
+export default function Clase3DataPersistenciaResultPage() {
+  return (
+    <Suspense
+      fallback={
+        <div className="min-h-screen flex items-center justify-center bg-slate-950">
+          <div className="h-10 w-10 animate-spin rounded-full border-t-2 border-cyan-400" />
+        </div>
+      }
+    >
+      <AssessmentResultClient
+        startHref="/assessments/clase3-data-persistencia/start"
+        fallbackRecommendation={
+          'Repasá el material de la Clase 3: diferencias entre ADO.NET y Entity Framework Core, migraciones, seguridad y pooling en PostgreSQL, separación entre DTOs y entidades de dominio, y reglas de FluentValidation.'
+        }
+      />
+    </Suspense>
+  );
+}

--- a/apps/frontend/src/app/assessments/clase3-data-persistencia/section/[sectionId]/page.tsx
+++ b/apps/frontend/src/app/assessments/clase3-data-persistencia/section/[sectionId]/page.tsx
@@ -1,0 +1,9 @@
+'use client';
+
+import AssessmentSectionScreen from '../../../_shared/components/AssessmentSectionScreen';
+
+export default function Clase3DataPersistenciaSectionPage() {
+  return (
+    <AssessmentSectionScreen basePath="/assessments/clase3-data-persistencia" />
+  );
+}

--- a/apps/frontend/src/app/assessments/clase3-data-persistencia/start/page.tsx
+++ b/apps/frontend/src/app/assessments/clase3-data-persistencia/start/page.tsx
@@ -1,0 +1,133 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { useTheme } from '@/contexts/ThemeContext';
+import { startAssessmentAttemptAction } from '@/actions/assessments';
+import ProcessCodeInput from '@/components/labs/ProcessCodeInput';
+import { CLASE3_DATA_PERSISTENCIA_SLUG } from '../data/assessment-definition';
+
+export default function StartClase3DataPersistenciaPage() {
+  const router = useRouter();
+  const { isDarkMode } = useTheme();
+  const [processCode, setProcessCode] = useState('');
+  const [error, setError] = useState('');
+  const [isStarting, setIsStarting] = useState(false);
+
+  // Pre-fill desde ?code= (links de invitaciones/procesos de empresa)
+  useEffect(() => {
+    const codeParam = new URLSearchParams(window.location.search).get('code');
+    if (codeParam) setProcessCode(codeParam);
+  }, []);
+
+  async function handleStart() {
+    setError('');
+    setIsStarting(true);
+
+    try {
+      const result = await startAssessmentAttemptAction({
+        slug: CLASE3_DATA_PERSISTENCIA_SLUG,
+        processCode,
+      });
+
+      if ('error' in result) {
+        setIsStarting(false);
+        setError(result.error);
+        return;
+      }
+
+      const { attempt, sectionSlug } = result;
+
+      if (!sectionSlug) {
+        setIsStarting(false);
+        setError('No se encontró la primera sección del assessment.');
+        return;
+      }
+
+      setIsStarting(false);
+      router.push(
+        `/assessments/clase3-data-persistencia/section/${sectionSlug}?attempt=${attempt.id}`
+      );
+    } catch (startError) {
+      setIsStarting(false);
+      setError(
+        startError instanceof Error
+          ? startError.message
+          : 'No se pudo iniciar el assessment.'
+      );
+    }
+  }
+
+  return (
+    <div
+      className={`min-h-screen px-4 py-12 ${
+        isDarkMode ? 'bg-slate-950 text-white' : 'bg-slate-50 text-slate-900'
+      }`}
+    >
+      <div className="mx-auto max-w-3xl rounded-3xl border border-slate-800 bg-slate-900/80 p-8 text-slate-50 shadow-2xl shadow-cyan-950/20">
+        <p className="text-sm font-semibold uppercase tracking-[0.18em] text-cyan-200">
+          Preparación del intento
+        </p>
+        <h1 className="mt-3 text-3xl font-bold">Clase 3 — Data Persistencia</h1>
+        <p className="mt-3 text-slate-300">
+          Vas a completar 3 secciones teóricas (10 preguntas en total) con
+          autosave, scoring por sección y resultado final consolidado.
+        </p>
+
+        <div className="mt-8 grid gap-4 rounded-2xl border border-slate-800 bg-slate-950/70 p-5 md:grid-cols-3">
+          <div>
+            <p className="text-xs uppercase tracking-[0.18em] text-slate-400">
+              Duración sugerida
+            </p>
+            <p className="mt-2 text-lg font-semibold">~20 minutos</p>
+          </div>
+          <div>
+            <p className="text-xs uppercase tracking-[0.18em] text-slate-400">
+              Modalidad
+            </p>
+            <p className="mt-2 text-lg font-semibold">Conceptual</p>
+          </div>
+          <div>
+            <p className="text-xs uppercase tracking-[0.18em] text-slate-400">
+              Resultado
+            </p>
+            <p className="mt-2 text-lg font-semibold">Score total sobre 100</p>
+          </div>
+        </div>
+
+        <div className="mt-8">
+          <ProcessCodeInput
+            value={processCode}
+            onChange={setProcessCode}
+            onNormalizedCode={setProcessCode}
+            autoValidate
+          />
+        </div>
+
+        {error ? (
+          <div className="mt-6 rounded-2xl border border-red-500/30 bg-red-500/10 px-4 py-3 text-sm text-red-200">
+            {error}
+          </div>
+        ) : null}
+
+        <div className="mt-8 flex flex-col gap-3 sm:flex-row">
+          <button
+            type="button"
+            onClick={handleStart}
+            disabled={isStarting}
+            className="inline-flex items-center justify-center rounded-2xl bg-cyan-400 px-5 py-3 text-sm font-semibold text-slate-950 transition hover:bg-cyan-300 disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {isStarting ? 'Preparando intento...' : 'Iniciar o reanudar'}
+          </button>
+          <button
+            type="button"
+            onClick={() => router.push('/assessments/clase3-data-persistencia')}
+            className="inline-flex items-center justify-center rounded-2xl border border-slate-700 px-5 py-3 text-sm font-semibold text-slate-200 transition hover:bg-slate-800"
+          >
+            Volver al overview
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/src/app/assessments/clase5-kubernetes/__tests__/definition.test.ts
+++ b/apps/frontend/src/app/assessments/clase5-kubernetes/__tests__/definition.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import { assertAssessmentDefinitionConsistency } from '../../_shared/testing/assessment-definition-checks';
+import {
+  CLASE5_KUBERNETES_SEED_VERSION,
+  CLASE5_KUBERNETES_SLUG,
+  clase5KubernetesDefinition,
+} from '../data/assessment-definition';
+import { ASSESSMENT_REGISTRY } from '../../_shared/registry';
+
+const questions = clase5KubernetesDefinition.sections.flatMap(
+  (section) => section.questions
+);
+
+describe('clase5-kubernetes definition', () => {
+  it('mantiene presupuestos de puntos y answer keys consistentes', () => {
+    assertAssessmentDefinitionConsistency(clase5KubernetesDefinition);
+  });
+
+  it('define 3 secciones sobre 100 puntos', () => {
+    expect(clase5KubernetesDefinition.sections).toHaveLength(3);
+    expect(clase5KubernetesDefinition.total_score).toBe(100);
+    expect(clase5KubernetesDefinition.slug).toBe(CLASE5_KUBERNETES_SLUG);
+  });
+
+  it('reproduce el banco del bootcamp: 10 preguntas, 9 de respuesta única y 1 de varias', () => {
+    expect(questions).toHaveLength(10);
+    expect(
+      questions.filter((q) => q.question_type === 'multiple_choice')
+    ).toHaveLength(9);
+    expect(
+      questions.filter((q) => q.question_type === 'multiple_select')
+    ).toHaveLength(1);
+    questions.forEach((q) => {
+      expect(q.points).toBe(10);
+      expect(q.options).toHaveLength(4);
+      expect(q.explanation).toBeTruthy();
+      expect(q.metadata?.paginasPdf).toBeTruthy();
+    });
+  });
+
+  it('está registrado con el seedVersion correcto', () => {
+    const entry = ASSESSMENT_REGISTRY[CLASE5_KUBERNETES_SLUG];
+    expect(entry).toBeDefined();
+    expect(entry.seedVersion).toBe(CLASE5_KUBERNETES_SEED_VERSION);
+    expect(entry.examType).toBe(CLASE5_KUBERNETES_SLUG);
+  });
+});

--- a/apps/frontend/src/app/assessments/clase5-kubernetes/data/assessment-definition.ts
+++ b/apps/frontend/src/app/assessments/clase5-kubernetes/data/assessment-definition.ts
@@ -1,0 +1,441 @@
+import type { AssessmentSeedDefinition } from '../../_shared/types';
+
+export const CLASE5_KUBERNETES_SLUG = 'clase5-kubernetes';
+
+// Bumpear cuando cambie la definición (secciones/preguntas) para forzar re-seed.
+export const CLASE5_KUBERNETES_SEED_VERSION = 1;
+
+// Preguntas, opciones, claves y justificaciones transcritas literalmente del
+// banco de preguntas del bootcamp (Clase 5 Kubernetes.xlsx).
+// La trazabilidad al PDF de origen vive en metadata.paginasPdf de cada pregunta.
+export const clase5KubernetesDefinition: AssessmentSeedDefinition = {
+  slug: CLASE5_KUBERNETES_SLUG,
+  title: 'Clase 5 — Kubernetes',
+  description:
+    'Evaluación teórica de la Clase 5 del bootcamp: propósito de Kubernetes, pilares de la orquestación, arquitectura del clúster, Pods, paradigma declarativo, Deployment y ReplicaSet, StatefulSet, Services y el ecosistema completo.',
+  level: 'Trainee a Junior',
+  type: 'Infraestructura',
+  duration_minutes: 20,
+  total_score: 100,
+  is_active: true,
+  metadata: {
+    moduleName: 'AIQUAA Assessments / Clase 5 Kubernetes',
+    passingScore: 70,
+    candidateBands: [
+      { min: 0, max: 39, label: 'Inicial' },
+      { min: 40, max: 59, label: 'En formación' },
+      { min: 60, max: 74, label: 'Trainee' },
+      { min: 75, max: 89, label: 'Junior' },
+      { min: 90, max: 100, label: 'Junior avanzado' },
+    ],
+  },
+  sections: [
+    {
+      slug: 'orquestacion-y-arquitectura',
+      title: 'Orquestación y arquitectura del clúster',
+      description:
+        'Qué resuelve Kubernetes, sus tres pilares, el reparto Scheduler/Kubelet y la diferencia entre entorno local y productivo.',
+      order_index: 1,
+      max_score: 40,
+      metadata: {
+        instructions:
+          'Selección múltiple y selección de varias respuestas sobre el propósito y la arquitectura base de Kubernetes.',
+        suggestedMinutes: 8,
+      },
+      questions: [
+        {
+          question_type: 'multiple_choice',
+          prompt: '¿Cómo define el material a Kubernetes?',
+          options: [
+            {
+              label:
+                'Como una plataforma de código abierto para automatizar el despliegue, escalado y gestión de aplicaciones en contenedores.',
+              value: 'a',
+            },
+            {
+              label:
+                'Como una herramienta destinada exclusivamente a crear imágenes de contenedores.',
+              value: 'b',
+            },
+            {
+              label:
+                'Como un sistema operativo completo para reemplazar servidores físicos.',
+              value: 'c',
+            },
+            {
+              label: 'Como un lenguaje para programar APIs y microservicios.',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'a' },
+          explanation:
+            'La diapositiva define Kubernetes como una plataforma de código abierto que automatiza el despliegue, el escalado y la gestión de aplicaciones en contenedores.',
+          points: 10,
+          order_index: 1,
+          metadata: {
+            tema: 'Propósito de Kubernetes',
+            dificultad: 'Media',
+            conceptoEvaluado: 'Definición y propósito de Kubernetes',
+            paginasPdf: '2',
+          },
+        },
+        {
+          question_type: 'multiple_select',
+          prompt:
+            '¿Cuáles de las siguientes capacidades forman parte de los tres pilares de la orquestación presentados?',
+          options: [
+            {
+              label:
+                'Alta disponibilidad mediante replicación y balanceo constante.',
+              value: 'a',
+            },
+            {
+              label:
+                'Escalado dinámico que agrega o reduce réplicas de Pods según la demanda.',
+              value: 'b',
+            },
+            {
+              label:
+                'Autorecuperación que detecta Pods fallidos y reinicia contenedores.',
+              value: 'c',
+            },
+            {
+              label: 'Recuperación exclusivamente manual ante cualquier fallo.',
+              value: 'd',
+            },
+          ],
+          correct_answer: { values: ['a', 'b', 'c'] },
+          explanation:
+            'El material identifica como pilares la alta disponibilidad, el escalado dinámico y la autorecuperación; la intervención exclusivamente manual contradice esas capacidades.',
+          points: 10,
+          order_index: 2,
+          metadata: {
+            tema: 'Pilares de la orquestación',
+            dificultad: 'Media',
+            conceptoEvaluado:
+              'Alta disponibilidad, escalado y autorecuperación',
+            paginasPdf: '3',
+          },
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            '¿Cuál asignación de responsabilidades coincide con la arquitectura base mostrada?',
+          options: [
+            {
+              label:
+                'El Kubelet decide el nodo de ejecución y el Scheduler mantiene los contenedores en funcionamiento.',
+              value: 'a',
+            },
+            {
+              label:
+                'El Scheduler decide en qué nodo se ejecuta la aplicación y el Kubelet asegura que los contenedores sigan corriendo.',
+              value: 'b',
+            },
+            {
+              label:
+                'El Scheduler almacena volúmenes y el Kubelet expone servicios externos.',
+              value: 'c',
+            },
+            {
+              label:
+                'El Scheduler y el Kubelet son dos tipos de Pod con la misma función.',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'b' },
+          explanation:
+            'El Scheduler evalúa y decide el nodo exacto de ejecución; el Kubelet es el agente del nodo que se comunica con el plano de control y asegura que los contenedores continúen corriendo.',
+          points: 10,
+          order_index: 3,
+          metadata: {
+            tema: 'Scheduler y Kubelet',
+            dificultad: 'Media',
+            conceptoEvaluado: 'Plano de control y agente de nodo',
+            paginasPdf: '4',
+          },
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            '¿Cuál comparación reproduce correctamente el uso de Minikube/Kind y el entorno de producción?',
+          options: [
+            {
+              label:
+                'Minikube/Kind: entorno local de un solo nodo para aprendizaje y pruebas; producción: múltiples nodos distribuidos para alta disponibilidad y escalado masivo.',
+              value: 'a',
+            },
+            {
+              label:
+                'Minikube/Kind: múltiples nodos físicos para alta disponibilidad; producción: una máquina virtual local para pruebas.',
+              value: 'b',
+            },
+            {
+              label:
+                'Minikube/Kind y producción: ambos se limitan a un único nodo y persiguen exclusivamente fines educativos.',
+              value: 'c',
+            },
+            {
+              label:
+                'Minikube/Kind: entorno cloud obligatorio; producción: laptop local sin nodos distribuidos.',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'a' },
+          explanation:
+            'La diapositiva presenta Minikube/Kind como un entorno local de un solo nodo para aprendizaje, desarrollo y pruebas, mientras producción utiliza múltiples nodos físicos o cloud para alta disponibilidad y escalado masivo.',
+          points: 10,
+          order_index: 4,
+          metadata: {
+            tema: 'Entorno local vs. producción',
+            dificultad: 'Extra',
+            conceptoEvaluado: 'Simulación local y entorno productivo',
+            paginasPdf: '5',
+            motivoDificultadExtra:
+              'Es Extra porque los distractores intercambian entorno, cantidad de nodos y propósito. Exige relacionar correctamente las tres dimensiones, no solo reconocer los nombres Minikube y producción.',
+          },
+        },
+      ],
+    },
+    {
+      slug: 'pods-y-controladores',
+      title: 'Pods, manifiestos y controladores',
+      description:
+        'El ciclo de vida del Pod, el paradigma declarativo del manifiesto y el bucle de reconciliación de Deployment y ReplicaSet.',
+      order_index: 2,
+      max_score: 30,
+      metadata: {
+        instructions:
+          'Selección múltiple sobre Pods, estado deseado y controladores.',
+        suggestedMinutes: 6,
+      },
+      questions: [
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            '¿Por qué el material indica que un Pod suelto no debe utilizarse solo en producción?',
+          options: [
+            {
+              label: 'Porque un Pod no puede contener más de un contenedor.',
+              value: 'a',
+            },
+            {
+              label:
+                'Porque los contenedores de un mismo Pod no pueden comunicarse.',
+              value: 'b',
+            },
+            {
+              label:
+                'Porque un Pod suelto no se recrea automáticamente si falla.',
+              value: 'c',
+            },
+            {
+              label:
+                'Porque Kubernetes administra contenedores directamente y no reconoce Pods.',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'c' },
+          explanation:
+            'El material señala como limitación crítica que los Pods sueltos no se recrean automáticamente cuando fallan y, por ello, no deben usarse solos en producción.',
+          points: 10,
+          order_index: 1,
+          metadata: {
+            tema: 'Pods',
+            dificultad: 'Media',
+            conceptoEvaluado: 'Ciclo de vida y debilidad del Pod',
+            paginasPdf: '6',
+          },
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt: '¿Qué describe el paradigma declarativo presentado?',
+          options: [
+            {
+              label:
+                'El manifiesto explica paso a paso cómo ejecutar cada operación manual.',
+              value: 'a',
+            },
+            {
+              label:
+                'El manifiesto describe el estado deseado y Kubernetes ajusta la realidad para que coincida con esa intención.',
+              value: 'b',
+            },
+            {
+              label:
+                'El manifiesto solo documenta el estado actual sin provocar cambios.',
+              value: 'c',
+            },
+            {
+              label:
+                'Kubernetes ignora el manifiesto y conserva siempre el estado existente.',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'b' },
+          explanation:
+            'El manifiesto YAML describe el qué, no el cómo; el orquestador compara el estado actual con la intención declarada y realiza los cambios necesarios.',
+          points: 10,
+          order_index: 2,
+          metadata: {
+            tema: 'Paradigma declarativo',
+            dificultad: 'Media',
+            conceptoEvaluado: 'Intención declarada y reconciliación',
+            paginasPdf: '7',
+          },
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            '¿Cuál relación entre Deployment y ReplicaSet coincide con el bucle de autorecuperación y escalado?',
+          options: [
+            {
+              label:
+                'ReplicaSet gestiona versiones y rollbacks; Deployment solo documenta el número de réplicas.',
+              value: 'a',
+            },
+            {
+              label:
+                'Deployment y ReplicaSet son Services usados para exponer Pods.',
+              value: 'b',
+            },
+            {
+              label:
+                'Deployment se limita a crear un único Pod y ReplicaSet administra nodos físicos.',
+              value: 'c',
+            },
+            {
+              label:
+                'Deployment define el estado deseado, versiones, rollbacks y rolling updates; ReplicaSet asegura el número exacto de réplicas de Pods.',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'd' },
+          explanation:
+            'La diapositiva asigna al Deployment la gestión del estado deseado, versiones, rollbacks y rolling updates; el ReplicaSet es su motor interno y mantiene el número exacto de réplicas.',
+          points: 10,
+          order_index: 3,
+          metadata: {
+            tema: 'Deployment y ReplicaSet',
+            dificultad: 'Extra',
+            conceptoEvaluado: 'Responsabilidades de Deployment y ReplicaSet',
+            paginasPdf: '8',
+            motivoDificultadExtra:
+              'Es Extra porque los distractores trasladan funciones reales entre Deployment, ReplicaSet, Service y nodo. La respuesta requiere distinguir coordinación de versiones frente a mantenimiento de réplicas.',
+          },
+        },
+      ],
+    },
+    {
+      slug: 'estado-services-y-ecosistema',
+      title: 'Cargas con estado, Services y ecosistema',
+      description:
+        'StatefulSet para identidad predecible, el Service como abstracción estable de red y la síntesis del ecosistema.',
+      order_index: 3,
+      max_score: 30,
+      metadata: {
+        instructions:
+          'Selección múltiple sobre persistencia, exposición de red e integración de componentes.',
+        suggestedMinutes: 6,
+      },
+      questions: [
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            '¿Qué controlador recomienda la matriz para bases de datos que necesitan identidad predecible y volúmenes estables?',
+          options: [
+            { label: 'Deployment', value: 'a' },
+            { label: 'StatefulSet', value: 'b' },
+            { label: 'DaemonSet', value: 'c' },
+            { label: 'NodePort', value: 'd' },
+          ],
+          correct_answer: { value: 'b' },
+          explanation:
+            'La matriz asocia StatefulSet con identidad única y predecible, volúmenes estables entre reinicios y casos como PostgreSQL, MongoDB y Kafka.',
+          points: 10,
+          order_index: 1,
+          metadata: {
+            tema: 'StatefulSet',
+            dificultad: 'Media',
+            conceptoEvaluado: 'Cargas con estado e identidad estable',
+            paginasPdf: '9',
+          },
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            '¿Qué problema resuelve un Service frente a la naturaleza efímera de los Pods?',
+          options: [
+            {
+              label: 'Convierte cada Pod en un nodo físico independiente.',
+              value: 'a',
+            },
+            {
+              label:
+                'Proporciona una IP estable y balanceo interno aunque cambien las IPs de los Pods.',
+              value: 'b',
+            },
+            {
+              label:
+                'Reemplaza todos los controladores y mantiene volúmenes persistentes.',
+              value: 'c',
+            },
+            {
+              label: 'Evita que los Pods puedan escalar o reiniciarse.',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'b' },
+          explanation:
+            'La diapositiva explica que las IPs de los Pods cambian por ser efímeros, mientras el Service aporta una IP estable y balanceo interno.',
+          points: 10,
+          order_index: 2,
+          metadata: {
+            tema: 'Services y exposición',
+            dificultad: 'Media',
+            conceptoEvaluado: 'Abstracción estable de red',
+            paginasPdf: '10',
+          },
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            '¿Cuál conjunto de asociaciones coincide con la síntesis del ecosistema?',
+          options: [
+            {
+              label:
+                'NodePort para tráfico externo; Service para enrutamiento estable; Deployment para escalabilidad sin estado; StatefulSet para persistencia e identidad; DaemonSet para monitoreo global.',
+              value: 'a',
+            },
+            {
+              label:
+                'StatefulSet para tráfico externo; NodePort para persistencia; DaemonSet para escalado sin estado.',
+              value: 'b',
+            },
+            {
+              label:
+                'Deployment para identidad estable; Service para un Pod por nodo; DaemonSet para bases de datos.',
+              value: 'c',
+            },
+            {
+              label:
+                'Todos los componentes cumplen la misma función y pueden intercambiarse sin efectos.',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'a' },
+          explanation:
+            'La síntesis rotula NodePort como entrada de tráfico externo, Service como enrutamiento estable, Deployment como escalabilidad sin estado, StatefulSet como persistencia e identidad y DaemonSet como monitoreo global.',
+          points: 10,
+          order_index: 3,
+          metadata: {
+            tema: 'Ecosistema Kubernetes',
+            dificultad: 'Media',
+            conceptoEvaluado: 'Integración de los componentes del ecosistema',
+            paginasPdf: '11',
+          },
+        },
+      ],
+    },
+  ],
+};

--- a/apps/frontend/src/app/assessments/clase5-kubernetes/lib/gamification.ts
+++ b/apps/frontend/src/app/assessments/clase5-kubernetes/lib/gamification.ts
@@ -1,0 +1,14 @@
+import { createAssessmentGamification } from '../../_shared/lib/gamification';
+
+const gamification = createAssessmentGamification({
+  prefix: 'CLASE5_KUBERNETES',
+  descriptions: {
+    completed: 'Completar el assessment Clase 5 Kubernetes',
+    passed: 'Aprobar el assessment Clase 5 Kubernetes (score >= 70)',
+    highScore: 'Score sobresaliente en Clase 5 Kubernetes (>= 90)',
+  },
+});
+
+export const CLASE5_KUBERNETES_GAMIFICATION_RULES = gamification.rules;
+
+export const buildClase5KubernetesGamificationEvents = gamification.buildEvents;

--- a/apps/frontend/src/app/assessments/clase5-kubernetes/lib/seed.ts
+++ b/apps/frontend/src/app/assessments/clase5-kubernetes/lib/seed.ts
@@ -1,0 +1,12 @@
+import { ensureAssessmentSeeded } from '../../_shared/lib/seed';
+import {
+  CLASE5_KUBERNETES_SEED_VERSION,
+  clase5KubernetesDefinition,
+} from '../data/assessment-definition';
+
+export async function ensureClase5KubernetesSeeded() {
+  return ensureAssessmentSeeded(
+    clase5KubernetesDefinition,
+    CLASE5_KUBERNETES_SEED_VERSION
+  );
+}

--- a/apps/frontend/src/app/assessments/clase5-kubernetes/page.tsx
+++ b/apps/frontend/src/app/assessments/clase5-kubernetes/page.tsx
@@ -1,0 +1,90 @@
+import { Metadata } from 'next';
+import { clase5KubernetesDefinition } from './data/assessment-definition';
+import AssessmentWelcome from '../_shared/components/AssessmentWelcome';
+
+export const metadata: Metadata = {
+  title: 'Clase 5 — Kubernetes | AIQUAA',
+  description:
+    'Prueba técnica teórica sobre Kubernetes: orquestación, arquitectura del clúster, Pods, Deployment/ReplicaSet, StatefulSet y Services.',
+  keywords: [
+    'Kubernetes',
+    'orquestación de contenedores',
+    'Pods',
+    'Deployment',
+    'ReplicaSet',
+    'StatefulSet',
+    'Service',
+    'Minikube',
+    'bootcamp',
+    'AIQUAA',
+  ],
+  openGraph: {
+    title: 'Clase 5 — Kubernetes | AIQUAA',
+    description:
+      'Prueba técnica teórica sobre Kubernetes: orquestación, arquitectura del clúster, Pods, Deployment/ReplicaSet, StatefulSet y Services.',
+    url: 'https://aiquaa.com/assessments/clase5-kubernetes',
+    siteName: 'AIQUAA',
+    type: 'website',
+    locale: 'es_PY',
+    images: [
+      {
+        url: '/api/og?title=Clase%205%20-%20Kubernetes&subtitle=Orquestaci%C3%B3n%2C%20Pods%20y%20controladores&section=Assessments',
+        width: 1200,
+        height: 630,
+        alt: 'Clase 5 — Kubernetes - AIQUAA',
+      },
+    ],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Clase 5 — Kubernetes | AIQUAA',
+    description:
+      'Prueba técnica teórica sobre Kubernetes: orquestación, arquitectura del clúster, Pods, Deployment/ReplicaSet, StatefulSet y Services.',
+    images: [
+      '/api/og?title=Clase%205%20-%20Kubernetes&subtitle=Orquestaci%C3%B3n%2C%20Pods%20y%20controladores&section=Assessments',
+    ],
+    creator: '@stevenayal',
+  },
+  alternates: {
+    canonical: 'https://aiquaa.com/assessments/clase5-kubernetes',
+  },
+};
+
+export default function Clase5KubernetesPage() {
+  const overview = {
+    assessment: {
+      id: 'static-clase5-kubernetes',
+      slug: clase5KubernetesDefinition.slug,
+      title: clase5KubernetesDefinition.title,
+      description: clase5KubernetesDefinition.description,
+      level: clase5KubernetesDefinition.level,
+      type: clase5KubernetesDefinition.type,
+      duration_minutes: clase5KubernetesDefinition.duration_minutes,
+      total_score: clase5KubernetesDefinition.total_score,
+      is_active: clase5KubernetesDefinition.is_active,
+      metadata: clase5KubernetesDefinition.metadata,
+    },
+    sections: clase5KubernetesDefinition.sections.map((section, index) => ({
+      id: `static-section-${index + 1}`,
+      assessment_id: 'static-clase5-kubernetes',
+      slug: section.slug,
+      title: section.title,
+      description: section.description,
+      order_index: section.order_index,
+      max_score: section.max_score,
+      metadata: section.metadata,
+    })),
+  };
+
+  return (
+    <AssessmentWelcome
+      overview={overview}
+      startHref="/assessments/clase5-kubernetes/start"
+      evaluatesCopy={
+        'La definición y el propósito de Kubernetes; los tres pilares de la orquestación (alta disponibilidad, escalado dinámico y autorecuperación); el reparto de responsabilidades entre Scheduler y Kubelet; entorno local con Minikube/Kind frente a producción; el ciclo de vida del Pod y su debilidad fuera de un controlador; el paradigma declarativo; Deployment frente a ReplicaSet; StatefulSet para cargas con estado; y el rol del Service frente a Pods efímeros.'
+      }
+      scoringCopy="Automático en las 3 secciones: 9 preguntas de respuesta única y 1 de varias respuestas, con crédito parcial."
+      resultCopy="Score total, score por sección, fortalezas, debilidades y temas a reforzar."
+    />
+  );
+}

--- a/apps/frontend/src/app/assessments/clase5-kubernetes/result/page.tsx
+++ b/apps/frontend/src/app/assessments/clase5-kubernetes/result/page.tsx
@@ -1,0 +1,21 @@
+import { Suspense } from 'react';
+import AssessmentResultClient from '../../_shared/components/AssessmentResultClient';
+
+export default function Clase5KubernetesResultPage() {
+  return (
+    <Suspense
+      fallback={
+        <div className="min-h-screen flex items-center justify-center bg-slate-950">
+          <div className="h-10 w-10 animate-spin rounded-full border-t-2 border-cyan-400" />
+        </div>
+      }
+    >
+      <AssessmentResultClient
+        startHref="/assessments/clase5-kubernetes/start"
+        fallbackRecommendation={
+          'Repasá el material de la Clase 5: pilares de la orquestación, plano de control y agente de nodo, por qué un Pod suelto no va a producción, la relación Deployment/ReplicaSet y para qué sirve cada componente del ecosistema.'
+        }
+      />
+    </Suspense>
+  );
+}

--- a/apps/frontend/src/app/assessments/clase5-kubernetes/section/[sectionId]/page.tsx
+++ b/apps/frontend/src/app/assessments/clase5-kubernetes/section/[sectionId]/page.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import AssessmentSectionScreen from '../../../_shared/components/AssessmentSectionScreen';
+
+export default function Clase5KubernetesSectionPage() {
+  return <AssessmentSectionScreen basePath="/assessments/clase5-kubernetes" />;
+}

--- a/apps/frontend/src/app/assessments/clase5-kubernetes/start/page.tsx
+++ b/apps/frontend/src/app/assessments/clase5-kubernetes/start/page.tsx
@@ -1,0 +1,133 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { useTheme } from '@/contexts/ThemeContext';
+import { startAssessmentAttemptAction } from '@/actions/assessments';
+import ProcessCodeInput from '@/components/labs/ProcessCodeInput';
+import { CLASE5_KUBERNETES_SLUG } from '../data/assessment-definition';
+
+export default function StartClase5KubernetesPage() {
+  const router = useRouter();
+  const { isDarkMode } = useTheme();
+  const [processCode, setProcessCode] = useState('');
+  const [error, setError] = useState('');
+  const [isStarting, setIsStarting] = useState(false);
+
+  // Pre-fill desde ?code= (links de invitaciones/procesos de empresa)
+  useEffect(() => {
+    const codeParam = new URLSearchParams(window.location.search).get('code');
+    if (codeParam) setProcessCode(codeParam);
+  }, []);
+
+  async function handleStart() {
+    setError('');
+    setIsStarting(true);
+
+    try {
+      const result = await startAssessmentAttemptAction({
+        slug: CLASE5_KUBERNETES_SLUG,
+        processCode,
+      });
+
+      if ('error' in result) {
+        setIsStarting(false);
+        setError(result.error);
+        return;
+      }
+
+      const { attempt, sectionSlug } = result;
+
+      if (!sectionSlug) {
+        setIsStarting(false);
+        setError('No se encontró la primera sección del assessment.');
+        return;
+      }
+
+      setIsStarting(false);
+      router.push(
+        `/assessments/clase5-kubernetes/section/${sectionSlug}?attempt=${attempt.id}`
+      );
+    } catch (startError) {
+      setIsStarting(false);
+      setError(
+        startError instanceof Error
+          ? startError.message
+          : 'No se pudo iniciar el assessment.'
+      );
+    }
+  }
+
+  return (
+    <div
+      className={`min-h-screen px-4 py-12 ${
+        isDarkMode ? 'bg-slate-950 text-white' : 'bg-slate-50 text-slate-900'
+      }`}
+    >
+      <div className="mx-auto max-w-3xl rounded-3xl border border-slate-800 bg-slate-900/80 p-8 text-slate-50 shadow-2xl shadow-cyan-950/20">
+        <p className="text-sm font-semibold uppercase tracking-[0.18em] text-cyan-200">
+          Preparación del intento
+        </p>
+        <h1 className="mt-3 text-3xl font-bold">Clase 5 — Kubernetes</h1>
+        <p className="mt-3 text-slate-300">
+          Vas a completar 3 secciones teóricas (10 preguntas en total) con
+          autosave, scoring por sección y resultado final consolidado.
+        </p>
+
+        <div className="mt-8 grid gap-4 rounded-2xl border border-slate-800 bg-slate-950/70 p-5 md:grid-cols-3">
+          <div>
+            <p className="text-xs uppercase tracking-[0.18em] text-slate-400">
+              Duración sugerida
+            </p>
+            <p className="mt-2 text-lg font-semibold">~20 minutos</p>
+          </div>
+          <div>
+            <p className="text-xs uppercase tracking-[0.18em] text-slate-400">
+              Modalidad
+            </p>
+            <p className="mt-2 text-lg font-semibold">Conceptual</p>
+          </div>
+          <div>
+            <p className="text-xs uppercase tracking-[0.18em] text-slate-400">
+              Resultado
+            </p>
+            <p className="mt-2 text-lg font-semibold">Score total sobre 100</p>
+          </div>
+        </div>
+
+        <div className="mt-8">
+          <ProcessCodeInput
+            value={processCode}
+            onChange={setProcessCode}
+            onNormalizedCode={setProcessCode}
+            autoValidate
+          />
+        </div>
+
+        {error ? (
+          <div className="mt-6 rounded-2xl border border-red-500/30 bg-red-500/10 px-4 py-3 text-sm text-red-200">
+            {error}
+          </div>
+        ) : null}
+
+        <div className="mt-8 flex flex-col gap-3 sm:flex-row">
+          <button
+            type="button"
+            onClick={handleStart}
+            disabled={isStarting}
+            className="inline-flex items-center justify-center rounded-2xl bg-cyan-400 px-5 py-3 text-sm font-semibold text-slate-950 transition hover:bg-cyan-300 disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {isStarting ? 'Preparando intento...' : 'Iniciar o reanudar'}
+          </button>
+          <button
+            type="button"
+            onClick={() => router.push('/assessments/clase5-kubernetes')}
+            className="inline-flex items-center justify-center rounded-2xl border border-slate-700 px-5 py-3 text-sm font-semibold text-slate-200 transition hover:bg-slate-800"
+          >
+            Volver al overview
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/src/app/assessments/clase6-config-kubernetes/__tests__/definition.test.ts
+++ b/apps/frontend/src/app/assessments/clase6-config-kubernetes/__tests__/definition.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import { assertAssessmentDefinitionConsistency } from '../../_shared/testing/assessment-definition-checks';
+import {
+  CLASE6_CONFIG_KUBERNETES_SEED_VERSION,
+  CLASE6_CONFIG_KUBERNETES_SLUG,
+  clase6ConfigKubernetesDefinition,
+} from '../data/assessment-definition';
+import { ASSESSMENT_REGISTRY } from '../../_shared/registry';
+
+const questions = clase6ConfigKubernetesDefinition.sections.flatMap(
+  (section) => section.questions
+);
+
+describe('clase6-config-kubernetes definition', () => {
+  it('mantiene presupuestos de puntos y answer keys consistentes', () => {
+    assertAssessmentDefinitionConsistency(clase6ConfigKubernetesDefinition);
+  });
+
+  it('define 3 secciones sobre 100 puntos', () => {
+    expect(clase6ConfigKubernetesDefinition.sections).toHaveLength(3);
+    expect(clase6ConfigKubernetesDefinition.total_score).toBe(100);
+    expect(clase6ConfigKubernetesDefinition.slug).toBe(
+      CLASE6_CONFIG_KUBERNETES_SLUG
+    );
+  });
+
+  it('reproduce el banco del bootcamp: 10 preguntas, 9 de respuesta única y 1 de varias', () => {
+    expect(questions).toHaveLength(10);
+    expect(
+      questions.filter((q) => q.question_type === 'multiple_choice')
+    ).toHaveLength(9);
+    expect(
+      questions.filter((q) => q.question_type === 'multiple_select')
+    ).toHaveLength(1);
+    questions.forEach((q) => {
+      expect(q.points).toBe(10);
+      expect(q.options).toHaveLength(4);
+      expect(q.explanation).toBeTruthy();
+      expect(q.metadata?.paginasPdf).toBeTruthy();
+    });
+  });
+
+  it('está registrado con el seedVersion correcto', () => {
+    const entry = ASSESSMENT_REGISTRY[CLASE6_CONFIG_KUBERNETES_SLUG];
+    expect(entry).toBeDefined();
+    expect(entry.seedVersion).toBe(CLASE6_CONFIG_KUBERNETES_SEED_VERSION);
+    expect(entry.examType).toBe(CLASE6_CONFIG_KUBERNETES_SLUG);
+  });
+});

--- a/apps/frontend/src/app/assessments/clase6-config-kubernetes/data/assessment-definition.ts
+++ b/apps/frontend/src/app/assessments/clase6-config-kubernetes/data/assessment-definition.ts
@@ -1,0 +1,447 @@
+import type { AssessmentSeedDefinition } from '../../_shared/types';
+
+export const CLASE6_CONFIG_KUBERNETES_SLUG = 'clase6-config-kubernetes';
+
+// Bumpear cuando cambie la definición (secciones/preguntas) para forzar re-seed.
+export const CLASE6_CONFIG_KUBERNETES_SEED_VERSION = 1;
+
+// Preguntas, opciones, claves y justificaciones transcritas literalmente del
+// banco de preguntas del bootcamp (Clase 6 Configuración en Kubernetes.xlsx).
+// La trazabilidad al PDF de origen vive en metadata.paginasPdf de cada pregunta.
+export const clase6ConfigKubernetesDefinition: AssessmentSeedDefinition = {
+  slug: CLASE6_CONFIG_KUBERNETES_SLUG,
+  title: 'Clase 6 — Configuración en Kubernetes',
+  description:
+    'Evaluación teórica de la Clase 6 del bootcamp: principio de inmutabilidad de la imagen, configuración desacoplada, ConfigMaps, inyección con envFrom, variables de entorno en .NET, Secrets y la ilusión Base64, Helm y el flujo CI/CD de configuración.',
+  level: 'Trainee a Junior',
+  type: 'Infraestructura',
+  duration_minutes: 20,
+  total_score: 100,
+  is_active: true,
+  metadata: {
+    moduleName: 'AIQUAA Assessments / Clase 6 Configuración en Kubernetes',
+    passingScore: 70,
+    candidateBands: [
+      { min: 0, max: 39, label: 'Inicial' },
+      { min: 40, max: 59, label: 'En formación' },
+      { min: 60, max: 74, label: 'Trainee' },
+      { min: 75, max: 89, label: 'Junior' },
+      { min: 90, max: 100, label: 'Junior avanzado' },
+    ],
+  },
+  sections: [
+    {
+      slug: 'inmutabilidad-y-configmaps',
+      title: 'Inmutabilidad y ConfigMaps',
+      description:
+        'Una imagen para todos los entornos, configuración externa al contenedor y qué guarda realmente un ConfigMap.',
+      order_index: 1,
+      max_score: 40,
+      metadata: {
+        instructions:
+          'Selección múltiple y selección de varias respuestas sobre inmutabilidad y casos de uso de ConfigMap.',
+        suggestedMinutes: 8,
+      },
+      questions: [
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            '¿Qué combinación respeta el principio de inmutabilidad presentado?',
+          options: [
+            {
+              label:
+                'Usar la misma imagen Docker entre entornos, cambiar la configuración según dev/QA/prod y evitar recompilar por cambios de variables.',
+              value: 'a',
+            },
+            {
+              label:
+                'Crear una imagen diferente por cada valor de configuración y recompilar ante cualquier cambio.',
+              value: 'b',
+            },
+            {
+              label:
+                'Mantener idéntica la configuración y modificar el código para distinguir los entornos.',
+              value: 'c',
+            },
+            {
+              label:
+                'Incluir todas las variables de producción dentro de la imagen de desarrollo.',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'a' },
+          explanation:
+            'El material establece que la imagen no cambia entre entornos, la configuración sí cambia y no debe recompilarse la imagen por cambios de variables.',
+          points: 10,
+          order_index: 1,
+          metadata: {
+            tema: 'Principio de inmutabilidad',
+            dificultad: 'Media',
+            conceptoEvaluado:
+              'Separación entre imagen inmutable y configuración variable',
+            paginasPdf: '2',
+          },
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            '¿Qué caracteriza al paradigma de configuración desacoplada en Kubernetes?',
+          options: [
+            {
+              label:
+                'La configuración queda incorporada permanentemente dentro del código de la aplicación.',
+              value: 'a',
+            },
+            {
+              label:
+                'La configuración es externa al contenedor y Kubernetes la proporciona en tiempo de ejecución.',
+              value: 'b',
+            },
+            {
+              label:
+                'Cada entorno requiere modificar y recompilar la aplicación.',
+              value: 'c',
+            },
+            {
+              label:
+                'Los manifiestos sustituyen por completo a la imagen Docker.',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'b' },
+          explanation:
+            'La diapositiva indica que Kubernetes desacopla la aplicación de la configuración y mantiene esta última completamente externa al contenedor.',
+          points: 10,
+          order_index: 2,
+          metadata: {
+            tema: 'Configuración desacoplada',
+            dificultad: 'Media',
+            conceptoEvaluado: 'Externalización de la configuración',
+            paginasPdf: '3',
+          },
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            '¿Para qué tipo de información debe utilizarse un ConfigMap según el material?',
+          options: [
+            {
+              label: 'Exclusivamente para passwords y tokens de autenticación.',
+              value: 'a',
+            },
+            {
+              label:
+                'Para información no confidencial almacenada como pares clave-valor.',
+              value: 'b',
+            },
+            {
+              label:
+                'Para cifrar automáticamente credenciales dentro de la imagen.',
+              value: 'c',
+            },
+            {
+              label: 'Para reemplazar el código fuente del contenedor.',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'b' },
+          explanation:
+            'El ConfigMap se define como un diccionario de pares clave-valor dentro del clúster y su propósito se limita a información no confidencial.',
+          points: 10,
+          order_index: 3,
+          metadata: {
+            tema: 'ConfigMap',
+            dificultad: 'Media',
+            conceptoEvaluado: 'Propósito y estructura de ConfigMap',
+            paginasPdf: '4',
+          },
+        },
+        {
+          question_type: 'multiple_select',
+          prompt:
+            '¿Cuáles de los siguientes son casos de uso reales de ConfigMap mencionados?',
+          options: [
+            {
+              label: 'Cambiar un string sin volver a desplegar la imagen.',
+              value: 'a',
+            },
+            { label: 'Ajustar niveles de log en producción.', value: 'b' },
+            { label: 'Configurar endpoints externos.', value: 'c' },
+            { label: 'Guardar passwords y variables sensibles.', value: 'd' },
+          ],
+          correct_answer: { values: ['a', 'b', 'c'] },
+          explanation:
+            'La diapositiva enumera connection strings, niveles de log y endpoints externos como usos reales; señala como error utilizar ConfigMap para passwords o variables sensibles.',
+          points: 10,
+          order_index: 4,
+          metadata: {
+            tema: 'Casos de uso de ConfigMap',
+            dificultad: 'Media',
+            conceptoEvaluado: 'Aplicaciones prácticas y límites de ConfigMap',
+            paginasPdf: '5',
+          },
+        },
+      ],
+    },
+    {
+      slug: 'inyeccion-y-secrets',
+      title: 'Inyección de variables y Secrets',
+      description:
+        'La secuencia de envFrom, el consumo estándar de variables de entorno desde .NET y la ilusión Base64 de los Secrets.',
+      order_index: 2,
+      max_score: 30,
+      metadata: {
+        instructions:
+          'Selección múltiple sobre inyección de configuración y protección de datos sensibles.',
+        suggestedMinutes: 6,
+      },
+      questions: [
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            '¿Cuál secuencia reproduce correctamente el motor de inyección con envFrom? Ten encuenta las clases prácticas de como se aplicó',
+          options: [
+            {
+              label:
+                'Se crea el ConfigMap; el Pod recibe la configuración al iniciar; el contenedor se ejecuta con las variables inyectadas, sin modificar la imagen.',
+              value: 'a',
+            },
+            {
+              label:
+                'El contenedor modifica la imagen; después crea el ConfigMap y finalmente inicia el Pod.',
+              value: 'b',
+            },
+            {
+              label:
+                'El Pod inicia sin configuración; Kubernetes recompila la imagen y luego crea variables locales.',
+              value: 'c',
+            },
+            {
+              label:
+                'envFrom cifra las variables, construye una imagen nueva y elimina el ConfigMap.',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'a' },
+          explanation:
+            'El diagrama muestra tres pasos: crear el ConfigMap, entregar la configuración al Pod durante el inicio y ejecutar el contenedor con las variables inyectadas; Kubernetes no modifica la imagen.',
+          points: 10,
+          order_index: 1,
+          metadata: {
+            tema: 'Inyección con envFrom',
+            dificultad: 'Extra',
+            conceptoEvaluado: 'Secuencia de inyección de variables',
+            paginasPdf: '6',
+            motivoDificultadExtra:
+              'Es Extra porque los distractores alteran el orden y atribuyen a envFrom tareas intuitivas pero incorrectas, como recompilar o modificar la imagen. Exige comprender todo el flujo.',
+          },
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            '¿Cómo consume una API .NET la configuración inyectada por Kubernetes según el ejemplo?',
+          options: [
+            {
+              label:
+                'Mediante variables de entorno incorporadas a la configuración estándar de la aplicación.',
+              value: 'a',
+            },
+            {
+              label:
+                'Leyendo directamente la API interna de Kubernetes desde cada controlador.',
+              value: 'b',
+            },
+            {
+              label:
+                'Modificando la imagen Docker cada vez que cambia un ConfigMap.',
+              value: 'c',
+            },
+            {
+              label:
+                'Convirtiendo automáticamente envFrom en un archivo de código fuente, Program.cs.',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'a' },
+          explanation:
+            'El material explica que el contenedor no necesita conocer Kubernetes; la API consume variables de entorno de forma estándar mediante AddEnvironmentVariables().',
+          points: 10,
+          order_index: 2,
+          metadata: {
+            tema: 'Configuración en API .NET',
+            dificultad: 'Media',
+            conceptoEvaluado: 'Integración de variables de entorno con .NET',
+            paginasPdf: '7',
+          },
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            '¿Qué afirmación describe correctamente la denominada “ilusión Base64” de los Secrets?',
+          options: [
+            {
+              label:
+                'Base64 cifra los datos y los vuelve ilegibles incluso para quien accede al Secret.',
+              value: 'a',
+            },
+            {
+              label:
+                'Todo Secret está cifrado por defecto y no requiere protección adicional.',
+              value: 'b',
+            },
+            {
+              label:
+                'Base64 reemplaza la necesidad de aplicar el principio de menor exposición.',
+              value: 'c',
+            },
+            {
+              label:
+                'Los datos están codificados en Base64, pero no cifrados por defecto; es una capa mínima de protección.',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'd' },
+          explanation:
+            'La diapositiva advierte expresamente que los Secrets se almacenan codificados en Base64, pero no están cifrados por defecto.',
+          points: 10,
+          order_index: 3,
+          metadata: {
+            tema: 'Secrets y Base64',
+            dificultad: 'Extra',
+            conceptoEvaluado: 'Diferencia entre codificación y cifrado',
+            paginasPdf: '8',
+            motivoDificultadExtra:
+              'Es Extra porque aprovecha la interpretación común pero incorrecta de que Base64 equivale a cifrado. Los distractores son plausibles si no se distingue codificación de protección criptográfica.',
+          },
+        },
+      ],
+    },
+    {
+      slug: 'matriz-helm-y-cicd',
+      title: 'Matriz de configuración, Helm y CI/CD',
+      description:
+        'Cuándo elegir ConfigMap o Secret, Helm como plantilla parametrizable y la entrega automatizada de configuración.',
+      order_index: 3,
+      max_score: 30,
+      metadata: {
+        instructions:
+          'Selección múltiple sobre criterios de elección, charts y arquitectura CI/CD.',
+        suggestedMinutes: 6,
+      },
+      questions: [
+        {
+          question_type: 'multiple_choice',
+          prompt: '¿Cuál comparación coincide con la matriz de configuración?',
+          options: [
+            {
+              label:
+                'ConfigMaps: datos críticos en Base64; Secrets: métricas en texto plano.',
+              value: 'a',
+            },
+            {
+              label:
+                'ConfigMaps: configuración no sensible en texto plano; Secrets: credenciales y datos críticos codificados en Base64.',
+              value: 'b',
+            },
+            {
+              label:
+                'ConfigMaps y Secrets almacenan exclusivamente contraseñas cifradas.',
+              value: 'c',
+            },
+            {
+              label:
+                'ConfigMaps y Secrets tienen el mismo rol y el mismo comando de inspección.',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'b' },
+          explanation:
+            'La matriz asocia ConfigMaps con comportamiento, métricas y configuración no sensible en texto plano; Secrets con credenciales y datos críticos codificados en Base64.',
+          points: 10,
+          order_index: 1,
+          metadata: {
+            tema: 'ConfigMaps vs. Secrets',
+            dificultad: 'Media',
+            conceptoEvaluado: 'Criterios para elegir ConfigMap o Secret',
+            paginasPdf: '9-10',
+          },
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            '¿Qué papel cumple Helm en la gestión de configuración presentada?',
+          options: [
+            {
+              label:
+                'Centraliza y versiona la configuración, convirtiendo YAML estático en plantillas parametrizables.',
+              value: 'a',
+            },
+            {
+              label:
+                'Elimina la necesidad de ConfigMaps, Secrets y values.yaml.',
+              value: 'b',
+            },
+            {
+              label: 'Obliga a crear una imagen distinta por cada entorno.',
+              value: 'c',
+            },
+            {
+              label:
+                'Guarda toda la lógica de negocio dentro de los templates.',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'a' },
+          explanation:
+            'Helm centraliza y versiona la configuración; mediante templates y .Values genera ConfigMaps y Secrets adaptables por entorno desde values.yaml.',
+          points: 10,
+          order_index: 2,
+          metadata: {
+            tema: 'Helm y configuración dinámica',
+            dificultad: 'Media',
+            conceptoEvaluado: 'Charts, values.yaml y renderizado',
+            paginasPdf: '11-13',
+          },
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            '¿Cuál flujo representa la arquitectura final CI/CD mostrada?',
+          options: [
+            {
+              label:
+                'El código y el Helm Chart pasan por el servidor de pipeline, que despliega ConfigMaps y Secrets usados por el Pod en el clúster.',
+              value: 'a',
+            },
+            {
+              label:
+                'El Pod modifica el repositorio y genera manualmente el pipeline después del despliegue.',
+              value: 'b',
+            },
+            {
+              label:
+                'La configuración se copia dentro de la imagen y evita el uso de Helm.',
+              value: 'c',
+            },
+            {
+              label:
+                'El pipeline solo almacena logs y no participa en la entrega de configuración.',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'a' },
+          explanation:
+            'El diagrama muestra el código y Helm Chart pasando por el servidor CI/CD hacia el clúster, donde ConfigMaps y Secrets alimentan al Pod de forma automatizada.',
+          points: 10,
+          order_index: 3,
+          metadata: {
+            tema: 'Flujo CI/CD de configuración',
+            dificultad: 'Media',
+            conceptoEvaluado: 'Entrega automatizada de configuración',
+            paginasPdf: '14',
+          },
+        },
+      ],
+    },
+  ],
+};

--- a/apps/frontend/src/app/assessments/clase6-config-kubernetes/lib/gamification.ts
+++ b/apps/frontend/src/app/assessments/clase6-config-kubernetes/lib/gamification.ts
@@ -1,0 +1,17 @@
+import { createAssessmentGamification } from '../../_shared/lib/gamification';
+
+const gamification = createAssessmentGamification({
+  prefix: 'CLASE6_CONFIG_KUBERNETES',
+  descriptions: {
+    completed: 'Completar el assessment Clase 6 Configuración en Kubernetes',
+    passed:
+      'Aprobar el assessment Clase 6 Configuración en Kubernetes (score >= 70)',
+    highScore:
+      'Score sobresaliente en Clase 6 Configuración en Kubernetes (>= 90)',
+  },
+});
+
+export const CLASE6_CONFIG_KUBERNETES_GAMIFICATION_RULES = gamification.rules;
+
+export const buildClase6ConfigKubernetesGamificationEvents =
+  gamification.buildEvents;

--- a/apps/frontend/src/app/assessments/clase6-config-kubernetes/lib/seed.ts
+++ b/apps/frontend/src/app/assessments/clase6-config-kubernetes/lib/seed.ts
@@ -1,0 +1,12 @@
+import { ensureAssessmentSeeded } from '../../_shared/lib/seed';
+import {
+  CLASE6_CONFIG_KUBERNETES_SEED_VERSION,
+  clase6ConfigKubernetesDefinition,
+} from '../data/assessment-definition';
+
+export async function ensureClase6ConfigKubernetesSeeded() {
+  return ensureAssessmentSeeded(
+    clase6ConfigKubernetesDefinition,
+    CLASE6_CONFIG_KUBERNETES_SEED_VERSION
+  );
+}

--- a/apps/frontend/src/app/assessments/clase6-config-kubernetes/page.tsx
+++ b/apps/frontend/src/app/assessments/clase6-config-kubernetes/page.tsx
@@ -1,0 +1,92 @@
+import { Metadata } from 'next';
+import { clase6ConfigKubernetesDefinition } from './data/assessment-definition';
+import AssessmentWelcome from '../_shared/components/AssessmentWelcome';
+
+export const metadata: Metadata = {
+  title: 'Clase 6 — Configuración en Kubernetes | AIQUAA',
+  description:
+    'Prueba técnica teórica sobre configuración en Kubernetes: inmutabilidad, ConfigMaps, envFrom, Secrets, Base64, Helm y CI/CD.',
+  keywords: [
+    'Kubernetes',
+    'ConfigMap',
+    'Secrets',
+    'envFrom',
+    'variables de entorno',
+    'Helm',
+    'values.yaml',
+    'CI/CD',
+    'bootcamp',
+    'AIQUAA',
+  ],
+  openGraph: {
+    title: 'Clase 6 — Configuración en Kubernetes | AIQUAA',
+    description:
+      'Prueba técnica teórica sobre configuración en Kubernetes: inmutabilidad, ConfigMaps, envFrom, Secrets, Base64, Helm y CI/CD.',
+    url: 'https://aiquaa.com/assessments/clase6-config-kubernetes',
+    siteName: 'AIQUAA',
+    type: 'website',
+    locale: 'es_PY',
+    images: [
+      {
+        url: '/api/og?title=Clase%206%20-%20Configuraci%C3%B3n%20en%20Kubernetes&subtitle=ConfigMaps%2C%20Secrets%20y%20Helm&section=Assessments',
+        width: 1200,
+        height: 630,
+        alt: 'Clase 6 — Configuración en Kubernetes - AIQUAA',
+      },
+    ],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Clase 6 — Configuración en Kubernetes | AIQUAA',
+    description:
+      'Prueba técnica teórica sobre configuración en Kubernetes: inmutabilidad, ConfigMaps, envFrom, Secrets, Base64, Helm y CI/CD.',
+    images: [
+      '/api/og?title=Clase%206%20-%20Configuraci%C3%B3n%20en%20Kubernetes&subtitle=ConfigMaps%2C%20Secrets%20y%20Helm&section=Assessments',
+    ],
+    creator: '@stevenayal',
+  },
+  alternates: {
+    canonical: 'https://aiquaa.com/assessments/clase6-config-kubernetes',
+  },
+};
+
+export default function Clase6ConfigKubernetesPage() {
+  const overview = {
+    assessment: {
+      id: 'static-clase6-config-kubernetes',
+      slug: clase6ConfigKubernetesDefinition.slug,
+      title: clase6ConfigKubernetesDefinition.title,
+      description: clase6ConfigKubernetesDefinition.description,
+      level: clase6ConfigKubernetesDefinition.level,
+      type: clase6ConfigKubernetesDefinition.type,
+      duration_minutes: clase6ConfigKubernetesDefinition.duration_minutes,
+      total_score: clase6ConfigKubernetesDefinition.total_score,
+      is_active: clase6ConfigKubernetesDefinition.is_active,
+      metadata: clase6ConfigKubernetesDefinition.metadata,
+    },
+    sections: clase6ConfigKubernetesDefinition.sections.map(
+      (section, index) => ({
+        id: `static-section-${index + 1}`,
+        assessment_id: 'static-clase6-config-kubernetes',
+        slug: section.slug,
+        title: section.title,
+        description: section.description,
+        order_index: section.order_index,
+        max_score: section.max_score,
+        metadata: section.metadata,
+      })
+    ),
+  };
+
+  return (
+    <AssessmentWelcome
+      overview={overview}
+      startHref="/assessments/clase6-config-kubernetes/start"
+      evaluatesCopy={
+        'El principio de inmutabilidad (una imagen, muchos entornos); la configuración externa al contenedor; qué información va en un ConfigMap y cuál no; el motor de inyección con envFrom; cómo consume una API .NET esas variables; la diferencia entre codificar en Base64 y cifrar; la matriz ConfigMaps frente a Secrets; el papel de Helm al parametrizar YAML; y el flujo CI/CD que entrega la configuración al clúster.'
+      }
+      scoringCopy="Automático en las 3 secciones: 9 preguntas de respuesta única y 1 de varias respuestas, con crédito parcial."
+      resultCopy="Score total, score por sección, fortalezas, debilidades y temas a reforzar."
+    />
+  );
+}

--- a/apps/frontend/src/app/assessments/clase6-config-kubernetes/result/page.tsx
+++ b/apps/frontend/src/app/assessments/clase6-config-kubernetes/result/page.tsx
@@ -1,0 +1,21 @@
+import { Suspense } from 'react';
+import AssessmentResultClient from '../../_shared/components/AssessmentResultClient';
+
+export default function Clase6ConfigKubernetesResultPage() {
+  return (
+    <Suspense
+      fallback={
+        <div className="min-h-screen flex items-center justify-center bg-slate-950">
+          <div className="h-10 w-10 animate-spin rounded-full border-t-2 border-cyan-400" />
+        </div>
+      }
+    >
+      <AssessmentResultClient
+        startHref="/assessments/clase6-config-kubernetes/start"
+        fallbackRecommendation={
+          'Repasá el material de la Clase 6: por qué la imagen no cambia entre entornos, casos de uso y límites de ConfigMap, la secuencia de inyección con envFrom, que Base64 no es cifrado, y cómo Helm y el pipeline versionan la configuración.'
+        }
+      />
+    </Suspense>
+  );
+}

--- a/apps/frontend/src/app/assessments/clase6-config-kubernetes/section/[sectionId]/page.tsx
+++ b/apps/frontend/src/app/assessments/clase6-config-kubernetes/section/[sectionId]/page.tsx
@@ -1,0 +1,9 @@
+'use client';
+
+import AssessmentSectionScreen from '../../../_shared/components/AssessmentSectionScreen';
+
+export default function Clase6ConfigKubernetesSectionPage() {
+  return (
+    <AssessmentSectionScreen basePath="/assessments/clase6-config-kubernetes" />
+  );
+}

--- a/apps/frontend/src/app/assessments/clase6-config-kubernetes/start/page.tsx
+++ b/apps/frontend/src/app/assessments/clase6-config-kubernetes/start/page.tsx
@@ -1,0 +1,135 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { useTheme } from '@/contexts/ThemeContext';
+import { startAssessmentAttemptAction } from '@/actions/assessments';
+import ProcessCodeInput from '@/components/labs/ProcessCodeInput';
+import { CLASE6_CONFIG_KUBERNETES_SLUG } from '../data/assessment-definition';
+
+export default function StartClase6ConfigKubernetesPage() {
+  const router = useRouter();
+  const { isDarkMode } = useTheme();
+  const [processCode, setProcessCode] = useState('');
+  const [error, setError] = useState('');
+  const [isStarting, setIsStarting] = useState(false);
+
+  // Pre-fill desde ?code= (links de invitaciones/procesos de empresa)
+  useEffect(() => {
+    const codeParam = new URLSearchParams(window.location.search).get('code');
+    if (codeParam) setProcessCode(codeParam);
+  }, []);
+
+  async function handleStart() {
+    setError('');
+    setIsStarting(true);
+
+    try {
+      const result = await startAssessmentAttemptAction({
+        slug: CLASE6_CONFIG_KUBERNETES_SLUG,
+        processCode,
+      });
+
+      if ('error' in result) {
+        setIsStarting(false);
+        setError(result.error);
+        return;
+      }
+
+      const { attempt, sectionSlug } = result;
+
+      if (!sectionSlug) {
+        setIsStarting(false);
+        setError('No se encontró la primera sección del assessment.');
+        return;
+      }
+
+      setIsStarting(false);
+      router.push(
+        `/assessments/clase6-config-kubernetes/section/${sectionSlug}?attempt=${attempt.id}`
+      );
+    } catch (startError) {
+      setIsStarting(false);
+      setError(
+        startError instanceof Error
+          ? startError.message
+          : 'No se pudo iniciar el assessment.'
+      );
+    }
+  }
+
+  return (
+    <div
+      className={`min-h-screen px-4 py-12 ${
+        isDarkMode ? 'bg-slate-950 text-white' : 'bg-slate-50 text-slate-900'
+      }`}
+    >
+      <div className="mx-auto max-w-3xl rounded-3xl border border-slate-800 bg-slate-900/80 p-8 text-slate-50 shadow-2xl shadow-cyan-950/20">
+        <p className="text-sm font-semibold uppercase tracking-[0.18em] text-cyan-200">
+          Preparación del intento
+        </p>
+        <h1 className="mt-3 text-3xl font-bold">
+          Clase 6 — Configuración en Kubernetes
+        </h1>
+        <p className="mt-3 text-slate-300">
+          Vas a completar 3 secciones teóricas (10 preguntas en total) con
+          autosave, scoring por sección y resultado final consolidado.
+        </p>
+
+        <div className="mt-8 grid gap-4 rounded-2xl border border-slate-800 bg-slate-950/70 p-5 md:grid-cols-3">
+          <div>
+            <p className="text-xs uppercase tracking-[0.18em] text-slate-400">
+              Duración sugerida
+            </p>
+            <p className="mt-2 text-lg font-semibold">~20 minutos</p>
+          </div>
+          <div>
+            <p className="text-xs uppercase tracking-[0.18em] text-slate-400">
+              Modalidad
+            </p>
+            <p className="mt-2 text-lg font-semibold">Conceptual</p>
+          </div>
+          <div>
+            <p className="text-xs uppercase tracking-[0.18em] text-slate-400">
+              Resultado
+            </p>
+            <p className="mt-2 text-lg font-semibold">Score total sobre 100</p>
+          </div>
+        </div>
+
+        <div className="mt-8">
+          <ProcessCodeInput
+            value={processCode}
+            onChange={setProcessCode}
+            onNormalizedCode={setProcessCode}
+            autoValidate
+          />
+        </div>
+
+        {error ? (
+          <div className="mt-6 rounded-2xl border border-red-500/30 bg-red-500/10 px-4 py-3 text-sm text-red-200">
+            {error}
+          </div>
+        ) : null}
+
+        <div className="mt-8 flex flex-col gap-3 sm:flex-row">
+          <button
+            type="button"
+            onClick={handleStart}
+            disabled={isStarting}
+            className="inline-flex items-center justify-center rounded-2xl bg-cyan-400 px-5 py-3 text-sm font-semibold text-slate-950 transition hover:bg-cyan-300 disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {isStarting ? 'Preparando intento...' : 'Iniciar o reanudar'}
+          </button>
+          <button
+            type="button"
+            onClick={() => router.push('/assessments/clase6-config-kubernetes')}
+            className="inline-flex items-center justify-center rounded-2xl border border-slate-700 px-5 py-3 text-sm font-semibold text-slate-200 transition hover:bg-slate-800"
+          >
+            Volver al overview
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/src/app/assessments/clase7-8-seq-logging/__tests__/definition.test.ts
+++ b/apps/frontend/src/app/assessments/clase7-8-seq-logging/__tests__/definition.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import { assertAssessmentDefinitionConsistency } from '../../_shared/testing/assessment-definition-checks';
+import {
+  CLASE7_8_SEQ_LOGGING_SEED_VERSION,
+  CLASE7_8_SEQ_LOGGING_SLUG,
+  clase78SeqLoggingDefinition,
+} from '../data/assessment-definition';
+import { ASSESSMENT_REGISTRY } from '../../_shared/registry';
+
+const questions = clase78SeqLoggingDefinition.sections.flatMap(
+  (section) => section.questions
+);
+
+describe('clase7-8-seq-logging definition', () => {
+  it('mantiene presupuestos de puntos y answer keys consistentes', () => {
+    assertAssessmentDefinitionConsistency(clase78SeqLoggingDefinition);
+  });
+
+  it('define 3 secciones sobre 100 puntos', () => {
+    expect(clase78SeqLoggingDefinition.sections).toHaveLength(3);
+    expect(clase78SeqLoggingDefinition.total_score).toBe(100);
+    expect(clase78SeqLoggingDefinition.slug).toBe(CLASE7_8_SEQ_LOGGING_SLUG);
+  });
+
+  it('reproduce el banco del bootcamp: 10 preguntas, 9 de respuesta única y 1 de varias', () => {
+    expect(questions).toHaveLength(10);
+    expect(
+      questions.filter((q) => q.question_type === 'multiple_choice')
+    ).toHaveLength(9);
+    expect(
+      questions.filter((q) => q.question_type === 'multiple_select')
+    ).toHaveLength(1);
+    questions.forEach((q) => {
+      expect(q.points).toBe(10);
+      expect(q.options).toHaveLength(4);
+      expect(q.explanation).toBeTruthy();
+      expect(q.metadata?.paginasPdf).toBeTruthy();
+    });
+  });
+
+  it('está registrado con el seedVersion correcto', () => {
+    const entry = ASSESSMENT_REGISTRY[CLASE7_8_SEQ_LOGGING_SLUG];
+    expect(entry).toBeDefined();
+    expect(entry.seedVersion).toBe(CLASE7_8_SEQ_LOGGING_SEED_VERSION);
+    expect(entry.examType).toBe(CLASE7_8_SEQ_LOGGING_SLUG);
+  });
+});

--- a/apps/frontend/src/app/assessments/clase7-8-seq-logging/data/assessment-definition.ts
+++ b/apps/frontend/src/app/assessments/clase7-8-seq-logging/data/assessment-definition.ts
@@ -1,0 +1,446 @@
+import type { AssessmentSeedDefinition } from '../../_shared/types';
+
+export const CLASE7_8_SEQ_LOGGING_SLUG = 'clase7-8-seq-logging';
+
+// Bumpear cuando cambie la definición (secciones/preguntas) para forzar re-seed.
+export const CLASE7_8_SEQ_LOGGING_SEED_VERSION = 1;
+
+// Preguntas, opciones, claves y justificaciones transcritas literalmente del
+// banco de preguntas del bootcamp (Clases 7 y 8 SEQ Structured Logging.xlsx).
+// La trazabilidad al PDF de origen vive en metadata.paginasPdf de cada pregunta.
+export const clase78SeqLoggingDefinition: AssessmentSeedDefinition = {
+  slug: CLASE7_8_SEQ_LOGGING_SLUG,
+  title: 'Clases 7 y 8 — SEQ Structured Logging',
+  description:
+    'Evaluación teórica de las Clases 7 y 8 del bootcamp: diagnóstico en sistemas distribuidos, límites de kubectl logs, efimeridad de los logs del Pod, logs estructurados, Serilog y su pipeline de sinks, niveles de severidad, Seq como receptor central y su despliegue en Kubernetes.',
+  level: 'Trainee a Junior',
+  type: 'Observabilidad',
+  duration_minutes: 20,
+  total_score: 100,
+  is_active: true,
+  metadata: {
+    moduleName: 'AIQUAA Assessments / Clases 7 y 8 SEQ Structured Logging',
+    passingScore: 70,
+    candidateBands: [
+      { min: 0, max: 39, label: 'Inicial' },
+      { min: 40, max: 59, label: 'En formación' },
+      { min: 60, max: 74, label: 'Trainee' },
+      { min: 75, max: 89, label: 'Junior' },
+      { min: 90, max: 100, label: 'Junior avanzado' },
+    ],
+  },
+  sections: [
+    {
+      slug: 'diagnostico-y-limites',
+      title: 'Diagnóstico en producción y límites de kubectl logs',
+      description:
+        'Por qué el logging centralizado es indispensable, qué no permite kubectl logs, la efimeridad del log del Pod y el diseño de logs estructurados.',
+      order_index: 1,
+      max_score: 40,
+      metadata: {
+        instructions:
+          'Selección múltiple sobre las limitaciones del diagnóstico local y el cambio de paradigma hacia logs como datos.',
+        suggestedMinutes: 8,
+      },
+      questions: [
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            '¿Qué conclusión presenta el material sobre el diagnóstico de un sistema distribuido bajo estrés o con un error crítico?',
+          options: [
+            {
+              label:
+                'Los logs locales de un único pod permiten reconstruir siempre todo el incidente.',
+              value: 'a',
+            },
+            {
+              label:
+                'Sin logging centralizado, el diagnóstico resulta imposible.',
+              value: 'b',
+            },
+            {
+              label:
+                'La correlación entre servicios deja de ser necesaria cuando existen varios pods.',
+              value: 'c',
+            },
+            {
+              label:
+                'Registrar únicamente los errores críticos resuelve todos los desafíos de observabilidad.',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'b' },
+          explanation:
+            'La diapositiva vincula el escenario real de producción con múltiples pods, requests fallidas, errores específicos y correlación entre servicios, y concluye que sin logging centralizado el diagnóstico es imposible.',
+          points: 10,
+          order_index: 1,
+          metadata: {
+            tema: 'Diagnóstico en producción',
+            dificultad: 'Media',
+            conceptoEvaluado:
+              'Necesidad de logging centralizado en sistemas distribuidos',
+            paginasPdf: '2',
+          },
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            '¿Cuál conjunto de actividades aparece como posibles bloqueantes o no permitido al depender únicamente de kubectl logs?',
+          options: [
+            {
+              label:
+                'Acceder a un pod específico y a un contenedor específico.',
+              value: 'a',
+            },
+            {
+              label:
+                'Visualizar stdout de un contenedor y hacer debugging puntual.',
+              value: 'b',
+            },
+            {
+              label:
+                'Consultar los logs de una instancia concreta durante su ejecución.',
+              value: 'c',
+            },
+            {
+              label:
+                'Realizar búsquedas globales, filtrar por request, usuario o error y correlacionar eventos.',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'd' },
+          explanation:
+            'El material permite consultar un pod o contenedor específico, pero marca como bloqueadas las búsquedas globales, los filtros por request, usuario o error y la correlación entre eventos.',
+          points: 10,
+          order_index: 2,
+          metadata: {
+            tema: 'Límites de kubectl logs',
+            dificultad: 'Media',
+            conceptoEvaluado: 'Alcance operativo de kubectl logs',
+            paginasPdf: '3',
+          },
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            '¿Por qué los logs de los pods son efímeros por naturaleza según el PDF?',
+          options: [
+            {
+              label:
+                'Porque se almacenan en el contenedor y se pierden cuando el pod se reinicia o es eliminado.',
+              value: 'a',
+            },
+            {
+              label:
+                'Porque Kubernetes los convierte automáticamente en métricas y elimina el texto original.',
+              value: 'b',
+            },
+            {
+              label:
+                'Porque cada nodo centraliza de forma permanente todos los logs del clúster.',
+              value: 'c',
+            },
+            {
+              label:
+                'Porque los logs solo existen cuando se consulta el dashboard web de Seq.',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'a' },
+          explanation:
+            'La diapositiva explica que los logs son temporales y locales, se almacenan en el contenedor y se pierden al reiniciarse o eliminarse el pod.',
+          points: 10,
+          order_index: 3,
+          metadata: {
+            tema: 'Efimeridad de los logs',
+            dificultad: 'Media',
+            conceptoEvaluado: 'Temporalidad y pérdida de logs locales',
+            paginasPdf: '4',
+          },
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            'Si se quiere buscar en el futuro por transactionId o userId y analizar eventos de varios pods, ¿qué diseño sigue completamente la recomendación del material?',
+          options: [
+            {
+              label:
+                'Escribir texto libre orientado a lectura humana y conservarlo solamente dentro de cada pod.',
+              value: 'a',
+            },
+            {
+              label:
+                'Generar mensajes JSON, pero colocar todos los datos dentro de una única cadena de texto y mantenerlos localmente.',
+              value: 'b',
+            },
+            {
+              label:
+                'Registrar eventos en JSON con propiedades clave-valor y centralizarlos fuera del pod para análisis automático.',
+              value: 'c',
+            },
+            {
+              label:
+                'Usar propiedades clave-valor, pero descartar la centralización porque kubectl logs ofrece búsquedas globales.',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'c' },
+          explanation:
+            'El cambio de paradigma propone JSON con pares clave-valor, pensado para análisis automático, y recomienda diseñar los logs como datos, prever búsquedas futuras y centralizarlos fuera del pod.',
+          points: 10,
+          order_index: 4,
+          metadata: {
+            tema: 'Logs estructurados',
+            dificultad: 'Extra',
+            conceptoEvaluado: 'Diseño de logs como datos estructurados',
+            paginasPdf: '5',
+            motivoDificultadExtra:
+              'Es Extra porque los distractores combinan rasgos parcialmente correctos —JSON, propiedades o lectura humana— con errores comunes como encapsular los datos en texto libre, mantenerlos solo en el pod o asumir búsquedas globales en kubectl logs.',
+          },
+        },
+      ],
+    },
+    {
+      slug: 'serilog-sinks-y-severidad',
+      title: 'Serilog: sinks, enriquecimiento y severidad',
+      description:
+        'Las capacidades de Serilog, el destino de cada sink y la clasificación correcta de los niveles de severidad.',
+      order_index: 2,
+      max_score: 30,
+      metadata: {
+        instructions:
+          'Selección múltiple y selección de varias respuestas sobre la biblioteca de logging y sus niveles.',
+        suggestedMinutes: 6,
+      },
+      questions: [
+        {
+          question_type: 'multiple_select',
+          prompt:
+            '¿Cuáles características de Serilog se mencionan explícitamente en el material?',
+          options: [
+            {
+              label: 'Se integra al pipeline de ASP.NET Core desde el inicio.',
+              value: 'a',
+            },
+            {
+              label:
+                'Restringe el envío de logs a archivos almacenados dentro del contenedor.',
+              value: 'b',
+            },
+            {
+              label: 'Permite enriquecer los logs con contexto de ejecución.',
+              value: 'c',
+            },
+            {
+              label:
+                'Admite múltiples destinos y está diseñado para stdout y Kubernetes.',
+              value: 'd',
+            },
+          ],
+          correct_answer: { values: ['a', 'c', 'd'] },
+          explanation:
+            'La diapositiva presenta integración nativa con ASP.NET Core, enriquecimiento con contexto, múltiples destinos y compatibilidad con contenedores mediante stdout y Kubernetes. No limita los logs a archivos locales.',
+          points: 10,
+          order_index: 1,
+          metadata: {
+            tema: 'Capacidades de Serilog',
+            dificultad: 'Media',
+            conceptoEvaluado:
+              'Integración, enriquecimiento y destinos de Serilog',
+            paginasPdf: '6',
+          },
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            '¿Qué sink se asocia en el PDF con centralización y análisis avanzado?',
+          options: [
+            { label: 'HTTP (Seq).', value: 'a' },
+            { label: 'Archivo local.', value: 'b' },
+            { label: 'Consola (stdout).', value: 'c' },
+            { label: 'kubectl logs como repositorio permanente.', value: 'd' },
+          ],
+          correct_answer: { value: 'a' },
+          explanation:
+            'El pipeline de sinks asigna la consola a la visualización con kubectl logs, el archivo a persistencia local y HTTP (Seq) a centralización y análisis avanzado.',
+          points: 10,
+          order_index: 2,
+          metadata: {
+            tema: 'Pipeline de sinks',
+            dificultad: 'Media',
+            conceptoEvaluado: 'Destino y propósito de los sinks',
+            paginasPdf: '7',
+          },
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            'La aplicación continúa funcionando, pero ocurre una situación anómala que debe quedar registrada. ¿Qué nivel corresponde según el termómetro de severidad?',
+          options: [
+            {
+              label:
+                'Fatal, porque toda anomalía implica la caída de la aplicación.',
+              value: 'a',
+            },
+            {
+              label:
+                'Error, porque cualquier comportamiento no normal debe clasificarse como fallo.',
+              value: 'b',
+            },
+            {
+              label:
+                'Warning, porque el material lo reserva para situaciones anómalas.',
+              value: 'c',
+            },
+            {
+              label:
+                'Information, porque la aplicación todavía mantiene su flujo normal.',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'c' },
+          explanation:
+            'El termómetro clasifica Fatal como caída de la aplicación, Error como fallos, Warning como situaciones anómalas e Information como flujo normal.',
+          points: 10,
+          order_index: 3,
+          metadata: {
+            tema: 'Niveles de severidad',
+            dificultad: 'Extra',
+            conceptoEvaluado: 'Clasificación correcta de severidad',
+            paginasPdf: '8',
+            motivoDificultadExtra:
+              'Es Extra porque obliga a distinguir entre tres niveles cercanos. Los distractores aprovechan asociaciones intuitivas pero incorrectas: equiparar toda anomalía con un fallo, una caída o un flujo normal por el solo hecho de que la aplicación siga activa.',
+          },
+        },
+      ],
+    },
+    {
+      slug: 'seq-y-observabilidad',
+      title: 'Seq y arquitectura de observabilidad',
+      description:
+        'Seq como servidor central de logs, el flujo completo desde la API hasta el dashboard y su despliegue persistente en el clúster.',
+      order_index: 3,
+      max_score: 30,
+      metadata: {
+        instructions:
+          'Selección múltiple sobre centralización, arquitectura y despliegue de Seq.',
+        suggestedMinutes: 6,
+      },
+      questions: [
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            '¿Qué beneficio de Seq destaca el material frente a los logs planos?',
+          options: [
+            {
+              label:
+                'Convierte todos los eventos en texto libre sin propiedades para simplificar la lectura.',
+              value: 'a',
+            },
+            {
+              label:
+                'Centraliza datos estructurados y permite búsquedas por dimensiones, filtros avanzados y propiedades.',
+              value: 'b',
+            },
+            {
+              label:
+                'Sustituye a Serilog y recibe únicamente archivos locales de cada pod.',
+              value: 'c',
+            },
+            {
+              label:
+                'Elimina la necesidad de correlacionar eventos en sistemas distribuidos.',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'b' },
+          explanation:
+            'Seq se presenta como servidor central de logs para sistemas distribuidos; trabaja con datos estructurados y ofrece búsquedas por dimensiones, filtros avanzados y propiedades.',
+          points: 10,
+          order_index: 1,
+          metadata: {
+            tema: 'Seq como receptor central',
+            dificultad: 'Media',
+            conceptoEvaluado: 'Centralización y análisis dinámico con Seq',
+            paginasPdf: '9',
+          },
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            '¿Cuál secuencia representa la arquitectura conceptual de observabilidad mostrada?',
+          options: [
+            {
+              label: 'Dashboard web → Seq → Serilog → pods de la API .NET.',
+              value: 'a',
+            },
+            {
+              label:
+                'Pods de la API .NET → Serilog → Seq mediante HTTP → dashboard web.',
+              value: 'b',
+            },
+            {
+              label:
+                'Pods de la API .NET → dashboard web → archivo local → Seq.',
+              value: 'c',
+            },
+            {
+              label: 'Serilog → dashboard web → pods de la API .NET → Seq.',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'b' },
+          explanation:
+            'El diagrama muestra múltiples instancias de la API .NET emitiendo logs estructurados mediante Serilog, Seq recibiéndolos por HTTP y el dashboard web permitiendo su análisis y visualización.',
+          points: 10,
+          order_index: 2,
+          metadata: {
+            tema: 'Arquitectura de observabilidad',
+            dificultad: 'Media',
+            conceptoEvaluado:
+              'Flujo de logs desde la API hasta la visualización',
+            paginasPdf: '10',
+          },
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            '¿Qué configuración reúne el blueprint de despliegue y el desafío práctico propuestos?',
+          options: [
+            {
+              label:
+                'Ejecutar Seq fuera de Kubernetes, exponerlo públicamente y guardar los logs solo en el contenedor.',
+              value: 'a',
+            },
+            {
+              label:
+                'Desplegar Seq en Minikube sin Service, conectar la API por archivos y omitir la persistencia.',
+              value: 'b',
+            },
+            {
+              label:
+                'Usar kubectl logs como almacenamiento central y analizar los eventos sin Seq ni Serilog.',
+              value: 'c',
+            },
+            {
+              label:
+                'Desplegar Seq como pod en Minikube, recibir por un Service HTTP interno, persistir con volumen y conectar la API mediante Serilog.',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'd' },
+          explanation:
+            'El blueprint indica Seq como pod, un Service para recepción HTTP interna y un volumen para persistir entre reinicios; el desafío práctico añade su despliegue en Minikube y la conexión de la API .NET mediante Serilog.',
+          points: 10,
+          order_index: 3,
+          metadata: {
+            tema: 'Despliegue y práctica en Kubernetes',
+            dificultad: 'Media',
+            conceptoEvaluado: 'Despliegue interno y persistente de Seq',
+            paginasPdf: '11-12',
+          },
+        },
+      ],
+    },
+  ],
+};

--- a/apps/frontend/src/app/assessments/clase7-8-seq-logging/lib/gamification.ts
+++ b/apps/frontend/src/app/assessments/clase7-8-seq-logging/lib/gamification.ts
@@ -1,0 +1,17 @@
+import { createAssessmentGamification } from '../../_shared/lib/gamification';
+
+const gamification = createAssessmentGamification({
+  prefix: 'CLASE7_8_SEQ_LOGGING',
+  descriptions: {
+    completed: 'Completar el assessment Clases 7 y 8 SEQ Structured Logging',
+    passed:
+      'Aprobar el assessment Clases 7 y 8 SEQ Structured Logging (score >= 70)',
+    highScore:
+      'Score sobresaliente en Clases 7 y 8 SEQ Structured Logging (>= 90)',
+  },
+});
+
+export const CLASE7_8_SEQ_LOGGING_GAMIFICATION_RULES = gamification.rules;
+
+export const buildClase78SeqLoggingGamificationEvents =
+  gamification.buildEvents;

--- a/apps/frontend/src/app/assessments/clase7-8-seq-logging/lib/seed.ts
+++ b/apps/frontend/src/app/assessments/clase7-8-seq-logging/lib/seed.ts
@@ -1,0 +1,12 @@
+import { ensureAssessmentSeeded } from '../../_shared/lib/seed';
+import {
+  CLASE7_8_SEQ_LOGGING_SEED_VERSION,
+  clase78SeqLoggingDefinition,
+} from '../data/assessment-definition';
+
+export async function ensureClase78SeqLoggingSeeded() {
+  return ensureAssessmentSeeded(
+    clase78SeqLoggingDefinition,
+    CLASE7_8_SEQ_LOGGING_SEED_VERSION
+  );
+}

--- a/apps/frontend/src/app/assessments/clase7-8-seq-logging/page.tsx
+++ b/apps/frontend/src/app/assessments/clase7-8-seq-logging/page.tsx
@@ -1,0 +1,90 @@
+import { Metadata } from 'next';
+import { clase78SeqLoggingDefinition } from './data/assessment-definition';
+import AssessmentWelcome from '../_shared/components/AssessmentWelcome';
+
+export const metadata: Metadata = {
+  title: 'Clases 7 y 8 — SEQ Structured Logging | AIQUAA',
+  description:
+    'Prueba técnica teórica sobre logging estructurado: límites de kubectl logs, Serilog, sinks, niveles de severidad y Seq en Kubernetes.',
+  keywords: [
+    'logging estructurado',
+    'Serilog',
+    'Seq',
+    'observabilidad',
+    'sinks',
+    'niveles de log',
+    'Kubernetes',
+    'kubectl logs',
+    'bootcamp',
+    'AIQUAA',
+  ],
+  openGraph: {
+    title: 'Clases 7 y 8 — SEQ Structured Logging | AIQUAA',
+    description:
+      'Prueba técnica teórica sobre logging estructurado: límites de kubectl logs, Serilog, sinks, niveles de severidad y Seq en Kubernetes.',
+    url: 'https://aiquaa.com/assessments/clase7-8-seq-logging',
+    siteName: 'AIQUAA',
+    type: 'website',
+    locale: 'es_PY',
+    images: [
+      {
+        url: '/api/og?title=Clases%207%20y%208%20-%20SEQ%20Structured%20Logging&subtitle=Serilog%2C%20sinks%20y%20Seq&section=Assessments',
+        width: 1200,
+        height: 630,
+        alt: 'Clases 7 y 8 — SEQ Structured Logging - AIQUAA',
+      },
+    ],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Clases 7 y 8 — SEQ Structured Logging | AIQUAA',
+    description:
+      'Prueba técnica teórica sobre logging estructurado: límites de kubectl logs, Serilog, sinks, niveles de severidad y Seq en Kubernetes.',
+    images: [
+      '/api/og?title=Clases%207%20y%208%20-%20SEQ%20Structured%20Logging&subtitle=Serilog%2C%20sinks%20y%20Seq&section=Assessments',
+    ],
+    creator: '@stevenayal',
+  },
+  alternates: {
+    canonical: 'https://aiquaa.com/assessments/clase7-8-seq-logging',
+  },
+};
+
+export default function Clase78SeqLoggingPage() {
+  const overview = {
+    assessment: {
+      id: 'static-clase7-8-seq-logging',
+      slug: clase78SeqLoggingDefinition.slug,
+      title: clase78SeqLoggingDefinition.title,
+      description: clase78SeqLoggingDefinition.description,
+      level: clase78SeqLoggingDefinition.level,
+      type: clase78SeqLoggingDefinition.type,
+      duration_minutes: clase78SeqLoggingDefinition.duration_minutes,
+      total_score: clase78SeqLoggingDefinition.total_score,
+      is_active: clase78SeqLoggingDefinition.is_active,
+      metadata: clase78SeqLoggingDefinition.metadata,
+    },
+    sections: clase78SeqLoggingDefinition.sections.map((section, index) => ({
+      id: `static-section-${index + 1}`,
+      assessment_id: 'static-clase7-8-seq-logging',
+      slug: section.slug,
+      title: section.title,
+      description: section.description,
+      order_index: section.order_index,
+      max_score: section.max_score,
+      metadata: section.metadata,
+    })),
+  };
+
+  return (
+    <AssessmentWelcome
+      overview={overview}
+      startHref="/assessments/clase7-8-seq-logging/start"
+      evaluatesCopy={
+        'Por qué sin logging centralizado el diagnóstico de un sistema distribuido es inviable; qué permite y qué bloquea kubectl logs; por qué los logs del Pod son efímeros; el diseño de logs como datos estructurados pensados para búsquedas futuras; las capacidades de Serilog y su pipeline de sinks; el termómetro de severidad (Information, Warning, Error, Fatal); Seq como receptor central; y el blueprint de despliegue de Seq en Minikube.'
+      }
+      scoringCopy="Automático en las 3 secciones: 9 preguntas de respuesta única y 1 de varias respuestas, con crédito parcial."
+      resultCopy="Score total, score por sección, fortalezas, debilidades y temas a reforzar."
+    />
+  );
+}

--- a/apps/frontend/src/app/assessments/clase7-8-seq-logging/result/page.tsx
+++ b/apps/frontend/src/app/assessments/clase7-8-seq-logging/result/page.tsx
@@ -1,0 +1,21 @@
+import { Suspense } from 'react';
+import AssessmentResultClient from '../../_shared/components/AssessmentResultClient';
+
+export default function Clase78SeqLoggingResultPage() {
+  return (
+    <Suspense
+      fallback={
+        <div className="min-h-screen flex items-center justify-center bg-slate-950">
+          <div className="h-10 w-10 animate-spin rounded-full border-t-2 border-cyan-400" />
+        </div>
+      }
+    >
+      <AssessmentResultClient
+        startHref="/assessments/clase7-8-seq-logging/start"
+        fallbackRecommendation={
+          'Repasá el material de las Clases 7 y 8: límites de kubectl logs, por qué los logs locales se pierden, JSON con pares clave-valor, los sinks de Serilog, la diferencia entre Warning y Error, y el despliegue de Seq con Service y volumen.'
+        }
+      />
+    </Suspense>
+  );
+}

--- a/apps/frontend/src/app/assessments/clase7-8-seq-logging/section/[sectionId]/page.tsx
+++ b/apps/frontend/src/app/assessments/clase7-8-seq-logging/section/[sectionId]/page.tsx
@@ -1,0 +1,9 @@
+'use client';
+
+import AssessmentSectionScreen from '../../../_shared/components/AssessmentSectionScreen';
+
+export default function Clase78SeqLoggingSectionPage() {
+  return (
+    <AssessmentSectionScreen basePath="/assessments/clase7-8-seq-logging" />
+  );
+}

--- a/apps/frontend/src/app/assessments/clase7-8-seq-logging/start/page.tsx
+++ b/apps/frontend/src/app/assessments/clase7-8-seq-logging/start/page.tsx
@@ -1,0 +1,135 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { useTheme } from '@/contexts/ThemeContext';
+import { startAssessmentAttemptAction } from '@/actions/assessments';
+import ProcessCodeInput from '@/components/labs/ProcessCodeInput';
+import { CLASE7_8_SEQ_LOGGING_SLUG } from '../data/assessment-definition';
+
+export default function StartClase78SeqLoggingPage() {
+  const router = useRouter();
+  const { isDarkMode } = useTheme();
+  const [processCode, setProcessCode] = useState('');
+  const [error, setError] = useState('');
+  const [isStarting, setIsStarting] = useState(false);
+
+  // Pre-fill desde ?code= (links de invitaciones/procesos de empresa)
+  useEffect(() => {
+    const codeParam = new URLSearchParams(window.location.search).get('code');
+    if (codeParam) setProcessCode(codeParam);
+  }, []);
+
+  async function handleStart() {
+    setError('');
+    setIsStarting(true);
+
+    try {
+      const result = await startAssessmentAttemptAction({
+        slug: CLASE7_8_SEQ_LOGGING_SLUG,
+        processCode,
+      });
+
+      if ('error' in result) {
+        setIsStarting(false);
+        setError(result.error);
+        return;
+      }
+
+      const { attempt, sectionSlug } = result;
+
+      if (!sectionSlug) {
+        setIsStarting(false);
+        setError('No se encontró la primera sección del assessment.');
+        return;
+      }
+
+      setIsStarting(false);
+      router.push(
+        `/assessments/clase7-8-seq-logging/section/${sectionSlug}?attempt=${attempt.id}`
+      );
+    } catch (startError) {
+      setIsStarting(false);
+      setError(
+        startError instanceof Error
+          ? startError.message
+          : 'No se pudo iniciar el assessment.'
+      );
+    }
+  }
+
+  return (
+    <div
+      className={`min-h-screen px-4 py-12 ${
+        isDarkMode ? 'bg-slate-950 text-white' : 'bg-slate-50 text-slate-900'
+      }`}
+    >
+      <div className="mx-auto max-w-3xl rounded-3xl border border-slate-800 bg-slate-900/80 p-8 text-slate-50 shadow-2xl shadow-cyan-950/20">
+        <p className="text-sm font-semibold uppercase tracking-[0.18em] text-cyan-200">
+          Preparación del intento
+        </p>
+        <h1 className="mt-3 text-3xl font-bold">
+          Clases 7 y 8 — SEQ Structured Logging
+        </h1>
+        <p className="mt-3 text-slate-300">
+          Vas a completar 3 secciones teóricas (10 preguntas en total) con
+          autosave, scoring por sección y resultado final consolidado.
+        </p>
+
+        <div className="mt-8 grid gap-4 rounded-2xl border border-slate-800 bg-slate-950/70 p-5 md:grid-cols-3">
+          <div>
+            <p className="text-xs uppercase tracking-[0.18em] text-slate-400">
+              Duración sugerida
+            </p>
+            <p className="mt-2 text-lg font-semibold">~20 minutos</p>
+          </div>
+          <div>
+            <p className="text-xs uppercase tracking-[0.18em] text-slate-400">
+              Modalidad
+            </p>
+            <p className="mt-2 text-lg font-semibold">Conceptual</p>
+          </div>
+          <div>
+            <p className="text-xs uppercase tracking-[0.18em] text-slate-400">
+              Resultado
+            </p>
+            <p className="mt-2 text-lg font-semibold">Score total sobre 100</p>
+          </div>
+        </div>
+
+        <div className="mt-8">
+          <ProcessCodeInput
+            value={processCode}
+            onChange={setProcessCode}
+            onNormalizedCode={setProcessCode}
+            autoValidate
+          />
+        </div>
+
+        {error ? (
+          <div className="mt-6 rounded-2xl border border-red-500/30 bg-red-500/10 px-4 py-3 text-sm text-red-200">
+            {error}
+          </div>
+        ) : null}
+
+        <div className="mt-8 flex flex-col gap-3 sm:flex-row">
+          <button
+            type="button"
+            onClick={handleStart}
+            disabled={isStarting}
+            className="inline-flex items-center justify-center rounded-2xl bg-cyan-400 px-5 py-3 text-sm font-semibold text-slate-950 transition hover:bg-cyan-300 disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {isStarting ? 'Preparando intento...' : 'Iniciar o reanudar'}
+          </button>
+          <button
+            type="button"
+            onClick={() => router.push('/assessments/clase7-8-seq-logging')}
+            className="inline-flex items-center justify-center rounded-2xl border border-slate-700 px-5 py-3 text-sm font-semibold text-slate-200 transition hover:bg-slate-800"
+          >
+            Volver al overview
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/src/app/assessments/clase9-cicd-github-actions/__tests__/definition.test.ts
+++ b/apps/frontend/src/app/assessments/clase9-cicd-github-actions/__tests__/definition.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import { assertAssessmentDefinitionConsistency } from '../../_shared/testing/assessment-definition-checks';
+import {
+  CLASE9_CICD_GITHUB_ACTIONS_SEED_VERSION,
+  CLASE9_CICD_GITHUB_ACTIONS_SLUG,
+  clase9CicdGithubActionsDefinition,
+} from '../data/assessment-definition';
+import { ASSESSMENT_REGISTRY } from '../../_shared/registry';
+
+const questions = clase9CicdGithubActionsDefinition.sections.flatMap(
+  (section) => section.questions
+);
+
+describe('clase9-cicd-github-actions definition', () => {
+  it('mantiene presupuestos de puntos y answer keys consistentes', () => {
+    assertAssessmentDefinitionConsistency(clase9CicdGithubActionsDefinition);
+  });
+
+  it('define 3 secciones sobre 100 puntos', () => {
+    expect(clase9CicdGithubActionsDefinition.sections).toHaveLength(3);
+    expect(clase9CicdGithubActionsDefinition.total_score).toBe(100);
+    expect(clase9CicdGithubActionsDefinition.slug).toBe(
+      CLASE9_CICD_GITHUB_ACTIONS_SLUG
+    );
+  });
+
+  it('reproduce el banco del bootcamp: 10 preguntas, 9 de respuesta única y 1 de varias', () => {
+    expect(questions).toHaveLength(10);
+    expect(
+      questions.filter((q) => q.question_type === 'multiple_choice')
+    ).toHaveLength(9);
+    expect(
+      questions.filter((q) => q.question_type === 'multiple_select')
+    ).toHaveLength(1);
+    questions.forEach((q) => {
+      expect(q.points).toBe(10);
+      expect(q.options).toHaveLength(4);
+      expect(q.explanation).toBeTruthy();
+      expect(q.metadata?.paginasPdf).toBeTruthy();
+    });
+  });
+
+  it('está registrado con el seedVersion correcto', () => {
+    const entry = ASSESSMENT_REGISTRY[CLASE9_CICD_GITHUB_ACTIONS_SLUG];
+    expect(entry).toBeDefined();
+    expect(entry.seedVersion).toBe(CLASE9_CICD_GITHUB_ACTIONS_SEED_VERSION);
+    expect(entry.examType).toBe(CLASE9_CICD_GITHUB_ACTIONS_SLUG);
+  });
+});

--- a/apps/frontend/src/app/assessments/clase9-cicd-github-actions/data/assessment-definition.ts
+++ b/apps/frontend/src/app/assessments/clase9-cicd-github-actions/data/assessment-definition.ts
@@ -1,0 +1,446 @@
+import type { AssessmentSeedDefinition } from '../../_shared/types';
+
+export const CLASE9_CICD_GITHUB_ACTIONS_SLUG = 'clase9-cicd-github-actions';
+
+// Bumpear cuando cambie la definición (secciones/preguntas) para forzar re-seed.
+export const CLASE9_CICD_GITHUB_ACTIONS_SEED_VERSION = 1;
+
+// Preguntas, opciones, claves y justificaciones transcritas literalmente del
+// banco de preguntas del bootcamp (Clase 9 CI CD con GitHub Actions.xlsx).
+// La trazabilidad al PDF de origen vive en metadata.paginasPdf de cada pregunta.
+export const clase9CicdGithubActionsDefinition: AssessmentSeedDefinition = {
+  slug: CLASE9_CICD_GITHUB_ACTIONS_SLUG,
+  title: 'Clase 9 — CI/CD con GitHub Actions',
+  description:
+    'Evaluación teórica de la Clase 9 del bootcamp: propósito de CI/CD, impacto de la automatización, integración continua, Continuous Delivery frente a Continuous Deployment, arquitectura y conceptos del pipeline, ecosistemas CI/CD, workflows de GitHub Actions, Variables y Secrets.',
+  level: 'Trainee a Junior',
+  type: 'Desarrollo DevOps',
+  duration_minutes: 20,
+  total_score: 100,
+  is_active: true,
+  metadata: {
+    moduleName: 'AIQUAA Assessments / Clase 9 CI/CD con GitHub Actions',
+    passingScore: 70,
+    candidateBands: [
+      { min: 0, max: 39, label: 'Inicial' },
+      { min: 40, max: 59, label: 'En formación' },
+      { min: 60, max: 74, label: 'Trainee' },
+      { min: 75, max: 89, label: 'Junior' },
+      { min: 90, max: 100, label: 'Junior avanzado' },
+    ],
+  },
+  sections: [
+    {
+      slug: 'proposito-y-integracion-continua',
+      title: 'Propósito, automatización e integración continua',
+      description:
+        'Qué resuelve CI/CD, los beneficios de automatizar, la práctica que arranca el ciclo de feedback y la diferencia Delivery/Deployment.',
+      order_index: 1,
+      max_score: 40,
+      metadata: {
+        instructions:
+          'Selección múltiple sobre los fundamentos de la integración y la entrega continua.',
+        suggestedMinutes: 8,
+      },
+      questions: [
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            '¿Qué objetivo atribuye el material a CI/CD para los cambios realizados en una API?',
+          options: [
+            {
+              label:
+                'Reservar la validación de calidad para el momento posterior al despliegue.',
+              value: 'a',
+            },
+            {
+              label:
+                'Asegurar calidad automática y llegada repetible y confiable a un entorno.',
+              value: 'b',
+            },
+            {
+              label:
+                'Reemplazar todos los cambios pequeños por entregas manuales de gran tamaño.',
+              value: 'c',
+            },
+            {
+              label:
+                'Eliminar los despliegues frecuentes para reducir el uso de automatización.',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'b' },
+          explanation:
+            'La diapositiva define CI/CD como la forma de asegurar que cada cambio en una API pase por calidad automática y llegue a un entorno de manera repetible y confiable.',
+          points: 10,
+          order_index: 1,
+          metadata: {
+            tema: 'Propósito de CI/CD',
+            dificultad: 'Media',
+            conceptoEvaluado:
+              'Cambio de procesos manuales a un flujo repetible',
+            paginasPdf: '2',
+          },
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            '¿Cuál combinación corresponde a beneficios futuros de la automatización señalados en el PDF?',
+          options: [
+            {
+              label:
+                'Builds manuales inconsistentes, cambios grandes y tests tardíos.',
+              value: 'a',
+            },
+            {
+              label:
+                "Mayor cantidad de errores humanos y dependencia del 'funciona en mi máquina'.",
+              value: 'b',
+            },
+            {
+              label:
+                'Trazabilidad completa, feedback rápido en PRs y menor time-to-market.',
+              value: 'c',
+            },
+            {
+              label:
+                'Despliegues manuales, costos operativos mayores y menor capacidad de respuesta.',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'c' },
+          explanation:
+            'Entre los beneficios clave se enumeran trazabilidad completa, confianza en cambios pequeños, feedback rápido en PRs, time-to-market más rápido, reducción de costos y mayor calidad.',
+          points: 10,
+          order_index: 2,
+          metadata: {
+            tema: 'Impacto de la automatización',
+            dificultad: 'Media',
+            conceptoEvaluado:
+              'Beneficios técnicos y de negocio de la automatización',
+            paginasPdf: '3',
+          },
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            '¿Qué práctica inicia el ciclo de feedback rápido de Continuous Integration mostrado?',
+          options: [
+            { label: 'Integrar cambios al repositorio', value: 'a' },
+            {
+              label: 'Esperar a reunir cambios grandes antes de incorporarlos.',
+              value: 'b',
+            },
+            {
+              label:
+                'Ejecutar validaciones únicamente después de llegar a producción.',
+              value: 'c',
+            },
+            {
+              label:
+                'Sustituir el feedback inmediato por revisiones manuales al final del proyecto.',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'a' },
+          explanation:
+            'El ciclo comienza con integración frecuente: incorporar cambios al repositorio varias veces al día. Luego se ejecutan validaciones automáticas, feedback inmediato y detección temprana.',
+          points: 10,
+          order_index: 3,
+          metadata: {
+            tema: 'Continuous Integration',
+            dificultad: 'Media',
+            conceptoEvaluado: 'Integración frecuente y feedback rápido',
+            paginasPdf: '4',
+          },
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            '¿Qué comparación distingue correctamente Continuous Delivery de Continuous Deployment sin confundir los pasos que ambos comparten?',
+          options: [
+            {
+              label:
+                'Delivery despliega automáticamente sin intervención; Deployment exige aprobación manual para producción.',
+              value: 'a',
+            },
+            {
+              label:
+                'Delivery construye imágenes Docker, mientras que Deployment es el único que usa registry, Kubernetes y health checks.',
+              value: 'b',
+            },
+            {
+              label:
+                'Delivery y Deployment requieren siempre aprobación manual; solo cambia la frecuencia de los commits.',
+              value: 'c',
+            },
+            {
+              label:
+                'Delivery mantiene el código desplegable y exige aprobación para producción; Deployment despliega automáticamente cada cambio validado. Ambos incluyen imagen, registry, Kubernetes y health checks.',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'd' },
+          explanation:
+            'El material define Delivery como control con aprobación manual explícita para producción y Deployment como despliegue automático sin intervención humana. También aclara que ambos caminos construyen imágenes, publican al registry, despliegan en Kubernetes y ejecutan health checks.',
+          points: 10,
+          order_index: 4,
+          metadata: {
+            tema: 'Delivery vs. Deployment',
+            dificultad: 'Extra',
+            conceptoEvaluado:
+              'Diferencia operativa entre Continuous Delivery y Deployment',
+            paginasPdf: '5',
+            motivoDificultadExtra:
+              'Es Extra porque los distractores intercambian la aprobación manual y la automatización, o presentan como exclusivos pasos que el PDF declara comunes a ambos enfoques. Exige separar la diferencia central del flujo compartido.',
+          },
+        },
+      ],
+    },
+    {
+      slug: 'pipeline-y-ecosistemas',
+      title: 'Arquitectura del pipeline y ecosistemas',
+      description:
+        'La secuencia completa de etapas, los conceptos de Pipeline/Jobs/Steps/Triggers/Runners y la comparación entre plataformas CI/CD.',
+      order_index: 2,
+      max_score: 30,
+      metadata: {
+        instructions:
+          'Selección múltiple y selección de varias respuestas sobre la anatomía de un pipeline.',
+        suggestedMinutes: 6,
+      },
+      questions: [
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            '¿Cuál es la secuencia completa del pipeline desde el cambio de código hasta la comprobación final?',
+          options: [
+            {
+              label:
+                'Entrada → empaquetado → validación → despliegue → publicación → verificación.',
+              value: 'a',
+            },
+            {
+              label:
+                'Entrada → validación → empaquetado → publicación → despliegue → verificación.',
+              value: 'b',
+            },
+            {
+              label:
+                'Validación → entrada → publicación → empaquetado → verificación → despliegue.',
+              value: 'c',
+            },
+            {
+              label:
+                'Entrada → despliegue → validación → publicación → empaquetado → verificación.',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'b' },
+          explanation:
+            'La arquitectura presentada sigue seis etapas: entrada por commit o PR, validación con compilación y tests, empaquetado de imagen Docker, publicación al registry, despliegue a Kubernetes y verificación mediante health checks.',
+          points: 10,
+          order_index: 1,
+          metadata: {
+            tema: 'Arquitectura del pipeline',
+            dificultad: 'Media',
+            conceptoEvaluado: 'Secuencia automatizada de código a producción',
+            paginasPdf: '6',
+          },
+        },
+        {
+          question_type: 'multiple_select',
+          prompt:
+            '¿Cuáles son los conceptos claves una arquitectura de un pipeline indicados en el material?',
+          options: [
+            { label: 'Pipeline: el flujo total.', value: 'a' },
+            { label: 'Jobs: los servidores de ejecución.', value: 'b' },
+            { label: 'Steps: las tareas.', value: 'c' },
+            { label: 'Triggers: los disparadores.', value: 'd' },
+          ],
+          correct_answer: { values: ['a', 'c', 'd'] },
+          explanation:
+            'El PDF asocia Pipeline con el flujo total, Jobs con agrupaciones, Steps con tareas, Triggers con disparadores y Runners con servidores de ejecución. Por eso la opción B atribuye a Jobs la definición de Runners.',
+          points: 10,
+          order_index: 2,
+          metadata: {
+            tema: 'Conceptos del pipeline',
+            dificultad: 'Media',
+            conceptoEvaluado: 'Pipeline, Jobs, Steps, Triggers y Runners',
+            paginasPdf: '6',
+          },
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            '¿Qué descripción de las plataformas CI/CD coincide con la comparación presentada?',
+          options: [
+            {
+              label:
+                'GitHub Actions requiere siempre operación propia y solo admite runners on-premise.',
+              value: 'a',
+            },
+            {
+              label:
+                'Jenkins está integrado al repositorio con YAML simple y no necesita administración propia.',
+              value: 'b',
+            },
+            {
+              label:
+                'GitHub Actions se integra al repositorio y admite runners hosted o self-hosted; Jenkins ofrece control total on-premise; Azure DevOps se integra fuertemente con Microsoft.',
+              value: 'c',
+            },
+            {
+              label:
+                'Azure DevOps está orientado exclusivamente a entornos legacy sin herramientas DevOps integradas.',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'c' },
+          explanation:
+            'La comparación describe GitHub Actions como integrado al repo con YAML simple y runners hosted o self-hosted; Jenkins como flexible, on-premise y de operación propia; Azure DevOps como un conjunto completo con fuerte integración Microsoft.',
+          points: 10,
+          order_index: 3,
+          metadata: {
+            tema: 'Ecosistemas CI/CD',
+            dificultad: 'Media',
+            conceptoEvaluado:
+              'Características de GitHub Actions, Jenkins y Azure DevOps',
+            paginasPdf: '7',
+          },
+        },
+      ],
+    },
+    {
+      slug: 'workflows-secrets-y-flujo',
+      title: 'GitHub Actions, Secrets y flujo del desarrollador',
+      description:
+        'Triggers y orden de steps en un workflow, la separación entre Variables y Secrets, y el valor de CI/CD como infraestructura de ingeniería.',
+      order_index: 3,
+      max_score: 30,
+      metadata: {
+        instructions:
+          'Selección múltiple sobre workflows, seguridad del pipeline y cierre conceptual.',
+        suggestedMinutes: 6,
+      },
+      questions: [
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            'Si se necesita validar antes del merge, permitir ejecución manual o validar por commit. ¿Cuáles son los triggers comunes?',
+          options: [
+            {
+              label: 'Usar pull_request o workflow_dispatch o push.',
+              value: 'a',
+            },
+            {
+              label:
+                'Usar solo push; ejecutar test, restore y build, todos sin dependencias previas.',
+              value: 'b',
+            },
+            {
+              label:
+                'Usar pull_request; ejecutar build --no-restore antes de restore y finalizar con checkout.',
+              value: 'c',
+            },
+            {
+              label:
+                'Usar solo workflow_dispatch; ejecutar restore, test --no-build y luego build.',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'a' },
+          explanation:
+            'La diapositiva identifica pull_request para validar antes del merge y workflow_dispatch para ejecución manual. El ejemplo ordena checkout, setup .NET, restore, build --no-restore y test --no-build.',
+          points: 10,
+          order_index: 1,
+          metadata: {
+            tema: 'Workflow de GitHub Actions',
+            dificultad: 'Extra',
+            conceptoEvaluado: 'Triggers y orden de steps en GitHub Actions',
+            paginasPdf: '8',
+            motivoDificultadExtra:
+              'Es Extra porque los distractores usan triggers y comandos reales del ejemplo, pero alteran su propósito o su dependencia lógica. La respuesta requiere relacionar el evento correcto con el orden Restore → Build → Test y sus opciones --no-restore y --no-build.',
+          },
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            '¿Cuál clasificación entre Variables y Secrets respeta el criterio de seguridad presentado?',
+          options: [
+            {
+              label:
+                'Los tokens y passwords son Variables porque describen la estructura del despliegue.',
+              value: 'a',
+            },
+            {
+              label:
+                'Los nombres de entorno y namespaces pueden ser Variables; las credenciales y connection strings deben ser Secrets y no exponerse en código ni logs.',
+              value: 'b',
+            },
+            {
+              label:
+                'Los nombres de imágenes Docker deben ser Secrets, mientras que las llaves de acceso pueden quedar en logs.',
+              value: 'c',
+            },
+            {
+              label:
+                'Variables y Secrets son equivalentes porque ambos tipos se muestran siempre en texto plano.',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'b' },
+          explanation:
+            'El material reserva Variables para valores no sensibles, como entornos, flags, imágenes y namespaces. Los Secrets almacenan credenciales, tokens, passwords y connection strings; están cifrados y no deben exponerse en código ni logs.',
+          points: 10,
+          order_index: 2,
+          metadata: {
+            tema: 'Seguridad del pipeline',
+            dificultad: 'Media',
+            conceptoEvaluado:
+              'Separación de configuración sensible y no sensible',
+            paginasPdf: '9',
+          },
+        },
+        {
+          question_type: 'multiple_choice',
+          prompt:
+            '¿Qué idea resume el cierre del material sobre el valor de CI/CD?',
+          options: [
+            {
+              label:
+                'Es principalmente un conjunto de comandos para reemplazar la colaboración del equipo.',
+              value: 'a',
+            },
+            {
+              label:
+                'Su objetivo es conservar procesos manuales para que cada entrega dependa del conocimiento individual.',
+              value: 'b',
+            },
+            {
+              label:
+                'Solo aporta velocidad, aunque los cambios dejen de ser medibles y seguros.',
+              value: 'c',
+            },
+            {
+              label:
+                'Es infraestructura para escalar, eliminar incidentes evitables y lograr entregas seguras, medibles y sin fricción.',
+              value: 'd',
+            },
+          ],
+          correct_answer: { value: 'd' },
+          explanation:
+            'La última diapositiva presenta CI/CD como infraestructura que permite escalar el talento de ingeniería y transformar procesos manuales frágiles en planos automatizados, con cambios seguros y entregas medibles.',
+          points: 10,
+          order_index: 3,
+          metadata: {
+            tema: 'Flujo del desarrollador',
+            dificultad: 'Media',
+            conceptoEvaluado: 'CI/CD como infraestructura de ingeniería',
+            paginasPdf: '10',
+          },
+        },
+      ],
+    },
+  ],
+};

--- a/apps/frontend/src/app/assessments/clase9-cicd-github-actions/lib/gamification.ts
+++ b/apps/frontend/src/app/assessments/clase9-cicd-github-actions/lib/gamification.ts
@@ -1,0 +1,17 @@
+import { createAssessmentGamification } from '../../_shared/lib/gamification';
+
+const gamification = createAssessmentGamification({
+  prefix: 'CLASE9_CICD_GITHUB_ACTIONS',
+  descriptions: {
+    completed: 'Completar el assessment Clase 9 CI/CD con GitHub Actions',
+    passed:
+      'Aprobar el assessment Clase 9 CI/CD con GitHub Actions (score >= 70)',
+    highScore:
+      'Score sobresaliente en Clase 9 CI/CD con GitHub Actions (>= 90)',
+  },
+});
+
+export const CLASE9_CICD_GITHUB_ACTIONS_GAMIFICATION_RULES = gamification.rules;
+
+export const buildClase9CicdGithubActionsGamificationEvents =
+  gamification.buildEvents;

--- a/apps/frontend/src/app/assessments/clase9-cicd-github-actions/lib/seed.ts
+++ b/apps/frontend/src/app/assessments/clase9-cicd-github-actions/lib/seed.ts
@@ -1,0 +1,12 @@
+import { ensureAssessmentSeeded } from '../../_shared/lib/seed';
+import {
+  CLASE9_CICD_GITHUB_ACTIONS_SEED_VERSION,
+  clase9CicdGithubActionsDefinition,
+} from '../data/assessment-definition';
+
+export async function ensureClase9CicdGithubActionsSeeded() {
+  return ensureAssessmentSeeded(
+    clase9CicdGithubActionsDefinition,
+    CLASE9_CICD_GITHUB_ACTIONS_SEED_VERSION
+  );
+}

--- a/apps/frontend/src/app/assessments/clase9-cicd-github-actions/page.tsx
+++ b/apps/frontend/src/app/assessments/clase9-cicd-github-actions/page.tsx
@@ -1,0 +1,92 @@
+import { Metadata } from 'next';
+import { clase9CicdGithubActionsDefinition } from './data/assessment-definition';
+import AssessmentWelcome from '../_shared/components/AssessmentWelcome';
+
+export const metadata: Metadata = {
+  title: 'Clase 9 — CI/CD con GitHub Actions | AIQUAA',
+  description:
+    'Prueba técnica teórica sobre CI/CD con GitHub Actions: pipeline, Delivery vs Deployment, triggers, jobs, steps, Variables y Secrets.',
+  keywords: [
+    'CI/CD',
+    'GitHub Actions',
+    'pipeline',
+    'Continuous Delivery',
+    'Continuous Deployment',
+    'workflow',
+    'triggers',
+    'Secrets',
+    'bootcamp',
+    'AIQUAA',
+  ],
+  openGraph: {
+    title: 'Clase 9 — CI/CD con GitHub Actions | AIQUAA',
+    description:
+      'Prueba técnica teórica sobre CI/CD con GitHub Actions: pipeline, Delivery vs Deployment, triggers, jobs, steps, Variables y Secrets.',
+    url: 'https://aiquaa.com/assessments/clase9-cicd-github-actions',
+    siteName: 'AIQUAA',
+    type: 'website',
+    locale: 'es_PY',
+    images: [
+      {
+        url: '/api/og?title=Clase%209%20-%20CI%2FCD%20con%20GitHub%20Actions&subtitle=Pipelines%2C%20triggers%20y%20Secrets&section=Assessments',
+        width: 1200,
+        height: 630,
+        alt: 'Clase 9 — CI/CD con GitHub Actions - AIQUAA',
+      },
+    ],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Clase 9 — CI/CD con GitHub Actions | AIQUAA',
+    description:
+      'Prueba técnica teórica sobre CI/CD con GitHub Actions: pipeline, Delivery vs Deployment, triggers, jobs, steps, Variables y Secrets.',
+    images: [
+      '/api/og?title=Clase%209%20-%20CI%2FCD%20con%20GitHub%20Actions&subtitle=Pipelines%2C%20triggers%20y%20Secrets&section=Assessments',
+    ],
+    creator: '@stevenayal',
+  },
+  alternates: {
+    canonical: 'https://aiquaa.com/assessments/clase9-cicd-github-actions',
+  },
+};
+
+export default function Clase9CicdGithubActionsPage() {
+  const overview = {
+    assessment: {
+      id: 'static-clase9-cicd-github-actions',
+      slug: clase9CicdGithubActionsDefinition.slug,
+      title: clase9CicdGithubActionsDefinition.title,
+      description: clase9CicdGithubActionsDefinition.description,
+      level: clase9CicdGithubActionsDefinition.level,
+      type: clase9CicdGithubActionsDefinition.type,
+      duration_minutes: clase9CicdGithubActionsDefinition.duration_minutes,
+      total_score: clase9CicdGithubActionsDefinition.total_score,
+      is_active: clase9CicdGithubActionsDefinition.is_active,
+      metadata: clase9CicdGithubActionsDefinition.metadata,
+    },
+    sections: clase9CicdGithubActionsDefinition.sections.map(
+      (section, index) => ({
+        id: `static-section-${index + 1}`,
+        assessment_id: 'static-clase9-cicd-github-actions',
+        slug: section.slug,
+        title: section.title,
+        description: section.description,
+        order_index: section.order_index,
+        max_score: section.max_score,
+        metadata: section.metadata,
+      })
+    ),
+  };
+
+  return (
+    <AssessmentWelcome
+      overview={overview}
+      startHref="/assessments/clase9-cicd-github-actions/start"
+      evaluatesCopy={
+        'El objetivo de CI/CD sobre los cambios de una API; los beneficios de la automatización; la práctica que inicia el ciclo de feedback rápido; la diferencia real entre Continuous Delivery y Continuous Deployment y los pasos que comparten; la secuencia completa del pipeline; los conceptos de Pipeline, Jobs, Steps, Triggers y Runners; la comparación entre GitHub Actions, Jenkins y Azure DevOps; los triggers y el orden de steps de un workflow; y la separación entre Variables y Secrets.'
+      }
+      scoringCopy="Automático en las 3 secciones: 9 preguntas de respuesta única y 1 de varias respuestas, con crédito parcial."
+      resultCopy="Score total, score por sección, fortalezas, debilidades y temas a reforzar."
+    />
+  );
+}

--- a/apps/frontend/src/app/assessments/clase9-cicd-github-actions/result/page.tsx
+++ b/apps/frontend/src/app/assessments/clase9-cicd-github-actions/result/page.tsx
@@ -1,0 +1,21 @@
+import { Suspense } from 'react';
+import AssessmentResultClient from '../../_shared/components/AssessmentResultClient';
+
+export default function Clase9CicdGithubActionsResultPage() {
+  return (
+    <Suspense
+      fallback={
+        <div className="min-h-screen flex items-center justify-center bg-slate-950">
+          <div className="h-10 w-10 animate-spin rounded-full border-t-2 border-cyan-400" />
+        </div>
+      }
+    >
+      <AssessmentResultClient
+        startHref="/assessments/clase9-cicd-github-actions/start"
+        fallbackRecommendation={
+          'Repasá el material de la Clase 9: beneficios de la automatización, Delivery frente a Deployment, las seis etapas del pipeline, los triggers pull_request/workflow_dispatch/push con el orden restore → build → test, y qué va en Variables y qué en Secrets.'
+        }
+      />
+    </Suspense>
+  );
+}

--- a/apps/frontend/src/app/assessments/clase9-cicd-github-actions/section/[sectionId]/page.tsx
+++ b/apps/frontend/src/app/assessments/clase9-cicd-github-actions/section/[sectionId]/page.tsx
@@ -1,0 +1,9 @@
+'use client';
+
+import AssessmentSectionScreen from '../../../_shared/components/AssessmentSectionScreen';
+
+export default function Clase9CicdGithubActionsSectionPage() {
+  return (
+    <AssessmentSectionScreen basePath="/assessments/clase9-cicd-github-actions" />
+  );
+}

--- a/apps/frontend/src/app/assessments/clase9-cicd-github-actions/start/page.tsx
+++ b/apps/frontend/src/app/assessments/clase9-cicd-github-actions/start/page.tsx
@@ -1,0 +1,137 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { useTheme } from '@/contexts/ThemeContext';
+import { startAssessmentAttemptAction } from '@/actions/assessments';
+import ProcessCodeInput from '@/components/labs/ProcessCodeInput';
+import { CLASE9_CICD_GITHUB_ACTIONS_SLUG } from '../data/assessment-definition';
+
+export default function StartClase9CicdGithubActionsPage() {
+  const router = useRouter();
+  const { isDarkMode } = useTheme();
+  const [processCode, setProcessCode] = useState('');
+  const [error, setError] = useState('');
+  const [isStarting, setIsStarting] = useState(false);
+
+  // Pre-fill desde ?code= (links de invitaciones/procesos de empresa)
+  useEffect(() => {
+    const codeParam = new URLSearchParams(window.location.search).get('code');
+    if (codeParam) setProcessCode(codeParam);
+  }, []);
+
+  async function handleStart() {
+    setError('');
+    setIsStarting(true);
+
+    try {
+      const result = await startAssessmentAttemptAction({
+        slug: CLASE9_CICD_GITHUB_ACTIONS_SLUG,
+        processCode,
+      });
+
+      if ('error' in result) {
+        setIsStarting(false);
+        setError(result.error);
+        return;
+      }
+
+      const { attempt, sectionSlug } = result;
+
+      if (!sectionSlug) {
+        setIsStarting(false);
+        setError('No se encontró la primera sección del assessment.');
+        return;
+      }
+
+      setIsStarting(false);
+      router.push(
+        `/assessments/clase9-cicd-github-actions/section/${sectionSlug}?attempt=${attempt.id}`
+      );
+    } catch (startError) {
+      setIsStarting(false);
+      setError(
+        startError instanceof Error
+          ? startError.message
+          : 'No se pudo iniciar el assessment.'
+      );
+    }
+  }
+
+  return (
+    <div
+      className={`min-h-screen px-4 py-12 ${
+        isDarkMode ? 'bg-slate-950 text-white' : 'bg-slate-50 text-slate-900'
+      }`}
+    >
+      <div className="mx-auto max-w-3xl rounded-3xl border border-slate-800 bg-slate-900/80 p-8 text-slate-50 shadow-2xl shadow-cyan-950/20">
+        <p className="text-sm font-semibold uppercase tracking-[0.18em] text-cyan-200">
+          Preparación del intento
+        </p>
+        <h1 className="mt-3 text-3xl font-bold">
+          Clase 9 — CI/CD con GitHub Actions
+        </h1>
+        <p className="mt-3 text-slate-300">
+          Vas a completar 3 secciones teóricas (10 preguntas en total) con
+          autosave, scoring por sección y resultado final consolidado.
+        </p>
+
+        <div className="mt-8 grid gap-4 rounded-2xl border border-slate-800 bg-slate-950/70 p-5 md:grid-cols-3">
+          <div>
+            <p className="text-xs uppercase tracking-[0.18em] text-slate-400">
+              Duración sugerida
+            </p>
+            <p className="mt-2 text-lg font-semibold">~20 minutos</p>
+          </div>
+          <div>
+            <p className="text-xs uppercase tracking-[0.18em] text-slate-400">
+              Modalidad
+            </p>
+            <p className="mt-2 text-lg font-semibold">Conceptual</p>
+          </div>
+          <div>
+            <p className="text-xs uppercase tracking-[0.18em] text-slate-400">
+              Resultado
+            </p>
+            <p className="mt-2 text-lg font-semibold">Score total sobre 100</p>
+          </div>
+        </div>
+
+        <div className="mt-8">
+          <ProcessCodeInput
+            value={processCode}
+            onChange={setProcessCode}
+            onNormalizedCode={setProcessCode}
+            autoValidate
+          />
+        </div>
+
+        {error ? (
+          <div className="mt-6 rounded-2xl border border-red-500/30 bg-red-500/10 px-4 py-3 text-sm text-red-200">
+            {error}
+          </div>
+        ) : null}
+
+        <div className="mt-8 flex flex-col gap-3 sm:flex-row">
+          <button
+            type="button"
+            onClick={handleStart}
+            disabled={isStarting}
+            className="inline-flex items-center justify-center rounded-2xl bg-cyan-400 px-5 py-3 text-sm font-semibold text-slate-950 transition hover:bg-cyan-300 disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {isStarting ? 'Preparando intento...' : 'Iniciar o reanudar'}
+          </button>
+          <button
+            type="button"
+            onClick={() =>
+              router.push('/assessments/clase9-cicd-github-actions')
+            }
+            className="inline-flex items-center justify-center rounded-2xl border border-slate-700 px-5 py-3 text-sm font-semibold text-slate-200 transition hover:bg-slate-800"
+          >
+            Volver al overview
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/src/app/assessments/page.tsx
+++ b/apps/frontend/src/app/assessments/page.tsx
@@ -11,10 +11,50 @@ import { infrastructureFundamentalsDefinition } from './infrastructure-fundament
 import { kubernetesHelmFundamentalsDefinition } from './kubernetes-helm-fundamentals/data/assessment-definition';
 import { observabilityFundamentalsDefinition } from './observability-fundamentals/data/assessment-definition';
 import { playwrightFundamentalsDefinition } from './playwright-fundamentals/data/assessment-definition';
+import { clase3DataPersistenciaDefinition } from './clase3-data-persistencia/data/assessment-definition';
+import { clase5KubernetesDefinition } from './clase5-kubernetes/data/assessment-definition';
+import { clase6ConfigKubernetesDefinition } from './clase6-config-kubernetes/data/assessment-definition';
+import { clase78SeqLoggingDefinition } from './clase7-8-seq-logging/data/assessment-definition';
+import { clase9CicdGithubActionsDefinition } from './clase9-cicd-github-actions/data/assessment-definition';
 
 export default function AssessmentsIndexPage() {
   const overview = apiTestingFundamentalsDefinition;
   const assessmentCards = [
+    {
+      definition: clase3DataPersistenciaDefinition,
+      badge: 'Examen teórico · Auto-corregido',
+      badgeColor: 'text-amber-300',
+      accentColor: 'text-violet-200',
+      buttonClass: 'bg-violet-500 hover:bg-violet-400',
+    },
+    {
+      definition: clase5KubernetesDefinition,
+      badge: 'Examen teórico · Auto-corregido',
+      badgeColor: 'text-amber-300',
+      accentColor: 'text-blue-200',
+      buttonClass: 'bg-blue-500 hover:bg-blue-400',
+    },
+    {
+      definition: clase6ConfigKubernetesDefinition,
+      badge: 'Examen teórico · Auto-corregido',
+      badgeColor: 'text-amber-300',
+      accentColor: 'text-teal-200',
+      buttonClass: 'bg-teal-500 hover:bg-teal-400',
+    },
+    {
+      definition: clase78SeqLoggingDefinition,
+      badge: 'Examen teórico · Auto-corregido',
+      badgeColor: 'text-amber-300',
+      accentColor: 'text-emerald-200',
+      buttonClass: 'bg-emerald-500 hover:bg-emerald-400',
+    },
+    {
+      definition: clase9CicdGithubActionsDefinition,
+      badge: 'Examen teórico · Auto-corregido',
+      badgeColor: 'text-amber-300',
+      accentColor: 'text-orange-200',
+      buttonClass: 'bg-orange-500 hover:bg-orange-400',
+    },
     {
       definition: databaseFundamentalsDefinition,
       badge: 'Examen teórico · Auto-corregido',

--- a/apps/frontend/src/app/dashboard/page.tsx
+++ b/apps/frontend/src/app/dashboard/page.tsx
@@ -90,6 +90,11 @@ export default function DashboardPage() {
     'cicd-fundamentals',
     'playwright-practico',
     'gherkin-fundamentals',
+    'clase3-data-persistencia',
+    'clase5-kubernetes',
+    'clase6-config-kubernetes',
+    'clase7-8-seq-logging',
+    'clase9-cicd-github-actions',
   ];
   const recommended = allTypes.find((t) => !passedTypes.has(t)) ?? null;
   const allPassed = allTypes.every((t) => passedTypes.has(t));

--- a/apps/frontend/src/app/empresa/candidatos/page.tsx
+++ b/apps/frontend/src/app/empresa/candidatos/page.tsx
@@ -25,6 +25,7 @@ import {
   type TalentCandidate,
 } from './candidateDirectory';
 import { createInvitacionAction } from '@/actions/empresa-invitaciones';
+import { reviewHrefFor } from '@/lib/exam-review-routes';
 
 type SectionScore = {
   section: string;
@@ -1485,9 +1486,9 @@ export default function CandidatosPage() {
                                       Contactar
                                     </a>
                                   )}
-                                  {r.exam_type === 'test-app' && (
+                                  {reviewHrefFor(r.exam_type, r.id) && (
                                     <Link
-                                      href={`/empresa/evaluar/${r.id}`}
+                                      href={reviewHrefFor(r.exam_type, r.id)!}
                                       className={`px-2.5 py-1 rounded-lg text-xs font-semibold transition-colors ${
                                         r.review_status === 'reviewed'
                                           ? isDarkMode

--- a/apps/frontend/src/app/empresa/evaluar-desarrollo/[resultId]/page.tsx
+++ b/apps/frontend/src/app/empresa/evaluar-desarrollo/[resultId]/page.tsx
@@ -1,0 +1,380 @@
+'use client';
+
+import Link from 'next/link';
+import { useEffect, useState } from 'react';
+import { useParams, useRouter } from 'next/navigation';
+import { useTheme } from '@/contexts/ThemeContext';
+import { useSupabaseAuth } from '@/contexts/SupabaseAuthContext';
+import {
+  getExamDetailAction,
+  saveExamReviewAction,
+  type ExamDetail,
+} from '@/actions/exam-review';
+import { getDesarrolloChallenge } from '@/lib/labs/desarrolloChallenges';
+
+const PASSING_SCORE = 70;
+const MAX_SCORE = 100;
+
+const REVIEW_STATUS_LABELS: Record<string, { text: string; color: string }> = {
+  pending: { text: 'Pendiente', color: 'bg-gray-100 text-gray-600' },
+  pending_correction: {
+    text: '⏳ Pendiente de corrección',
+    color: 'bg-amber-100 text-amber-700',
+  },
+  in_review: { text: 'En revisión', color: 'bg-blue-100 text-blue-700' },
+  reviewed: { text: '✅ Revisado', color: 'bg-green-100 text-green-700' },
+};
+
+export default function EvaluarDesarrolloPage() {
+  const { isDarkMode } = useTheme();
+  const { user, isLoading: authLoading } = useSupabaseAuth();
+  const params = useParams();
+  const router = useRouter();
+  const resultId = params?.resultId as string;
+
+  const [exam, setExam] = useState<ExamDetail | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [notFound, setNotFound] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const [savedOk, setSavedOk] = useState(false);
+
+  const [score, setScore] = useState<number | null>(null);
+  const [overallNotes, setOverallNotes] = useState('');
+
+  useEffect(() => {
+    if (authLoading) return;
+    if (!user) router.replace('/login');
+  }, [user, authLoading, router]);
+
+  useEffect(() => {
+    if (!resultId) return;
+    let cancelled = false;
+
+    (async () => {
+      const { data, error } = await getExamDetailAction(resultId);
+      if (cancelled) return;
+
+      if (error || !data) {
+        setNotFound(true);
+        setLoading(false);
+        return;
+      }
+
+      setExam(data);
+      setOverallNotes(data.review_data?.overallNotes ?? '');
+      setScore(
+        data.review_data?.adjustedScore ??
+          (data.review_status === 'reviewed' ? data.score : null)
+      );
+      setLoading(false);
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [resultId]);
+
+  const submission =
+    exam?.metadata && 'repoUrl' in exam.metadata ? exam.metadata : null;
+  const challenge = submission
+    ? getDesarrolloChallenge(submission.challengeId)
+    : undefined;
+
+  const handleSave = async (status: 'in_review' | 'reviewed') => {
+    if (status === 'reviewed' && score == null) {
+      setSaveError('Cargá un puntaje antes de finalizar la corrección.');
+      return;
+    }
+
+    setSaving(true);
+    setSaveError(null);
+
+    const finalScore =
+      status === 'reviewed' && score != null
+        ? {
+            score,
+            percentage: score, // el máximo es 100, score y porcentaje coinciden
+            passed: score >= PASSING_SCORE,
+          }
+        : undefined;
+
+    const { error } = await saveExamReviewAction(
+      resultId,
+      { overallNotes, adjustedScore: score },
+      status,
+      finalScore
+    );
+
+    setSaving(false);
+    if (error) {
+      setSaveError(error);
+      return;
+    }
+    setSavedOk(true);
+    setTimeout(() => setSavedOk(false), 3000);
+    if (status === 'reviewed') {
+      setExam((prev) => (prev ? { ...prev, review_status: 'reviewed' } : prev));
+    }
+  };
+
+  const cardClass = `rounded-xl border p-6 ${
+    isDarkMode ? 'bg-slate-800 border-slate-700' : 'bg-white border-gray-200'
+  }`;
+  const mutedClass = isDarkMode ? 'text-slate-400' : 'text-gray-500';
+  const labelClass = `block text-sm font-medium mb-1.5 ${isDarkMode ? 'text-slate-300' : 'text-gray-700'}`;
+
+  if (authLoading || loading) {
+    return (
+      <div
+        className={`min-h-screen flex items-center justify-center ${isDarkMode ? 'bg-dark-bg' : 'bg-gray-50'}`}
+      >
+        <div className="h-10 w-10 animate-spin rounded-full border-t-2 border-indigo-500" />
+      </div>
+    );
+  }
+
+  if (notFound || !exam) {
+    return (
+      <div
+        className={`min-h-screen flex flex-col items-center justify-center gap-4 ${isDarkMode ? 'bg-dark-bg text-white' : 'bg-gray-50 text-gray-900'}`}
+      >
+        <p className="text-lg font-semibold">Resultado no encontrado</p>
+        <Link href="/empresa/candidatos" className="text-indigo-500 underline">
+          Volver a candidatos
+        </Link>
+      </div>
+    );
+  }
+
+  const statusLabel = REVIEW_STATUS_LABELS[exam.review_status] ?? {
+    text: exam.review_status,
+    color: 'bg-gray-100 text-gray-600',
+  };
+
+  return (
+    <div
+      className={`min-h-screen transition-colors duration-300 ${isDarkMode ? 'bg-dark-bg' : 'bg-gray-50'}`}
+    >
+      <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-12 space-y-6">
+        <header className="space-y-2">
+          <Link
+            href="/empresa/candidatos"
+            className={`text-sm ${mutedClass} hover:underline`}
+          >
+            ← Volver a candidatos
+          </Link>
+          <div className="flex flex-wrap items-center gap-3">
+            <h1
+              className={`text-2xl font-bold ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
+            >
+              {challenge
+                ? `${challenge.emoji} ${challenge.title}`
+                : 'Prueba de desarrollo'}
+            </h1>
+            <span
+              className={`px-2.5 py-1 rounded-lg text-xs font-semibold ${statusLabel.color}`}
+            >
+              {statusLabel.text}
+            </span>
+          </div>
+          <p className={`text-sm ${mutedClass}`}>
+            {exam.participant_name ?? 'Candidato sin nombre'}
+            {exam.participant_email ? ` · ${exam.participant_email}` : ''}
+            {exam.process_code ? ` · proceso ${exam.process_code}` : ''}
+          </p>
+        </header>
+
+        {/* Entrega */}
+        <section className={`${cardClass} space-y-4`}>
+          <h2
+            className={`text-lg font-semibold ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
+          >
+            Entrega del candidato
+          </h2>
+
+          {submission ? (
+            <>
+              <div>
+                <p className={labelClass}>Repositorio</p>
+                <a
+                  href={submission.repoUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-sm font-mono text-indigo-500 underline break-all"
+                >
+                  {submission.repoUrl}
+                </a>
+                <p className={`text-xs mt-1 ${mutedClass}`}>
+                  Link enviado por el candidato. Se abre en una pestaña nueva.
+                </p>
+              </div>
+
+              {submission.githubUser ? (
+                <div>
+                  <p className={labelClass}>Usuario de GitHub</p>
+                  <p
+                    className={`text-sm font-mono ${isDarkMode ? 'text-slate-300' : 'text-gray-700'}`}
+                  >
+                    {submission.githubUser}
+                  </p>
+                </div>
+              ) : null}
+
+              {submission.notes ? (
+                <div>
+                  <p className={labelClass}>Notas del candidato</p>
+                  <p
+                    className={`text-sm whitespace-pre-wrap ${isDarkMode ? 'text-slate-300' : 'text-gray-700'}`}
+                  >
+                    {submission.notes}
+                  </p>
+                </div>
+              ) : null}
+
+              <p className={`text-xs ${mutedClass}`}>
+                Entregado el{' '}
+                {new Date(
+                  submission.submittedAt ?? exam.created_at
+                ).toLocaleString('es-PY')}
+              </p>
+            </>
+          ) : (
+            <p className={`text-sm ${mutedClass}`}>
+              Este resultado no tiene una entrega de repositorio asociada.
+            </p>
+          )}
+        </section>
+
+        {/* Consigna y criterios */}
+        {challenge ? (
+          <section className={`${cardClass} space-y-4`}>
+            <h2
+              className={`text-lg font-semibold ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
+            >
+              Qué se le pidió ({challenge.clase})
+            </h2>
+            <ol
+              className={`list-decimal space-y-2 pl-5 text-sm ${isDarkMode ? 'text-slate-300' : 'text-gray-700'}`}
+            >
+              {challenge.consigna.map((item, index) => (
+                <li key={index}>{item}</li>
+              ))}
+            </ol>
+
+            <div>
+              <p className={`${labelClass} mt-4`}>Criterios de evaluación</p>
+              <ul
+                className={`list-disc space-y-2 pl-5 text-sm ${isDarkMode ? 'text-slate-300' : 'text-gray-700'}`}
+              >
+                {challenge.criteriosDeEvaluacion.map((item, index) => (
+                  <li key={index}>{item}</li>
+                ))}
+              </ul>
+            </div>
+          </section>
+        ) : null}
+
+        {/* Corrección */}
+        <section className={`${cardClass} space-y-4`}>
+          <h2
+            className={`text-lg font-semibold ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
+          >
+            Corrección
+          </h2>
+
+          <div>
+            <label className={labelClass} htmlFor="puntaje">
+              Puntaje (0 a {MAX_SCORE}) *
+            </label>
+            <input
+              id="puntaje"
+              type="number"
+              min={0}
+              max={MAX_SCORE}
+              value={score ?? ''}
+              onChange={(e) => {
+                const raw = e.target.value;
+                if (raw === '') {
+                  setScore(null);
+                  return;
+                }
+                const parsed = Number(raw);
+                if (Number.isNaN(parsed)) return;
+                setScore(Math.min(MAX_SCORE, Math.max(0, Math.round(parsed))));
+              }}
+              className={`w-32 rounded-lg border px-3 py-2 text-sm outline-none transition-colors focus:ring-2 focus:ring-indigo-500 ${
+                isDarkMode
+                  ? 'bg-slate-700 border-slate-600 text-white'
+                  : 'bg-white border-gray-300 text-gray-900'
+              }`}
+            />
+            <p className={`text-xs mt-1 ${mutedClass}`}>
+              Se aprueba con {PASSING_SCORE}.{' '}
+              {score != null
+                ? score >= PASSING_SCORE
+                  ? 'Con este puntaje el candidato aprueba.'
+                  : 'Con este puntaje el candidato no aprueba.'
+                : ''}
+            </p>
+          </div>
+
+          <div>
+            <label className={labelClass} htmlFor="comentarios">
+              Comentarios para el candidato
+            </label>
+            <textarea
+              id="comentarios"
+              value={overallNotes}
+              onChange={(e) => setOverallNotes(e.target.value)}
+              placeholder="Qué resolvió bien, qué faltó, qué reforzar..."
+              className={`w-full min-h-32 rounded-lg border px-3 py-2 text-sm outline-none transition-colors focus:ring-2 focus:ring-indigo-500 ${
+                isDarkMode
+                  ? 'bg-slate-700 border-slate-600 text-white placeholder-slate-400'
+                  : 'bg-white border-gray-300 text-gray-900 placeholder-gray-400'
+              }`}
+            />
+          </div>
+
+          {saveError && (
+            <div className="rounded-lg border border-red-300 bg-red-50 text-red-700 px-4 py-3 text-sm dark:border-red-700/50 dark:bg-red-900/20 dark:text-red-300">
+              {saveError}
+            </div>
+          )}
+          {savedOk && (
+            <div className="rounded-lg border border-emerald-300 bg-emerald-50 text-emerald-700 px-4 py-3 text-sm dark:border-emerald-700/50 dark:bg-emerald-900/20 dark:text-emerald-300">
+              Cambios guardados.
+            </div>
+          )}
+
+          <div className="flex flex-col gap-3 sm:flex-row">
+            <button
+              type="button"
+              onClick={() => handleSave('in_review')}
+              disabled={saving}
+              className={`rounded-lg border px-4 py-2.5 text-sm font-semibold transition-colors disabled:opacity-50 ${
+                isDarkMode
+                  ? 'border-slate-600 text-slate-200 hover:bg-slate-700'
+                  : 'border-gray-300 text-gray-700 hover:bg-gray-50'
+              }`}
+            >
+              Guardar borrador
+            </button>
+            <button
+              type="button"
+              onClick={() => handleSave('reviewed')}
+              disabled={saving || score == null}
+              className="rounded-lg bg-indigo-600 px-4 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-indigo-700 disabled:opacity-50"
+            >
+              {saving ? 'Guardando...' : 'Finalizar corrección'}
+            </button>
+          </div>
+          <p className={`text-xs ${mutedClass}`}>
+            Al finalizar la corrección, el puntaje cargado pasa a ser el puntaje
+            oficial del examen y el candidato lo ve en su perfil.
+          </p>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/src/app/empresa/evaluar/[resultId]/page.tsx
+++ b/apps/frontend/src/app/empresa/evaluar/[resultId]/page.tsx
@@ -128,7 +128,8 @@ export default function EvaluarPage() {
       setExam(data);
 
       const initialReviews: BugReviewMap = {};
-      const bugs = data.metadata?.bugs ?? [];
+      const bugs =
+        data.metadata && 'bugs' in data.metadata ? data.metadata.bugs : [];
       const savedReview = data.review_data;
       bugs.forEach((bug) => {
         const saved = savedReview?.bugs?.[bug.id];
@@ -146,7 +147,8 @@ export default function EvaluarPage() {
     load();
   }, [resultId]);
 
-  const bugs = exam?.metadata?.bugs ?? [];
+  const bugs =
+    exam?.metadata && 'bugs' in exam.metadata ? exam.metadata.bugs : [];
   const autoScore = exam?.score ?? 0;
 
   const approvedCount = Object.values(bugReviews).filter(

--- a/apps/frontend/src/app/empresa/procesos/[id]/page.tsx
+++ b/apps/frontend/src/app/empresa/procesos/[id]/page.tsx
@@ -14,6 +14,7 @@ import {
   type Prospect,
   type ProspectStatus,
 } from '@/actions/prospects';
+import { reviewHrefFor } from '@/lib/exam-review-routes';
 
 type HiringProcess = {
   id: string;
@@ -910,9 +911,9 @@ export default function ProcesoDetailPage() {
                         >
                           {mins(r.time_spent)}
                         </span>
-                        {r.exam_type === 'test-app' && (
+                        {reviewHrefFor(r.exam_type, r.id) && (
                           <Link
-                            href={`/empresa/evaluar/${r.id}`}
+                            href={reviewHrefFor(r.exam_type, r.id)!}
                             className={`text-xs px-2 py-1 rounded-lg font-semibold transition-colors shrink-0 ${
                               r.review_status === 'reviewed'
                                 ? isDarkMode
@@ -1026,9 +1027,9 @@ export default function ProcesoDetailPage() {
                             {new Date(r.created_at).toLocaleDateString('es-PY')}
                           </td>
                           <td className="px-5 py-3">
-                            {r.exam_type === 'test-app' && (
+                            {reviewHrefFor(r.exam_type, r.id) && (
                               <Link
-                                href={`/empresa/evaluar/${r.id}`}
+                                href={reviewHrefFor(r.exam_type, r.id)!}
                                 className={`text-xs px-2.5 py-1 rounded-lg font-semibold transition-colors ${
                                   r.review_status === 'reviewed'
                                     ? isDarkMode

--- a/apps/frontend/src/app/empresa/procesos/nuevo/page.tsx
+++ b/apps/frontend/src/app/empresa/procesos/nuevo/page.tsx
@@ -144,34 +144,10 @@ const EXAM_OPTIONS = [
       'Delivery vs Deployment, etapas del pipeline, Jobs/Steps/Triggers/Runners, workflows y separación Variables/Secrets — auto-corregido, 10 preguntas, 100 pts',
   },
   {
-    id: 'dev-persistencia',
-    label: 'Clase 3 — Persistencia con EF Core (Prueba de desarrollo)',
+    id: 'dev-proyecto-final',
+    label: 'Proyecto final: API + Kubernetes + CI/CD (Prueba de desarrollo)',
     description:
-      'API .NET con EF Core, PostgreSQL, migraciones, DTOs y FluentValidation — entrega por link de repositorio, corrección manual del evaluador sobre 100 pts',
-  },
-  {
-    id: 'dev-kubernetes',
-    label: 'Clase 5 — Despliegue en Kubernetes (Prueba de desarrollo)',
-    description:
-      'Manifiestos de Deployment, Service y StatefulSet en Minikube, con evidencia de autorecuperación y escalado — entrega por link de repositorio, corrección manual sobre 100 pts',
-  },
-  {
-    id: 'dev-config-kubernetes',
-    label: 'Clase 6 — ConfigMaps, Secrets y Helm (Prueba de desarrollo)',
-    description:
-      'Configuración externalizada con ConfigMap y Secret, inyección con envFrom y chart de Helm con values por entorno — entrega por link de repositorio, corrección manual sobre 100 pts',
-  },
-  {
-    id: 'dev-seq-logging',
-    label: 'Clases 7 y 8 — Serilog y Seq (Prueba de desarrollo)',
-    description:
-      'Logging estructurado con Serilog, sinks a consola y Seq, niveles de severidad y Seq desplegado en el clúster — entrega por link de repositorio, corrección manual sobre 100 pts',
-  },
-  {
-    id: 'dev-cicd-actions',
-    label: 'Clase 9 — Pipeline con GitHub Actions (Prueba de desarrollo)',
-    description:
-      'Workflow con triggers push/pull_request/workflow_dispatch, orden restore→build→test, publicación de imagen y separación Variables/Secrets — entrega por link de repositorio, corrección manual sobre 100 pts',
+      'Integra las 5 clases en un solo repo: API .NET con EF Core/PostgreSQL, despliegue en Kubernetes, configuración con ConfigMaps/Secrets/Helm, logging con Serilog/Seq y pipeline de GitHub Actions — entrega por link de repositorio, corrección manual del evaluador sobre 100 pts',
   },
   {
     id: 'test-app',

--- a/apps/frontend/src/app/empresa/procesos/nuevo/page.tsx
+++ b/apps/frontend/src/app/empresa/procesos/nuevo/page.tsx
@@ -114,6 +114,66 @@ const EXAM_OPTIONS = [
       'Fundamentos de BDD, sintaxis Gherkin (Given/When/Then) y escenarios avanzados aplicados a testing — auto-corregido, 3 niveles',
   },
   {
+    id: 'clase3-data-persistencia',
+    label: 'Clase 3 — Data Persistencia (Examen teórico)',
+    description:
+      'Persistencia, ADO.NET vs Entity Framework Core, migraciones, PostgreSQL/Npgsql, DTOs y FluentValidation — auto-corregido, 10 preguntas, 100 pts',
+  },
+  {
+    id: 'clase5-kubernetes',
+    label: 'Clase 5 — Kubernetes (Examen teórico)',
+    description:
+      'Pilares de la orquestación, arquitectura del clúster, Pods, Deployment/ReplicaSet, StatefulSet y Services — auto-corregido, 10 preguntas, 100 pts',
+  },
+  {
+    id: 'clase6-config-kubernetes',
+    label: 'Clase 6 — Configuración en Kubernetes (Examen teórico)',
+    description:
+      'Inmutabilidad de la imagen, ConfigMaps, Secrets y Base64, inyección con envFrom, Helm y CI/CD de configuración — auto-corregido, 10 preguntas, 100 pts',
+  },
+  {
+    id: 'clase7-8-seq-logging',
+    label: 'Clases 7 y 8 — SEQ Structured Logging (Examen teórico)',
+    description:
+      'Límites de kubectl logs, logs estructurados, Serilog y sus sinks, niveles de severidad y Seq en Kubernetes — auto-corregido, 10 preguntas, 100 pts',
+  },
+  {
+    id: 'clase9-cicd-github-actions',
+    label: 'Clase 9 — CI/CD con GitHub Actions (Examen teórico)',
+    description:
+      'Delivery vs Deployment, etapas del pipeline, Jobs/Steps/Triggers/Runners, workflows y separación Variables/Secrets — auto-corregido, 10 preguntas, 100 pts',
+  },
+  {
+    id: 'dev-persistencia',
+    label: 'Clase 3 — Persistencia con EF Core (Prueba de desarrollo)',
+    description:
+      'API .NET con EF Core, PostgreSQL, migraciones, DTOs y FluentValidation — entrega por link de repositorio, corrección manual del evaluador sobre 100 pts',
+  },
+  {
+    id: 'dev-kubernetes',
+    label: 'Clase 5 — Despliegue en Kubernetes (Prueba de desarrollo)',
+    description:
+      'Manifiestos de Deployment, Service y StatefulSet en Minikube, con evidencia de autorecuperación y escalado — entrega por link de repositorio, corrección manual sobre 100 pts',
+  },
+  {
+    id: 'dev-config-kubernetes',
+    label: 'Clase 6 — ConfigMaps, Secrets y Helm (Prueba de desarrollo)',
+    description:
+      'Configuración externalizada con ConfigMap y Secret, inyección con envFrom y chart de Helm con values por entorno — entrega por link de repositorio, corrección manual sobre 100 pts',
+  },
+  {
+    id: 'dev-seq-logging',
+    label: 'Clases 7 y 8 — Serilog y Seq (Prueba de desarrollo)',
+    description:
+      'Logging estructurado con Serilog, sinks a consola y Seq, niveles de severidad y Seq desplegado en el clúster — entrega por link de repositorio, corrección manual sobre 100 pts',
+  },
+  {
+    id: 'dev-cicd-actions',
+    label: 'Clase 9 — Pipeline con GitHub Actions (Prueba de desarrollo)',
+    description:
+      'Workflow con triggers push/pull_request/workflow_dispatch, orden restore→build→test, publicación de imagen y separación Variables/Secrets — entrega por link de repositorio, corrección manual sobre 100 pts',
+  },
+  {
     id: 'test-app',
     label: 'Test App — Exploratory Testing & Bug Hunt',
     description:

--- a/apps/frontend/src/app/invitaciones/[token]/page.tsx
+++ b/apps/frontend/src/app/invitaciones/[token]/page.tsx
@@ -28,11 +28,7 @@ const EXAM_LABELS: Record<string, string> = {
   'clase6-config-kubernetes': 'Clase 6 — Configuración en Kubernetes',
   'clase7-8-seq-logging': 'Clases 7 y 8 — SEQ Structured Logging',
   'clase9-cicd-github-actions': 'Clase 9 — CI/CD con GitHub Actions',
-  'dev-persistencia': 'Clase 3 — Desarrollo: Persistencia con EF Core',
-  'dev-kubernetes': 'Clase 5 — Desarrollo: Despliegue en Kubernetes',
-  'dev-config-kubernetes': 'Clase 6 — Desarrollo: ConfigMaps, Secrets y Helm',
-  'dev-seq-logging': 'Clases 7 y 8 — Desarrollo: Serilog y Seq',
-  'dev-cicd-actions': 'Clase 9 — Desarrollo: Pipeline con GitHub Actions',
+  'dev-proyecto-final': 'Proyecto final — Desarrollo integrador',
 };
 
 type Props = { params: Promise<{ token: string }> };

--- a/apps/frontend/src/app/invitaciones/[token]/page.tsx
+++ b/apps/frontend/src/app/invitaciones/[token]/page.tsx
@@ -16,6 +16,23 @@ const EXAM_LABELS: Record<string, string> = {
   'infrastructure-fundamentals': 'Infraestructura — Fundamentos',
   'api-developer-fundamentals': 'APIs para Desarrolladores — Fundamentos',
   'gherkin-fundamentals': 'Gherkin y BDD — Fundamentos',
+  'api-dotnet-fundamentals': 'API .NET — Fundamentos',
+  'docker-fundamentals': 'Docker — Fundamentos',
+  'kubernetes-helm-fundamentals': 'Kubernetes + Helm — Fundamentos',
+  'observability-fundamentals': 'Observabilidad — Fundamentos',
+  'cicd-fundamentals': 'CI/CD — Fundamentos',
+  'playwright-fundamentals': 'Playwright — Fundamentos',
+  'test-app': 'Test App — Bug Hunt',
+  'clase3-data-persistencia': 'Clase 3 — Data Persistencia',
+  'clase5-kubernetes': 'Clase 5 — Kubernetes',
+  'clase6-config-kubernetes': 'Clase 6 — Configuración en Kubernetes',
+  'clase7-8-seq-logging': 'Clases 7 y 8 — SEQ Structured Logging',
+  'clase9-cicd-github-actions': 'Clase 9 — CI/CD con GitHub Actions',
+  'dev-persistencia': 'Clase 3 — Desarrollo: Persistencia con EF Core',
+  'dev-kubernetes': 'Clase 5 — Desarrollo: Despliegue en Kubernetes',
+  'dev-config-kubernetes': 'Clase 6 — Desarrollo: ConfigMaps, Secrets y Helm',
+  'dev-seq-logging': 'Clases 7 y 8 — Desarrollo: Serilog y Seq',
+  'dev-cicd-actions': 'Clase 9 — Desarrollo: Pipeline con GitHub Actions',
 };
 
 type Props = { params: Promise<{ token: string }> };

--- a/apps/frontend/src/app/labs/desarrollo/[challengeId]/DesarrolloChallengeClient.tsx
+++ b/apps/frontend/src/app/labs/desarrollo/[challengeId]/DesarrolloChallengeClient.tsx
@@ -1,0 +1,367 @@
+'use client';
+
+import { useState } from 'react';
+import Link from 'next/link';
+import { useTheme } from '@/contexts/ThemeContext';
+import { useToolUsage } from '@/hooks/useToolUsage';
+import { validateProcessCodeAction } from '@/actions/employer';
+import { saveExamResultAction } from '@/actions/exams';
+import {
+  isValidRepoUrl,
+  type DesarrolloChallenge,
+} from '@/lib/labs/desarrolloChallenges';
+
+interface ResolvedProcess {
+  code: string;
+  position_name: string;
+  company_name: string;
+}
+
+export default function DesarrolloChallengeClient({
+  challenge,
+}: {
+  challenge: DesarrolloChallenge;
+}) {
+  const { isDarkMode } = useTheme();
+  const { logUsage, logError } = useToolUsage(challenge.id);
+
+  const [code, setCode] = useState('');
+  const [validating, setValidating] = useState(false);
+  const [process, setProcess] = useState<ResolvedProcess | null>(null);
+  const [gateError, setGateError] = useState<string | null>(null);
+
+  const [github, setGithub] = useState('');
+  const [repoUrl, setRepoUrl] = useState('');
+  const [notes, setNotes] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [formError, setFormError] = useState<string | null>(null);
+  const [submitted, setSubmitted] = useState(false);
+
+  const handleValidate = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!code.trim()) return;
+    setValidating(true);
+    setGateError(null);
+    try {
+      const {
+        valid,
+        process: p,
+        reason,
+      } = await validateProcessCodeAction(code.trim());
+      if (!valid || !p) {
+        setGateError(
+          reason === 'expired'
+            ? 'El proceso está vencido.'
+            : 'Código inválido. Revisá el código que te dio la empresa.'
+        );
+        return;
+      }
+      if (!(p.exam_types ?? []).includes(challenge.examType)) {
+        setGateError(`Este código no incluye la prueba "${challenge.title}".`);
+        return;
+      }
+      setProcess({
+        code: p.code,
+        position_name: p.position_name,
+        company_name: p.company_name,
+      });
+      void logUsage('start');
+    } catch (err) {
+      setGateError('No se pudo validar el código. Intentá de nuevo.');
+      void logError(err, 'validate');
+    } finally {
+      setValidating(false);
+    }
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!process) return;
+
+    const trimmedRepo = repoUrl.trim();
+    if (!isValidRepoUrl(trimmedRepo)) {
+      setFormError(
+        'La URL debe ser la raíz de un repositorio público de GitHub, con la forma https://github.com/usuario/repositorio'
+      );
+      return;
+    }
+
+    setSubmitting(true);
+    setFormError(null);
+    try {
+      // Score 0 a propósito: el examen entra como `pending_correction` y el
+      // puntaje real lo carga el profesor desde /empresa/evaluar-desarrollo.
+      const result = await saveExamResultAction({
+        exam_type: challenge.examType,
+        exam_mode: 'exam',
+        process_code: process.code,
+        github_profile: github.trim() || undefined,
+        company_name: process.company_name,
+        score: 0,
+        total_questions: 1,
+        max_possible_score: 100,
+        correct_answers: 0,
+        incorrect_answers: 0,
+        passing_score: 70,
+        passed: false,
+        percentage: 0,
+        time_spent: 0,
+        metadata: {
+          challengeId: challenge.id,
+          repoUrl: trimmedRepo,
+          githubUser: github.trim(),
+          notes: notes.trim(),
+          submittedAt: new Date().toISOString(),
+        },
+      });
+
+      if ('error' in result && result.error) {
+        setFormError(result.error);
+        return;
+      }
+
+      setSubmitted(true);
+      void logUsage('submit');
+    } catch (err) {
+      setFormError('No se pudo registrar la entrega. Intentá de nuevo.');
+      void logError(err, 'submit');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const inputClass = `w-full rounded-lg border px-3 py-2 text-sm outline-none transition-colors focus:ring-2 focus:ring-indigo-500 ${
+    isDarkMode
+      ? 'bg-slate-700 border-slate-600 text-white placeholder-slate-400'
+      : 'bg-white border-gray-300 text-gray-900 placeholder-gray-400'
+  }`;
+  const labelClass = `block text-sm font-medium mb-1.5 ${isDarkMode ? 'text-slate-300' : 'text-gray-700'}`;
+  const cardClass = `rounded-xl border p-6 ${isDarkMode ? 'bg-dark-secondary border-slate-700' : 'bg-white border-gray-200'}`;
+  const mutedClass = isDarkMode ? 'text-slate-400' : 'text-gray-500';
+
+  return (
+    <div
+      className={`min-h-screen transition-colors duration-300 ${isDarkMode ? 'bg-dark-bg' : 'bg-gray-50'}`}
+    >
+      <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-12 space-y-6">
+        <header>
+          <p
+            className={`text-xs font-semibold uppercase tracking-[0.18em] ${mutedClass}`}
+          >
+            {challenge.clase} · Prueba de desarrollo
+          </p>
+          <h1
+            className={`text-2xl font-bold mt-1 ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
+          >
+            {challenge.emoji} {challenge.title}
+          </h1>
+          <p className={`text-sm mt-2 ${mutedClass}`}>{challenge.objetivo}</p>
+          <p className={`text-xs mt-3 ${mutedClass}`}>
+            Duración estimada: ~{Math.round(challenge.duracionEstimadaMin / 60)}{' '}
+            horas · Entrega: link del repositorio · Corrección manual del
+            evaluador sobre 100 puntos.
+          </p>
+        </header>
+
+        {/* Step 0 — gate por código */}
+        {!process && (
+          <form onSubmit={handleValidate} className={`${cardClass} space-y-4`}>
+            <div>
+              <label className={labelClass}>Código del proceso *</label>
+              <input
+                type="text"
+                className={`${inputClass} font-mono tracking-wider`}
+                placeholder="ej. AIQUAA-2026-X7K"
+                value={code}
+                onChange={(e) => setCode(e.target.value.toUpperCase())}
+                required
+              />
+              <p className={`text-xs mt-1 ${mutedClass}`}>
+                Es el código que te compartió la empresa para esta prueba.
+              </p>
+            </div>
+            {gateError && (
+              <div className="rounded-lg border border-red-300 bg-red-50 text-red-700 px-4 py-3 text-sm dark:border-red-700/50 dark:bg-red-900/20 dark:text-red-300">
+                {gateError}
+              </div>
+            )}
+            <button
+              type="submit"
+              disabled={validating || !code.trim()}
+              className="w-full py-2.5 rounded-lg text-sm font-semibold bg-indigo-600 text-white hover:bg-indigo-700 disabled:opacity-50 transition-colors"
+            >
+              {validating ? 'Validando...' : 'Continuar'}
+            </button>
+          </form>
+        )}
+
+        {process && (
+          <>
+            <div className={`${cardClass} space-y-1`}>
+              <p
+                className={`text-sm font-semibold ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
+              >
+                {process.position_name}
+              </p>
+              <p className={`text-xs ${mutedClass}`}>
+                {process.company_name} · código{' '}
+                <span className="font-mono">{process.code}</span>
+              </p>
+            </div>
+
+            <section className={`${cardClass} space-y-4`}>
+              <h2
+                className={`text-lg font-semibold ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
+              >
+                Consigna
+              </h2>
+              <ol
+                className={`list-decimal space-y-2 pl-5 text-sm ${isDarkMode ? 'text-slate-300' : 'text-gray-700'}`}
+              >
+                {challenge.consigna.map((item, index) => (
+                  <li key={index}>{item}</li>
+                ))}
+              </ol>
+            </section>
+
+            <section className={`${cardClass} space-y-4`}>
+              <h2
+                className={`text-lg font-semibold ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
+              >
+                Entregables
+              </h2>
+              <ul
+                className={`list-disc space-y-2 pl-5 text-sm ${isDarkMode ? 'text-slate-300' : 'text-gray-700'}`}
+              >
+                {challenge.entregables.map((item, index) => (
+                  <li key={index}>{item}</li>
+                ))}
+              </ul>
+
+              <div>
+                <p className={`${labelClass} mb-2`}>Estructura sugerida</p>
+                <pre
+                  className={`overflow-x-auto rounded-lg border p-4 text-xs font-mono ${
+                    isDarkMode
+                      ? 'border-slate-700 bg-slate-900 text-slate-300'
+                      : 'border-gray-200 bg-gray-50 text-gray-700'
+                  }`}
+                >
+                  {challenge.estructuraEsperada}
+                </pre>
+              </div>
+            </section>
+
+            <section className={`${cardClass} space-y-3`}>
+              <h2
+                className={`text-lg font-semibold ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
+              >
+                Cómo se evalúa
+              </h2>
+              <p className={`text-sm ${mutedClass}`}>
+                Un evaluador revisa tu repositorio después de la entrega y
+                asigna un puntaje de 0 a 100. Se aprueba con 70.
+              </p>
+              <ul
+                className={`list-disc space-y-2 pl-5 text-sm ${isDarkMode ? 'text-slate-300' : 'text-gray-700'}`}
+              >
+                {challenge.criteriosDeEvaluacion.map((item, index) => (
+                  <li key={index}>{item}</li>
+                ))}
+              </ul>
+            </section>
+
+            {/* Entrega */}
+            {submitted ? (
+              <div className={`${cardClass} space-y-3`}>
+                <h2 className="text-lg font-semibold text-emerald-500">
+                  ✅ Entrega registrada
+                </h2>
+                <p
+                  className={`text-sm ${isDarkMode ? 'text-slate-300' : 'text-gray-700'}`}
+                >
+                  Tu repositorio quedó registrado y está pendiente de
+                  corrección. Cuando el evaluador cargue el puntaje vas a verlo
+                  en tu perfil.
+                </p>
+                <p className={`text-xs font-mono break-all ${mutedClass}`}>
+                  {repoUrl.trim()}
+                </p>
+                <Link
+                  href="/perfil"
+                  className="inline-flex items-center justify-center rounded-lg bg-indigo-600 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-indigo-700"
+                >
+                  Ir a mi perfil
+                </Link>
+              </div>
+            ) : (
+              <form
+                onSubmit={handleSubmit}
+                className={`${cardClass} space-y-4`}
+              >
+                <h2
+                  className={`text-lg font-semibold ${isDarkMode ? 'text-white' : 'text-gray-900'}`}
+                >
+                  Entregar
+                </h2>
+
+                <div>
+                  <label className={labelClass}>Usuario de GitHub</label>
+                  <input
+                    type="text"
+                    className={inputClass}
+                    placeholder="ej. stevenayal"
+                    value={github}
+                    onChange={(e) => setGithub(e.target.value)}
+                  />
+                </div>
+
+                <div>
+                  <label className={labelClass}>URL del repositorio *</label>
+                  <input
+                    type="url"
+                    className={inputClass}
+                    placeholder="https://github.com/usuario/repositorio"
+                    value={repoUrl}
+                    onChange={(e) => setRepoUrl(e.target.value)}
+                    required
+                  />
+                  <p className={`text-xs mt-1 ${mutedClass}`}>
+                    Tiene que ser la raíz de un repositorio público de GitHub, y
+                    debe seguir accesible hasta que el evaluador lo revise.
+                  </p>
+                </div>
+
+                <div>
+                  <label className={labelClass}>Notas para el evaluador</label>
+                  <textarea
+                    className={`${inputClass} min-h-28`}
+                    placeholder="Decisiones de diseño, qué quedó pendiente, cómo levantar el proyecto..."
+                    value={notes}
+                    onChange={(e) => setNotes(e.target.value)}
+                  />
+                </div>
+
+                {formError && (
+                  <div className="rounded-lg border border-red-300 bg-red-50 text-red-700 px-4 py-3 text-sm dark:border-red-700/50 dark:bg-red-900/20 dark:text-red-300">
+                    {formError}
+                  </div>
+                )}
+
+                <button
+                  type="submit"
+                  disabled={submitting || !repoUrl.trim()}
+                  className="w-full py-2.5 rounded-lg text-sm font-semibold bg-indigo-600 text-white hover:bg-indigo-700 disabled:opacity-50 transition-colors"
+                >
+                  {submitting
+                    ? 'Registrando entrega...'
+                    : 'Entregar repositorio'}
+                </button>
+              </form>
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/src/app/labs/desarrollo/[challengeId]/page.tsx
+++ b/apps/frontend/src/app/labs/desarrollo/[challengeId]/page.tsx
@@ -1,0 +1,72 @@
+import type { Metadata } from 'next';
+import { notFound } from 'next/navigation';
+import DesarrolloChallengeClient from './DesarrolloChallengeClient';
+import {
+  DESARROLLO_CHALLENGE_IDS,
+  getDesarrolloChallenge,
+} from '@/lib/labs/desarrolloChallenges';
+
+interface PageProps {
+  params: { challengeId: string };
+}
+
+export function generateStaticParams() {
+  return DESARROLLO_CHALLENGE_IDS.map((challengeId) => ({ challengeId }));
+}
+
+export function generateMetadata({ params }: PageProps): Metadata {
+  const challenge = getDesarrolloChallenge(params.challengeId);
+  if (!challenge) return { title: 'Prueba de desarrollo | AIQUAA Labs' };
+
+  const title = `${challenge.title} | AIQUAA Labs`;
+  const description = `Prueba técnica de desarrollo (${challenge.clase}): ${challenge.objetivo}`;
+  const url = `https://aiquaa.com/labs/desarrollo/${challenge.id}`;
+  const og = `/api/og?title=${encodeURIComponent(challenge.title)}&subtitle=${encodeURIComponent(
+    `${challenge.clase} - Prueba de desarrollo`
+  )}&section=Labs`;
+
+  return {
+    title,
+    description,
+    keywords: [
+      'prueba técnica de desarrollo',
+      'entrega por repositorio',
+      challenge.clase,
+      challenge.title,
+      'bootcamp',
+      'AIQUAA',
+      'evaluación técnica',
+    ],
+    openGraph: {
+      title,
+      description,
+      url,
+      siteName: 'AIQUAA',
+      type: 'website',
+      locale: 'es_PY',
+      images: [
+        {
+          url: og,
+          width: 1200,
+          height: 630,
+          alt: `${challenge.title} - AIQUAA`,
+        },
+      ],
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title,
+      description,
+      images: [og],
+      creator: '@stevenayal',
+    },
+    alternates: { canonical: url },
+  };
+}
+
+export default function DesarrolloChallengePage({ params }: PageProps) {
+  const challenge = getDesarrolloChallenge(params.challengeId);
+  if (!challenge) notFound();
+
+  return <DesarrolloChallengeClient challenge={challenge} />;
+}

--- a/apps/frontend/src/lib/exam-review-routes.ts
+++ b/apps/frontend/src/lib/exam-review-routes.ts
@@ -1,0 +1,31 @@
+// Ruta de corrección manual según el tipo de examen. Centralizado acá porque
+// los paneles de empresa (candidatos, procesos) tenían la condición
+// `exam_type === 'test-app'` hardcodeada en tres lugares distintos.
+
+import { DESARROLLO_CHALLENGE_IDS } from '@/lib/labs/desarrolloChallenges';
+
+/** Bug hunt y prácticas con score heurístico: rúbrica por item. */
+const RUBRIC_REVIEW_TYPES = new Set<string>(['test-app']);
+
+/** Pruebas de desarrollo: el evaluador carga un puntaje global. */
+const DESARROLLO_REVIEW_TYPES = new Set<string>(DESARROLLO_CHALLENGE_IDS);
+
+/**
+ * Devuelve el link de corrección para un resultado, o `null` si ese tipo de
+ * examen se corrige solo.
+ */
+export function reviewHrefFor(
+  examType: string | null | undefined,
+  resultId: string
+): string | null {
+  if (!examType) return null;
+  if (RUBRIC_REVIEW_TYPES.has(examType)) return `/empresa/evaluar/${resultId}`;
+  if (DESARROLLO_REVIEW_TYPES.has(examType)) {
+    return `/empresa/evaluar-desarrollo/${resultId}`;
+  }
+  return null;
+}
+
+export function isManuallyReviewed(examType: string | null | undefined) {
+  return reviewHrefFor(examType, 'x') !== null;
+}

--- a/apps/frontend/src/lib/exams.ts
+++ b/apps/frontend/src/lib/exams.ts
@@ -27,11 +27,7 @@ export type ExamType =
   | 'clase6-config-kubernetes'
   | 'clase7-8-seq-logging'
   | 'clase9-cicd-github-actions'
-  | 'dev-persistencia'
-  | 'dev-kubernetes'
-  | 'dev-config-kubernetes'
-  | 'dev-seq-logging'
-  | 'dev-cicd-actions';
+  | 'dev-proyecto-final';
 
 export interface ExamMeta {
   emoji: string;
@@ -152,30 +148,10 @@ export const EXAM_META: Record<ExamType, ExamMeta> = {
     label: 'Clase 9 — CI/CD con GitHub Actions',
     href: '/assessments/clase9-cicd-github-actions',
   },
-  'dev-persistencia': {
-    emoji: '🗃️',
-    label: 'Clase 3 — Desarrollo: Persistencia con EF Core',
-    href: '/labs/desarrollo/dev-persistencia',
-  },
-  'dev-kubernetes': {
-    emoji: '☸️',
-    label: 'Clase 5 — Desarrollo: Despliegue en Kubernetes',
-    href: '/labs/desarrollo/dev-kubernetes',
-  },
-  'dev-config-kubernetes': {
-    emoji: '🔐',
-    label: 'Clase 6 — Desarrollo: ConfigMaps, Secrets y Helm',
-    href: '/labs/desarrollo/dev-config-kubernetes',
-  },
-  'dev-seq-logging': {
-    emoji: '📊',
-    label: 'Clases 7 y 8 — Desarrollo: Serilog y Seq',
-    href: '/labs/desarrollo/dev-seq-logging',
-  },
-  'dev-cicd-actions': {
-    emoji: '🔁',
-    label: 'Clase 9 — Desarrollo: Pipeline con GitHub Actions',
-    href: '/labs/desarrollo/dev-cicd-actions',
+  'dev-proyecto-final': {
+    emoji: '🏆',
+    label: 'Proyecto final — Desarrollo integrador',
+    href: '/labs/desarrollo/dev-proyecto-final',
   },
 };
 
@@ -203,11 +179,7 @@ export const POINTS_BASED_TYPES = new Set<ExamType>([
   'clase6-config-kubernetes',
   'clase7-8-seq-logging',
   'clase9-cicd-github-actions',
-  'dev-persistencia',
-  'dev-kubernetes',
-  'dev-config-kubernetes',
-  'dev-seq-logging',
-  'dev-cicd-actions',
+  'dev-proyecto-final',
 ]);
 
 export interface ExamScoreFields {

--- a/apps/frontend/src/lib/exams.ts
+++ b/apps/frontend/src/lib/exams.ts
@@ -21,7 +21,17 @@ export type ExamType =
   | 'cicd-fundamentals'
   | 'playwright-practico'
   | 'playwright-fundamentals'
-  | 'gherkin-fundamentals';
+  | 'gherkin-fundamentals'
+  | 'clase3-data-persistencia'
+  | 'clase5-kubernetes'
+  | 'clase6-config-kubernetes'
+  | 'clase7-8-seq-logging'
+  | 'clase9-cicd-github-actions'
+  | 'dev-persistencia'
+  | 'dev-kubernetes'
+  | 'dev-config-kubernetes'
+  | 'dev-seq-logging'
+  | 'dev-cicd-actions';
 
 export interface ExamMeta {
   emoji: string;
@@ -117,6 +127,56 @@ export const EXAM_META: Record<ExamType, ExamMeta> = {
     label: 'Gherkin y BDD — Fundamentos',
     href: '/assessments/gherkin-fundamentals',
   },
+  'clase3-data-persistencia': {
+    emoji: '🗃️',
+    label: 'Clase 3 — Data Persistencia',
+    href: '/assessments/clase3-data-persistencia',
+  },
+  'clase5-kubernetes': {
+    emoji: '☸️',
+    label: 'Clase 5 — Kubernetes',
+    href: '/assessments/clase5-kubernetes',
+  },
+  'clase6-config-kubernetes': {
+    emoji: '🔐',
+    label: 'Clase 6 — Configuración en Kubernetes',
+    href: '/assessments/clase6-config-kubernetes',
+  },
+  'clase7-8-seq-logging': {
+    emoji: '📊',
+    label: 'Clases 7 y 8 — SEQ Structured Logging',
+    href: '/assessments/clase7-8-seq-logging',
+  },
+  'clase9-cicd-github-actions': {
+    emoji: '🔁',
+    label: 'Clase 9 — CI/CD con GitHub Actions',
+    href: '/assessments/clase9-cicd-github-actions',
+  },
+  'dev-persistencia': {
+    emoji: '🗃️',
+    label: 'Clase 3 — Desarrollo: Persistencia con EF Core',
+    href: '/labs/desarrollo/dev-persistencia',
+  },
+  'dev-kubernetes': {
+    emoji: '☸️',
+    label: 'Clase 5 — Desarrollo: Despliegue en Kubernetes',
+    href: '/labs/desarrollo/dev-kubernetes',
+  },
+  'dev-config-kubernetes': {
+    emoji: '🔐',
+    label: 'Clase 6 — Desarrollo: ConfigMaps, Secrets y Helm',
+    href: '/labs/desarrollo/dev-config-kubernetes',
+  },
+  'dev-seq-logging': {
+    emoji: '📊',
+    label: 'Clases 7 y 8 — Desarrollo: Serilog y Seq',
+    href: '/labs/desarrollo/dev-seq-logging',
+  },
+  'dev-cicd-actions': {
+    emoji: '🔁',
+    label: 'Clase 9 — Desarrollo: Pipeline con GitHub Actions',
+    href: '/labs/desarrollo/dev-cicd-actions',
+  },
 };
 
 export const EXAM_TYPES = Object.keys(EXAM_META) as ExamType[];
@@ -138,6 +198,16 @@ export const POINTS_BASED_TYPES = new Set<ExamType>([
   'playwright-practico',
   'playwright-fundamentals',
   'gherkin-fundamentals',
+  'clase3-data-persistencia',
+  'clase5-kubernetes',
+  'clase6-config-kubernetes',
+  'clase7-8-seq-logging',
+  'clase9-cicd-github-actions',
+  'dev-persistencia',
+  'dev-kubernetes',
+  'dev-config-kubernetes',
+  'dev-seq-logging',
+  'dev-cicd-actions',
 ]);
 
 export interface ExamScoreFields {

--- a/apps/frontend/src/lib/labs/__tests__/desarrolloChallenges.test.ts
+++ b/apps/frontend/src/lib/labs/__tests__/desarrolloChallenges.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest';
+import {
+  DESARROLLO_CHALLENGES,
+  DESARROLLO_CHALLENGE_IDS,
+  getDesarrolloChallenge,
+  isValidRepoUrl,
+} from '../desarrolloChallenges';
+import { EXAM_META, POINTS_BASED_TYPES, type ExamType } from '@/lib/exams';
+import { reviewHrefFor } from '@/lib/exam-review-routes';
+
+const challenges = DESARROLLO_CHALLENGE_IDS.map(
+  (id) => DESARROLLO_CHALLENGES[id]
+);
+
+describe('catálogo de pruebas de desarrollo', () => {
+  it('define una prueba por clase del bootcamp', () => {
+    expect(DESARROLLO_CHALLENGE_IDS).toHaveLength(5);
+    expect(new Set(DESARROLLO_CHALLENGE_IDS).size).toBe(5);
+  });
+
+  it('mantiene id y examType alineados con la clave del record', () => {
+    DESARROLLO_CHALLENGE_IDS.forEach((id) => {
+      expect(DESARROLLO_CHALLENGES[id].id).toBe(id);
+      expect(DESARROLLO_CHALLENGES[id].examType).toBe(id);
+    });
+  });
+
+  it('está registrado en el catálogo de exámenes apuntando a su lab', () => {
+    challenges.forEach((challenge) => {
+      const meta = EXAM_META[challenge.examType as ExamType];
+      expect(meta).toBeDefined();
+      expect(meta.href).toBe(`/labs/desarrollo/${challenge.id}`);
+      expect(POINTS_BASED_TYPES.has(challenge.examType as ExamType)).toBe(true);
+    });
+  });
+
+  it('enruta la corrección a la pantalla de puntaje global', () => {
+    challenges.forEach((challenge) => {
+      expect(reviewHrefFor(challenge.examType, 'abc')).toBe(
+        '/empresa/evaluar-desarrollo/abc'
+      );
+    });
+    expect(reviewHrefFor('test-app', 'abc')).toBe('/empresa/evaluar/abc');
+    expect(reviewHrefFor('cicd-fundamentals', 'abc')).toBeNull();
+    expect(reviewHrefFor(null, 'abc')).toBeNull();
+  });
+
+  it('trae consigna, entregables y criterios en cada prueba', () => {
+    challenges.forEach((challenge) => {
+      expect(challenge.consigna.length).toBeGreaterThanOrEqual(5);
+      expect(challenge.entregables.length).toBeGreaterThanOrEqual(3);
+      expect(challenge.criteriosDeEvaluacion.length).toBeGreaterThanOrEqual(5);
+      expect(challenge.objetivo).toBeTruthy();
+      expect(challenge.estructuraEsperada).toBeTruthy();
+    });
+  });
+
+  it('resuelve por id y devuelve undefined para uno desconocido', () => {
+    expect(getDesarrolloChallenge('dev-kubernetes')?.clase).toBe('Clase 5');
+    expect(getDesarrolloChallenge('no-existe')).toBeUndefined();
+  });
+});
+
+describe('isValidRepoUrl', () => {
+  it('acepta la raíz de un repositorio de GitHub', () => {
+    expect(isValidRepoUrl('https://github.com/stevenayal/mi-api')).toBe(true);
+    expect(isValidRepoUrl('https://github.com/stevenayal/mi-api/')).toBe(true);
+    expect(isValidRepoUrl('  https://github.com/org/repo  ')).toBe(true);
+  });
+
+  it('rechaza hosts que no son GitHub', () => {
+    expect(isValidRepoUrl('https://gitlab.com/org/repo')).toBe(false);
+    expect(isValidRepoUrl('https://githubb.com/org/repo')).toBe(false);
+    expect(isValidRepoUrl('http://github.com/org/repo')).toBe(false);
+  });
+
+  it('rechaza rutas internas y URLs incompletas', () => {
+    expect(isValidRepoUrl('https://github.com/org')).toBe(false);
+    expect(isValidRepoUrl('https://github.com/org/repo/tree/main')).toBe(false);
+    expect(isValidRepoUrl('github.com/org/repo')).toBe(false);
+    expect(isValidRepoUrl('')).toBe(false);
+  });
+});

--- a/apps/frontend/src/lib/labs/__tests__/desarrolloChallenges.test.ts
+++ b/apps/frontend/src/lib/labs/__tests__/desarrolloChallenges.test.ts
@@ -13,9 +13,9 @@ const challenges = DESARROLLO_CHALLENGE_IDS.map(
 );
 
 describe('catálogo de pruebas de desarrollo', () => {
-  it('define una prueba por clase del bootcamp', () => {
-    expect(DESARROLLO_CHALLENGE_IDS).toHaveLength(5);
-    expect(new Set(DESARROLLO_CHALLENGE_IDS).size).toBe(5);
+  it('define un único proyecto final de desarrollo', () => {
+    expect(DESARROLLO_CHALLENGE_IDS).toHaveLength(1);
+    expect(DESARROLLO_CHALLENGE_IDS[0]).toBe('dev-proyecto-final');
   });
 
   it('mantiene id y examType alineados con la clave del record', () => {
@@ -45,18 +45,26 @@ describe('catálogo de pruebas de desarrollo', () => {
     expect(reviewHrefFor(null, 'abc')).toBeNull();
   });
 
-  it('trae consigna, entregables y criterios en cada prueba', () => {
-    challenges.forEach((challenge) => {
-      expect(challenge.consigna.length).toBeGreaterThanOrEqual(5);
-      expect(challenge.entregables.length).toBeGreaterThanOrEqual(3);
-      expect(challenge.criteriosDeEvaluacion.length).toBeGreaterThanOrEqual(5);
-      expect(challenge.objetivo).toBeTruthy();
-      expect(challenge.estructuraEsperada).toBeTruthy();
-    });
+  it('trae consigna, entregables y criterios cubriendo las 5 clases', () => {
+    const challenge = DESARROLLO_CHALLENGES['dev-proyecto-final'];
+    expect(challenge.consigna.length).toBeGreaterThanOrEqual(6);
+    expect(challenge.entregables.length).toBeGreaterThanOrEqual(4);
+    expect(challenge.criteriosDeEvaluacion.length).toBeGreaterThanOrEqual(5);
+    expect(challenge.objetivo).toBeTruthy();
+    expect(challenge.estructuraEsperada).toBeTruthy();
+
+    const consignaText = challenge.consigna.join(' ');
+    expect(consignaText).toMatch(/EF Core|Entity Framework/i);
+    expect(consignaText).toMatch(/Kubernetes|Deployment|StatefulSet/i);
+    expect(consignaText).toMatch(/ConfigMap|Secret|Helm/i);
+    expect(consignaText).toMatch(/Serilog|Seq/i);
+    expect(consignaText).toMatch(/GitHub Actions|workflow/i);
   });
 
   it('resuelve por id y devuelve undefined para uno desconocido', () => {
-    expect(getDesarrolloChallenge('dev-kubernetes')?.clase).toBe('Clase 5');
+    expect(getDesarrolloChallenge('dev-proyecto-final')?.title).toContain(
+      'Proyecto final'
+    );
     expect(getDesarrolloChallenge('no-existe')).toBeUndefined();
   });
 });

--- a/apps/frontend/src/lib/labs/desarrolloChallenges.ts
+++ b/apps/frontend/src/lib/labs/desarrolloChallenges.ts
@@ -1,4 +1,4 @@
-// Catálogo de las pruebas técnicas de DESARROLLO del bootcamp: una por clase.
+// Catálogo de las pruebas técnicas de DESARROLLO del bootcamp.
 //
 // A diferencia de git-practico / playwright-practico, acá no hay verificación
 // automática contra la GitHub API. El candidato entrega el link de su
@@ -9,12 +9,7 @@
 // para que sepa qué se mira, y al profesor como guía al puntuar. No produce
 // puntaje por sí solo.
 
-export type DesarrolloChallengeId =
-  | 'dev-persistencia'
-  | 'dev-kubernetes'
-  | 'dev-config-kubernetes'
-  | 'dev-seq-logging'
-  | 'dev-cicd-actions';
+export type DesarrolloChallengeId = 'dev-proyecto-final';
 
 export interface DesarrolloChallenge {
   id: DesarrolloChallengeId;
@@ -35,116 +30,50 @@ export const DESARROLLO_CHALLENGES: Record<
   DesarrolloChallengeId,
   DesarrolloChallenge
 > = {
-  'dev-persistencia': {
-    id: 'dev-persistencia',
-    examType: 'dev-persistencia',
-    clase: 'Clase 3',
-    title: 'Persistencia con EF Core y PostgreSQL',
-    emoji: '🗃️',
+  'dev-proyecto-final': {
+    id: 'dev-proyecto-final',
+    examType: 'dev-proyecto-final',
+    clase: 'Proyecto final — Clases 3, 5, 6, 7-8 y 9',
+    title: 'Proyecto final: API con persistencia, Kubernetes y CI/CD',
+    emoji: '🏆',
     objetivo:
-      'Construir una API .NET que persista datos en PostgreSQL usando Entity Framework Core, exponiendo DTOs en lugar de entidades de dominio y validando la entrada con FluentValidation.',
+      'Construir e integrar en un solo repositorio todo lo visto en el bootcamp: una API .NET con persistencia en PostgreSQL, desplegada en Kubernetes con configuración externalizada, logging estructurado centralizado, y un pipeline de CI/CD que la valide y la despliegue.',
     consigna: [
-      'Creá una API .NET (minimal API o controllers) con al menos una entidad de dominio propia — por ejemplo `Producto`, `Cliente` o similar — con 4 o más campos.',
-      'Configurá Entity Framework Core con el proveedor Npgsql apuntando a PostgreSQL. La cadena de conexión debe leerse de configuración o de una variable de entorno, nunca hardcodeada en el código.',
-      'Generá y versioná al menos una migración de EF Core. El repositorio tiene que incluir la carpeta `Migrations/`.',
-      'Exponé un CRUD completo (GET lista, GET por id, POST, PUT y DELETE) que reciba y devuelva DTOs, no las entidades internas.',
-      'Validá el payload de creación y actualización con FluentValidation: al menos una regla `NotEmpty()` y una regla de formato o de rango.',
-      'Levantá PostgreSQL con Docker (`docker-compose.yml` o el comando `docker run` documentado), pasando la contraseña por variable de entorno.',
-      'Documentá en el README cómo levantar la base, aplicar las migraciones y correr la API.',
+      '(Persistencia) Creá una API .NET con al menos una entidad de dominio propia, usando Entity Framework Core con el proveedor Npgsql apuntando a PostgreSQL. Generá y versioná al menos una migración. Exponé un CRUD completo que reciba y devuelva DTOs, no las entidades internas, y validá la entrada con FluentValidation.',
+      '(Kubernetes) Escribí los manifiestos para desplegar la API en un clúster local (Minikube o Kind): un Deployment con al menos 2 réplicas, resources y un readinessProbe; un Service que la exponga; y un StatefulSet con volumeClaimTemplates para la base de datos. Demostrá en el README la autorecuperación (borrar un Pod y ver que el ReplicaSet lo recrea) y el escalado declarativo.',
+      '(Configuración) Sacá del código toda la configuración hardcodeada. Creá un ConfigMap para lo no sensible (nivel de log, entorno) y un Secret para lo sensible (credenciales de la base), inyectados con envFrom. Empaquetá todo en un chart de Helm con un values.yaml parametrizable y al menos un archivo de values por entorno (por ejemplo dev y qa).',
+      '(Logging) Configurá Serilog desde el arranque del pipeline con al menos dos sinks: consola y HTTP hacia Seq. Emití logs estructurados con propiedades clave-valor (como mínimo un requestId) y usá los cuatro niveles de severidad con criterio. Desplegá Seq como Pod en el mismo clúster, con Service y volumen, y mostrá en el README una búsqueda por propiedad que correlacione eventos de más de una réplica de la API.',
+      '(CI/CD) Creá un workflow de GitHub Actions con triggers push, pull_request y workflow_dispatch. El job de validación debe seguir el orden checkout → restore → build (--no-restore) → test (--no-build). Agregá un job de empaquetado que construya y publique la imagen Docker, dependiente del de validación con needs y limitado a la rama principal. Separá Variables (no sensible) de Secrets (credenciales), sin exponer ningún secreto en el código ni en los logs.',
+      'Provocá un fallo a propósito en un Pull Request (por ejemplo, un test roto), documentá el check en rojo, arreglalo y documentá el check en verde.',
+      'Escribí un README único que explique cómo levantar todo el proyecto de punta a punta: base de datos, clúster, configuración, logging y pipeline.',
     ],
     entregables: [
-      'Repositorio público de GitHub con el código de la API.',
-      'Carpeta `Migrations/` con al menos una migración aplicada.',
-      '`docker-compose.yml` (o instrucciones equivalentes) para levantar PostgreSQL.',
-      'README con los pasos de ejecución de punta a punta.',
+      'Un único repositorio público de GitHub con la API, los manifiestos de Kubernetes, el chart de Helm y los workflows de GitHub Actions.',
+      'Carpeta `Migrations/` con al menos una migración de EF Core aplicada.',
+      'Manifiestos o chart con Deployment, Service, StatefulSet, ConfigMap y Secret.',
+      'Workflows en `.github/workflows/` con al menos una ejecución exitosa y una fallida visibles en la pestaña Actions.',
+      'README único con instrucciones de punta a punta y evidencia (capturas o salidas de comandos) de autorecuperación, escalado y búsqueda en Seq.',
     ],
-    estructuraEsperada: `mi-api/
-├── docker-compose.yml
+    estructuraEsperada: `mi-proyecto-final/
+├── .github/
+│   └── workflows/
+│       ├── ci.yml
+│       └── cd.yml
 ├── README.md
-└── src/
-    ├── Program.cs
-    ├── Data/AppDbContext.cs
-    ├── Domain/Producto.cs
-    ├── Dtos/ProductoDto.cs
-    ├── Validators/ProductoValidator.cs
-    └── Migrations/`,
-    criteriosDeEvaluacion: [
-      'El `DbContext` está configurado con Npgsql y la cadena de conexión sale de configuración o del entorno.',
-      'Existen migraciones versionadas en el repositorio y el README explica cómo aplicarlas.',
-      'Los endpoints reciben y devuelven DTOs; la entidad de dominio no se expone al exterior.',
-      'FluentValidation está registrado en el pipeline y las reglas se ejecutan de verdad ante un payload inválido.',
-      'No hay credenciales hardcodeadas en el código ni commiteadas al repositorio.',
-      'El README permite a un tercero levantar el proyecto sin conocimiento previo.',
-    ],
-    duracionEstimadaMin: 180,
-  },
-
-  'dev-kubernetes': {
-    id: 'dev-kubernetes',
-    examType: 'dev-kubernetes',
-    clase: 'Clase 5',
-    title: 'Despliegue de una API en Kubernetes',
-    emoji: '☸️',
-    objetivo:
-      'Desplegar una aplicación contenerizada en un clúster local de Kubernetes usando manifiestos declarativos, con un Deployment que se autorecupere y un Service que la exponga.',
-    consigna: [
-      'Partí de una API propia (puede ser la de la Clase 3) con su `Dockerfile`, o de una imagen pública si preferís enfocarte en los manifiestos.',
-      'Escribí un manifiesto de `Deployment` con al menos 2 réplicas, `resources` declarados y un `readinessProbe`.',
-      'Escribí un manifiesto de `Service` que exponga la aplicación dentro del clúster, más un `NodePort` (o `minikube service`) para poder acceder desde afuera.',
-      'Agregá un `StatefulSet` para la base de datos con su `volumeClaimTemplates`, justificando en el README por qué acá corresponde StatefulSet y no Deployment.',
-      'Demostrá la autorecuperación: borrá un Pod con `kubectl delete pod`, mostrá que el ReplicaSet lo recrea y dejá la evidencia (captura o salida de `kubectl get pods`) en el README.',
-      'Demostrá el escalado: cambiá el número de réplicas de forma declarativa (editando el manifiesto y re-aplicando, no con `kubectl scale`) y documentá el resultado.',
-      'Documentá en el README los comandos exactos para levantar todo desde cero en Minikube o Kind.',
-    ],
-    entregables: [
-      'Repositorio público de GitHub con la carpeta `k8s/` de manifiestos.',
-      'Manifiestos de Deployment, Service y StatefulSet.',
-      'README con los comandos de despliegue y la evidencia de autorecuperación y escalado.',
-    ],
-    estructuraEsperada: `mi-app/
-├── Dockerfile
-├── README.md
-└── k8s/
-    ├── deployment.yaml
-    ├── service.yaml
-    ├── statefulset-postgres.yaml
-    └── service-postgres.yaml`,
-    criteriosDeEvaluacion: [
-      'Los manifiestos son declarativos y se aplican sin errores con `kubectl apply -f k8s/`.',
-      'El Deployment declara réplicas, recursos y al menos una probe.',
-      'El Service enruta correctamente al Deployment mediante selectores coherentes con las labels.',
-      'El StatefulSet usa `volumeClaimTemplates` y el README justifica la elección frente a Deployment.',
-      'Hay evidencia real de la autorecuperación y del escalado declarativo.',
-      'El README permite reproducir el despliegue completo en un clúster local limpio.',
-    ],
-    duracionEstimadaMin: 180,
-  },
-
-  'dev-config-kubernetes': {
-    id: 'dev-config-kubernetes',
-    examType: 'dev-config-kubernetes',
-    clase: 'Clase 6',
-    title: 'Configuración desacoplada con ConfigMaps, Secrets y Helm',
-    emoji: '🔐',
-    objetivo:
-      'Externalizar toda la configuración de una aplicación siguiendo el principio de inmutabilidad: la misma imagen debe correr en dev y en prod cambiando únicamente la configuración.',
-    consigna: [
-      'Tomá una aplicación contenerizada y sacá del código toda la configuración que hoy esté hardcodeada.',
-      'Creá un `ConfigMap` con la configuración no sensible: nivel de log, endpoints externos, nombre del entorno.',
-      'Creá un `Secret` con los datos sensibles: contraseña de la base, connection string o tokens.',
-      'Inyectá ambos en el Pod con `envFrom` y demostrá que la aplicación los consume como variables de entorno estándar, sin conocer Kubernetes.',
-      'Demostrá el principio de inmutabilidad: desplegá la MISMA imagen en dos namespaces (por ejemplo `dev` y `qa`) con configuraciones distintas, y documentá la diferencia de comportamiento.',
-      'Empaquetá todo en un chart de Helm con `values.yaml` parametrizable, más un `values-dev.yaml` y un `values-qa.yaml`.',
-      'Explicá en el README por qué un Secret en Base64 no está cifrado y qué medidas adicionales tomarías en un entorno real.',
-    ],
-    entregables: [
-      'Repositorio público de GitHub con el chart de Helm.',
-      'Manifiestos o templates de ConfigMap y Secret.',
-      '`values.yaml` más un archivo de values por entorno.',
-      'README con la demostración de una imagen en dos entornos y la nota sobre Base64.',
-    ],
-    estructuraEsperada: `mi-app/
-├── README.md
+├── src/
+│   ├── Program.cs
+│   ├── Data/AppDbContext.cs
+│   ├── Domain/
+│   ├── Dtos/
+│   ├── Validators/
+│   └── Migrations/
+├── docs/
+│   └── capturas/
+├── k8s/
+│   ├── deployment.yaml
+│   ├── service.yaml
+│   ├── statefulset-postgres.yaml
+│   └── seq-deployment.yaml
 └── chart/
     ├── Chart.yaml
     ├── values.yaml
@@ -155,99 +84,14 @@ export const DESARROLLO_CHALLENGES: Record<
         ├── configmap.yaml
         └── secret.yaml`,
     criteriosDeEvaluacion: [
-      'No queda configuración hardcodeada en el código ni en la imagen.',
-      'El reparto entre ConfigMap y Secret respeta el criterio de sensibilidad del material.',
-      'La inyección usa `envFrom` y la aplicación lee variables de entorno de forma estándar.',
-      'Se demuestra la misma imagen corriendo con dos configuraciones distintas.',
-      'El chart de Helm renderiza correctamente con cada archivo de values (`helm template` sin errores).',
-      'El README explica la diferencia entre codificación Base64 y cifrado real.',
+      'Persistencia: el DbContext usa Npgsql, hay migraciones versionadas, los endpoints trabajan con DTOs y FluentValidation valida de verdad la entrada.',
+      'Kubernetes: los manifiestos se aplican sin errores, el Deployment declara réplicas/recursos/probe, y hay evidencia real de autorecuperación y escalado.',
+      'Configuración: no queda nada hardcodeado, el reparto ConfigMap/Secret respeta el criterio de sensibilidad, y el chart de Helm renderiza con cada archivo de values.',
+      'Logging: Serilog reemplaza al logger por defecto, los logs son estructurados (no texto interpolado), y hay evidencia de una búsqueda en Seq que correlaciona varias réplicas.',
+      'CI/CD: el workflow declara los tres triggers, respeta el orden restore→build→test, separa Variables de Secrets sin filtrar nada, y hay evidencia de un check fallando y luego pasando.',
+      'Integración: el README permite a un tercero levantar el proyecto completo desde cero, sin conocimiento previo del candidato.',
     ],
-    duracionEstimadaMin: 180,
-  },
-
-  'dev-seq-logging': {
-    id: 'dev-seq-logging',
-    examType: 'dev-seq-logging',
-    clase: 'Clases 7 y 8',
-    title: 'Logging estructurado con Serilog y Seq',
-    emoji: '📊',
-    objetivo:
-      'Reemplazar los logs de texto plano por logs estructurados centralizados, de modo que se pueda buscar por propiedades y correlacionar eventos entre varias instancias.',
-    consigna: [
-      'Configurá Serilog en una API .NET desde el arranque del pipeline, reemplazando el logger por defecto.',
-      'Configurá al menos dos sinks: consola (para `kubectl logs`) y HTTP hacia Seq (para centralización y análisis).',
-      'Emití logs estructurados con propiedades clave-valor — como mínimo `requestId` y algún identificador de negocio (`userId`, `pedidoId`) — nunca concatenando valores dentro del mensaje.',
-      'Usá los cuatro niveles de severidad de forma correcta: Information para el flujo normal, Warning para situaciones anómalas, Error para fallos y Fatal para caídas. Incluí al menos un caso de cada uno.',
-      'Enriquecé los logs con contexto de ejecución (nombre de la máquina, entorno, versión).',
-      'Desplegá Seq como Pod en Minikube, con un Service para la recepción HTTP interna y un volumen para persistir entre reinicios.',
-      'Escalá la API a 2 o más réplicas y demostrá en el README, con capturas del dashboard de Seq, una búsqueda filtrando por una propiedad que devuelva eventos de ambas instancias.',
-    ],
-    entregables: [
-      'Repositorio público de GitHub con la configuración de Serilog.',
-      'Manifiestos de despliegue de Seq (Deployment/Pod, Service y volumen).',
-      'README con capturas del dashboard de Seq mostrando una búsqueda por propiedad.',
-    ],
-    estructuraEsperada: `mi-api/
-├── README.md
-├── src/
-│   ├── Program.cs
-│   └── appsettings.json
-├── docs/
-│   └── capturas-seq/
-└── k8s/
-    ├── api-deployment.yaml
-    ├── seq-deployment.yaml
-    └── seq-service.yaml`,
-    criteriosDeEvaluacion: [
-      'Serilog está integrado al arranque de la aplicación y reemplaza al logger por defecto.',
-      'Los logs salen como propiedades estructuradas, no como texto interpolado dentro del mensaje.',
-      'Los cuatro niveles de severidad se usan con el criterio del material (Warning ≠ Error).',
-      'Seq corre dentro del clúster, recibe por Service HTTP interno y persiste con un volumen.',
-      'Hay evidencia de una búsqueda por propiedad que correlaciona eventos de más de una réplica.',
-      'La URL de Seq y cualquier API key salen de configuración, no del código.',
-    ],
-    duracionEstimadaMin: 180,
-  },
-
-  'dev-cicd-actions': {
-    id: 'dev-cicd-actions',
-    examType: 'dev-cicd-actions',
-    clase: 'Clase 9',
-    title: 'Pipeline CI/CD con GitHub Actions',
-    emoji: '🔁',
-    objetivo:
-      'Automatizar la validación y la entrega de una aplicación con GitHub Actions, separando correctamente la configuración no sensible de los secretos.',
-    consigna: [
-      'Creá un workflow de CI en `.github/workflows/` que se dispare con `push`, con `pull_request` y con `workflow_dispatch`.',
-      'El job de validación debe ejecutar los steps en el orden correcto: checkout, setup del runtime, restore, build (`--no-restore`) y test (`--no-build`).',
-      'Agregá un job de empaquetado que construya la imagen Docker y la publique en un registry (GitHub Container Registry sirve).',
-      'El job de empaquetado debe depender del de validación con `needs`, y ejecutarse solo en la rama principal.',
-      'Usá Variables del repositorio para lo no sensible (nombre de la imagen, entorno, namespace) y Secrets para las credenciales. Ningún secreto puede aparecer en el código ni en la salida de los logs.',
-      'Provocá un fallo a propósito en un Pull Request (por ejemplo, un test roto), mostrá el check en rojo y documentalo; después arreglalo y mostrá el check en verde.',
-      'Documentá en el README el diagrama del pipeline y qué Variables y Secrets hay que configurar para reproducirlo.',
-    ],
-    entregables: [
-      'Repositorio público de GitHub con los workflows en `.github/workflows/`.',
-      'Al menos una ejecución exitosa y una fallida visibles en la pestaña Actions.',
-      'README con el diagrama del pipeline y la lista de Variables y Secrets requeridos.',
-    ],
-    estructuraEsperada: `mi-app/
-├── .github/
-│   └── workflows/
-│       ├── ci.yml
-│       └── cd.yml
-├── Dockerfile
-├── README.md
-└── src/`,
-    criteriosDeEvaluacion: [
-      'El workflow declara los tres triggers pedidos y cada uno cumple su propósito.',
-      'El orden restore → build → test es correcto y usa `--no-restore` / `--no-build`.',
-      'El job de empaquetado usa `needs` y está condicionado a la rama principal.',
-      'La separación Variables / Secrets respeta el criterio de sensibilidad; no hay secretos en el código ni filtrados en los logs.',
-      'Hay evidencia del check fallando y después pasando sobre un Pull Request.',
-      'El README documenta el pipeline y permite reproducirlo en otro repositorio.',
-    ],
-    duracionEstimadaMin: 180,
+    duracionEstimadaMin: 600,
   },
 };
 

--- a/apps/frontend/src/lib/labs/desarrolloChallenges.ts
+++ b/apps/frontend/src/lib/labs/desarrolloChallenges.ts
@@ -1,0 +1,270 @@
+// Catálogo de las pruebas técnicas de DESARROLLO del bootcamp: una por clase.
+//
+// A diferencia de git-practico / playwright-practico, acá no hay verificación
+// automática contra la GitHub API. El candidato entrega el link de su
+// repositorio y el resultado queda en `pending_correction` hasta que el
+// profesor le asigna un puntaje global desde /empresa/evaluar-desarrollo.
+//
+// `criteriosDeEvaluacion` es material de referencia: se le muestra al candidato
+// para que sepa qué se mira, y al profesor como guía al puntuar. No produce
+// puntaje por sí solo.
+
+export type DesarrolloChallengeId =
+  | 'dev-persistencia'
+  | 'dev-kubernetes'
+  | 'dev-config-kubernetes'
+  | 'dev-seq-logging'
+  | 'dev-cicd-actions';
+
+export interface DesarrolloChallenge {
+  id: DesarrolloChallengeId;
+  /** Coincide con el id: es también el `exam_type` en `exam_results`. */
+  examType: DesarrolloChallengeId;
+  clase: string;
+  title: string;
+  emoji: string;
+  objetivo: string;
+  consigna: string[];
+  entregables: string[];
+  estructuraEsperada: string;
+  criteriosDeEvaluacion: string[];
+  duracionEstimadaMin: number;
+}
+
+export const DESARROLLO_CHALLENGES: Record<
+  DesarrolloChallengeId,
+  DesarrolloChallenge
+> = {
+  'dev-persistencia': {
+    id: 'dev-persistencia',
+    examType: 'dev-persistencia',
+    clase: 'Clase 3',
+    title: 'Persistencia con EF Core y PostgreSQL',
+    emoji: '🗃️',
+    objetivo:
+      'Construir una API .NET que persista datos en PostgreSQL usando Entity Framework Core, exponiendo DTOs en lugar de entidades de dominio y validando la entrada con FluentValidation.',
+    consigna: [
+      'Creá una API .NET (minimal API o controllers) con al menos una entidad de dominio propia — por ejemplo `Producto`, `Cliente` o similar — con 4 o más campos.',
+      'Configurá Entity Framework Core con el proveedor Npgsql apuntando a PostgreSQL. La cadena de conexión debe leerse de configuración o de una variable de entorno, nunca hardcodeada en el código.',
+      'Generá y versioná al menos una migración de EF Core. El repositorio tiene que incluir la carpeta `Migrations/`.',
+      'Exponé un CRUD completo (GET lista, GET por id, POST, PUT y DELETE) que reciba y devuelva DTOs, no las entidades internas.',
+      'Validá el payload de creación y actualización con FluentValidation: al menos una regla `NotEmpty()` y una regla de formato o de rango.',
+      'Levantá PostgreSQL con Docker (`docker-compose.yml` o el comando `docker run` documentado), pasando la contraseña por variable de entorno.',
+      'Documentá en el README cómo levantar la base, aplicar las migraciones y correr la API.',
+    ],
+    entregables: [
+      'Repositorio público de GitHub con el código de la API.',
+      'Carpeta `Migrations/` con al menos una migración aplicada.',
+      '`docker-compose.yml` (o instrucciones equivalentes) para levantar PostgreSQL.',
+      'README con los pasos de ejecución de punta a punta.',
+    ],
+    estructuraEsperada: `mi-api/
+├── docker-compose.yml
+├── README.md
+└── src/
+    ├── Program.cs
+    ├── Data/AppDbContext.cs
+    ├── Domain/Producto.cs
+    ├── Dtos/ProductoDto.cs
+    ├── Validators/ProductoValidator.cs
+    └── Migrations/`,
+    criteriosDeEvaluacion: [
+      'El `DbContext` está configurado con Npgsql y la cadena de conexión sale de configuración o del entorno.',
+      'Existen migraciones versionadas en el repositorio y el README explica cómo aplicarlas.',
+      'Los endpoints reciben y devuelven DTOs; la entidad de dominio no se expone al exterior.',
+      'FluentValidation está registrado en el pipeline y las reglas se ejecutan de verdad ante un payload inválido.',
+      'No hay credenciales hardcodeadas en el código ni commiteadas al repositorio.',
+      'El README permite a un tercero levantar el proyecto sin conocimiento previo.',
+    ],
+    duracionEstimadaMin: 180,
+  },
+
+  'dev-kubernetes': {
+    id: 'dev-kubernetes',
+    examType: 'dev-kubernetes',
+    clase: 'Clase 5',
+    title: 'Despliegue de una API en Kubernetes',
+    emoji: '☸️',
+    objetivo:
+      'Desplegar una aplicación contenerizada en un clúster local de Kubernetes usando manifiestos declarativos, con un Deployment que se autorecupere y un Service que la exponga.',
+    consigna: [
+      'Partí de una API propia (puede ser la de la Clase 3) con su `Dockerfile`, o de una imagen pública si preferís enfocarte en los manifiestos.',
+      'Escribí un manifiesto de `Deployment` con al menos 2 réplicas, `resources` declarados y un `readinessProbe`.',
+      'Escribí un manifiesto de `Service` que exponga la aplicación dentro del clúster, más un `NodePort` (o `minikube service`) para poder acceder desde afuera.',
+      'Agregá un `StatefulSet` para la base de datos con su `volumeClaimTemplates`, justificando en el README por qué acá corresponde StatefulSet y no Deployment.',
+      'Demostrá la autorecuperación: borrá un Pod con `kubectl delete pod`, mostrá que el ReplicaSet lo recrea y dejá la evidencia (captura o salida de `kubectl get pods`) en el README.',
+      'Demostrá el escalado: cambiá el número de réplicas de forma declarativa (editando el manifiesto y re-aplicando, no con `kubectl scale`) y documentá el resultado.',
+      'Documentá en el README los comandos exactos para levantar todo desde cero en Minikube o Kind.',
+    ],
+    entregables: [
+      'Repositorio público de GitHub con la carpeta `k8s/` de manifiestos.',
+      'Manifiestos de Deployment, Service y StatefulSet.',
+      'README con los comandos de despliegue y la evidencia de autorecuperación y escalado.',
+    ],
+    estructuraEsperada: `mi-app/
+├── Dockerfile
+├── README.md
+└── k8s/
+    ├── deployment.yaml
+    ├── service.yaml
+    ├── statefulset-postgres.yaml
+    └── service-postgres.yaml`,
+    criteriosDeEvaluacion: [
+      'Los manifiestos son declarativos y se aplican sin errores con `kubectl apply -f k8s/`.',
+      'El Deployment declara réplicas, recursos y al menos una probe.',
+      'El Service enruta correctamente al Deployment mediante selectores coherentes con las labels.',
+      'El StatefulSet usa `volumeClaimTemplates` y el README justifica la elección frente a Deployment.',
+      'Hay evidencia real de la autorecuperación y del escalado declarativo.',
+      'El README permite reproducir el despliegue completo en un clúster local limpio.',
+    ],
+    duracionEstimadaMin: 180,
+  },
+
+  'dev-config-kubernetes': {
+    id: 'dev-config-kubernetes',
+    examType: 'dev-config-kubernetes',
+    clase: 'Clase 6',
+    title: 'Configuración desacoplada con ConfigMaps, Secrets y Helm',
+    emoji: '🔐',
+    objetivo:
+      'Externalizar toda la configuración de una aplicación siguiendo el principio de inmutabilidad: la misma imagen debe correr en dev y en prod cambiando únicamente la configuración.',
+    consigna: [
+      'Tomá una aplicación contenerizada y sacá del código toda la configuración que hoy esté hardcodeada.',
+      'Creá un `ConfigMap` con la configuración no sensible: nivel de log, endpoints externos, nombre del entorno.',
+      'Creá un `Secret` con los datos sensibles: contraseña de la base, connection string o tokens.',
+      'Inyectá ambos en el Pod con `envFrom` y demostrá que la aplicación los consume como variables de entorno estándar, sin conocer Kubernetes.',
+      'Demostrá el principio de inmutabilidad: desplegá la MISMA imagen en dos namespaces (por ejemplo `dev` y `qa`) con configuraciones distintas, y documentá la diferencia de comportamiento.',
+      'Empaquetá todo en un chart de Helm con `values.yaml` parametrizable, más un `values-dev.yaml` y un `values-qa.yaml`.',
+      'Explicá en el README por qué un Secret en Base64 no está cifrado y qué medidas adicionales tomarías en un entorno real.',
+    ],
+    entregables: [
+      'Repositorio público de GitHub con el chart de Helm.',
+      'Manifiestos o templates de ConfigMap y Secret.',
+      '`values.yaml` más un archivo de values por entorno.',
+      'README con la demostración de una imagen en dos entornos y la nota sobre Base64.',
+    ],
+    estructuraEsperada: `mi-app/
+├── README.md
+└── chart/
+    ├── Chart.yaml
+    ├── values.yaml
+    ├── values-dev.yaml
+    ├── values-qa.yaml
+    └── templates/
+        ├── deployment.yaml
+        ├── configmap.yaml
+        └── secret.yaml`,
+    criteriosDeEvaluacion: [
+      'No queda configuración hardcodeada en el código ni en la imagen.',
+      'El reparto entre ConfigMap y Secret respeta el criterio de sensibilidad del material.',
+      'La inyección usa `envFrom` y la aplicación lee variables de entorno de forma estándar.',
+      'Se demuestra la misma imagen corriendo con dos configuraciones distintas.',
+      'El chart de Helm renderiza correctamente con cada archivo de values (`helm template` sin errores).',
+      'El README explica la diferencia entre codificación Base64 y cifrado real.',
+    ],
+    duracionEstimadaMin: 180,
+  },
+
+  'dev-seq-logging': {
+    id: 'dev-seq-logging',
+    examType: 'dev-seq-logging',
+    clase: 'Clases 7 y 8',
+    title: 'Logging estructurado con Serilog y Seq',
+    emoji: '📊',
+    objetivo:
+      'Reemplazar los logs de texto plano por logs estructurados centralizados, de modo que se pueda buscar por propiedades y correlacionar eventos entre varias instancias.',
+    consigna: [
+      'Configurá Serilog en una API .NET desde el arranque del pipeline, reemplazando el logger por defecto.',
+      'Configurá al menos dos sinks: consola (para `kubectl logs`) y HTTP hacia Seq (para centralización y análisis).',
+      'Emití logs estructurados con propiedades clave-valor — como mínimo `requestId` y algún identificador de negocio (`userId`, `pedidoId`) — nunca concatenando valores dentro del mensaje.',
+      'Usá los cuatro niveles de severidad de forma correcta: Information para el flujo normal, Warning para situaciones anómalas, Error para fallos y Fatal para caídas. Incluí al menos un caso de cada uno.',
+      'Enriquecé los logs con contexto de ejecución (nombre de la máquina, entorno, versión).',
+      'Desplegá Seq como Pod en Minikube, con un Service para la recepción HTTP interna y un volumen para persistir entre reinicios.',
+      'Escalá la API a 2 o más réplicas y demostrá en el README, con capturas del dashboard de Seq, una búsqueda filtrando por una propiedad que devuelva eventos de ambas instancias.',
+    ],
+    entregables: [
+      'Repositorio público de GitHub con la configuración de Serilog.',
+      'Manifiestos de despliegue de Seq (Deployment/Pod, Service y volumen).',
+      'README con capturas del dashboard de Seq mostrando una búsqueda por propiedad.',
+    ],
+    estructuraEsperada: `mi-api/
+├── README.md
+├── src/
+│   ├── Program.cs
+│   └── appsettings.json
+├── docs/
+│   └── capturas-seq/
+└── k8s/
+    ├── api-deployment.yaml
+    ├── seq-deployment.yaml
+    └── seq-service.yaml`,
+    criteriosDeEvaluacion: [
+      'Serilog está integrado al arranque de la aplicación y reemplaza al logger por defecto.',
+      'Los logs salen como propiedades estructuradas, no como texto interpolado dentro del mensaje.',
+      'Los cuatro niveles de severidad se usan con el criterio del material (Warning ≠ Error).',
+      'Seq corre dentro del clúster, recibe por Service HTTP interno y persiste con un volumen.',
+      'Hay evidencia de una búsqueda por propiedad que correlaciona eventos de más de una réplica.',
+      'La URL de Seq y cualquier API key salen de configuración, no del código.',
+    ],
+    duracionEstimadaMin: 180,
+  },
+
+  'dev-cicd-actions': {
+    id: 'dev-cicd-actions',
+    examType: 'dev-cicd-actions',
+    clase: 'Clase 9',
+    title: 'Pipeline CI/CD con GitHub Actions',
+    emoji: '🔁',
+    objetivo:
+      'Automatizar la validación y la entrega de una aplicación con GitHub Actions, separando correctamente la configuración no sensible de los secretos.',
+    consigna: [
+      'Creá un workflow de CI en `.github/workflows/` que se dispare con `push`, con `pull_request` y con `workflow_dispatch`.',
+      'El job de validación debe ejecutar los steps en el orden correcto: checkout, setup del runtime, restore, build (`--no-restore`) y test (`--no-build`).',
+      'Agregá un job de empaquetado que construya la imagen Docker y la publique en un registry (GitHub Container Registry sirve).',
+      'El job de empaquetado debe depender del de validación con `needs`, y ejecutarse solo en la rama principal.',
+      'Usá Variables del repositorio para lo no sensible (nombre de la imagen, entorno, namespace) y Secrets para las credenciales. Ningún secreto puede aparecer en el código ni en la salida de los logs.',
+      'Provocá un fallo a propósito en un Pull Request (por ejemplo, un test roto), mostrá el check en rojo y documentalo; después arreglalo y mostrá el check en verde.',
+      'Documentá en el README el diagrama del pipeline y qué Variables y Secrets hay que configurar para reproducirlo.',
+    ],
+    entregables: [
+      'Repositorio público de GitHub con los workflows en `.github/workflows/`.',
+      'Al menos una ejecución exitosa y una fallida visibles en la pestaña Actions.',
+      'README con el diagrama del pipeline y la lista de Variables y Secrets requeridos.',
+    ],
+    estructuraEsperada: `mi-app/
+├── .github/
+│   └── workflows/
+│       ├── ci.yml
+│       └── cd.yml
+├── Dockerfile
+├── README.md
+└── src/`,
+    criteriosDeEvaluacion: [
+      'El workflow declara los tres triggers pedidos y cada uno cumple su propósito.',
+      'El orden restore → build → test es correcto y usa `--no-restore` / `--no-build`.',
+      'El job de empaquetado usa `needs` y está condicionado a la rama principal.',
+      'La separación Variables / Secrets respeta el criterio de sensibilidad; no hay secretos en el código ni filtrados en los logs.',
+      'Hay evidencia del check fallando y después pasando sobre un Pull Request.',
+      'El README documenta el pipeline y permite reproducirlo en otro repositorio.',
+    ],
+    duracionEstimadaMin: 180,
+  },
+};
+
+export const DESARROLLO_CHALLENGE_IDS = Object.keys(
+  DESARROLLO_CHALLENGES
+) as DesarrolloChallengeId[];
+
+export function getDesarrolloChallenge(
+  id: string
+): DesarrolloChallenge | undefined {
+  return DESARROLLO_CHALLENGES[id as DesarrolloChallengeId];
+}
+
+// El profesor abre este link desde el panel de corrección, así que sólo se
+// aceptan repositorios de GitHub y no una URL arbitraria.
+const GITHUB_REPO_URL = /^https:\/\/github\.com\/[^/\s]+\/[^/\s]+\/?$/;
+
+export function isValidRepoUrl(value: string): boolean {
+  return GITHUB_REPO_URL.test(value.trim());
+}

--- a/apps/frontend/src/lib/labsCatalog.ts
+++ b/apps/frontend/src/lib/labsCatalog.ts
@@ -290,53 +290,13 @@ export const toolCategories: LabCategory[] = [
         implementedDate: 'Ago 2026',
       },
       {
-        id: 'dev-persistencia',
-        name: 'Clase 3 — Desarrollo: Persistencia con EF Core',
+        id: 'dev-proyecto-final',
+        name: 'Proyecto final: API + Kubernetes + CI/CD',
         description:
-          'Construí una API .NET con EF Core, PostgreSQL, migraciones, DTOs y FluentValidation. Entregás el link del repo y un evaluador lo corrige sobre 100 pts',
-        icon: '🗃️',
+          'Integrá las 5 clases en un solo repo: API .NET con EF Core/PostgreSQL, despliegue en Kubernetes, ConfigMaps/Secrets/Helm, Serilog/Seq y un pipeline de GitHub Actions. Entregás el link del repo y un evaluador lo corrige sobre 100 pts',
+        icon: '🏆',
         color: 'from-violet-600 to-fuchsia-700',
-        href: '/labs/desarrollo/dev-persistencia',
-        implementedDate: 'Ago 2026',
-      },
-      {
-        id: 'dev-kubernetes',
-        name: 'Clase 5 — Desarrollo: Despliegue en Kubernetes',
-        description:
-          'Desplegá una API en Minikube con Deployment, Service y StatefulSet, y demostrá autorecuperación y escalado. Entrega por link de repo, corrección manual',
-        icon: '☸️',
-        color: 'from-blue-600 to-sky-700',
-        href: '/labs/desarrollo/dev-kubernetes',
-        implementedDate: 'Ago 2026',
-      },
-      {
-        id: 'dev-config-kubernetes',
-        name: 'Clase 6 — Desarrollo: ConfigMaps, Secrets y Helm',
-        description:
-          'Externalizá la configuración con ConfigMaps y Secrets, inyectala con envFrom y empaquetá todo en un chart de Helm. Entrega por link de repo, corrección manual',
-        icon: '🔐',
-        color: 'from-teal-600 to-cyan-700',
-        href: '/labs/desarrollo/dev-config-kubernetes',
-        implementedDate: 'Ago 2026',
-      },
-      {
-        id: 'dev-seq-logging',
-        name: 'Clases 7 y 8 — Desarrollo: Serilog y Seq',
-        description:
-          'Instrumentá una API con Serilog, centralizá los logs en Seq dentro del clúster y demostrá búsquedas por propiedad. Entrega por link de repo, corrección manual',
-        icon: '📊',
-        color: 'from-emerald-600 to-teal-700',
-        href: '/labs/desarrollo/dev-seq-logging',
-        implementedDate: 'Ago 2026',
-      },
-      {
-        id: 'dev-cicd-actions',
-        name: 'Clase 9 — Desarrollo: Pipeline con GitHub Actions',
-        description:
-          'Armá un pipeline de GitHub Actions con validación, empaquetado y separación Variables/Secrets. Entrega por link de repo, corrección manual sobre 100 pts',
-        icon: '🔁',
-        color: 'from-orange-600 to-red-700',
-        href: '/labs/desarrollo/dev-cicd-actions',
+        href: '/labs/desarrollo/dev-proyecto-final',
         implementedDate: 'Ago 2026',
       },
     ],

--- a/apps/frontend/src/lib/labsCatalog.ts
+++ b/apps/frontend/src/lib/labsCatalog.ts
@@ -239,6 +239,106 @@ export const toolCategories: LabCategory[] = [
         featured: true,
         implementedDate: 'Ago 2026',
       },
+      {
+        id: 'clase3-data-persistencia',
+        name: 'Clase 3 — Data Persistencia',
+        description:
+          'Evaluación de la Clase 3 del bootcamp: persistencia, ADO.NET vs EF Core, migraciones, PostgreSQL/Npgsql, DTOs y FluentValidation — auto-corregido, 100 pts',
+        icon: '🗃️',
+        color: 'from-violet-500 to-purple-700',
+        href: '/assessments/clase3-data-persistencia',
+        implementedDate: 'Ago 2026',
+      },
+      {
+        id: 'clase5-kubernetes',
+        name: 'Clase 5 — Kubernetes',
+        description:
+          'Evaluación de la Clase 5 del bootcamp: orquestación, arquitectura del clúster, Pods, controladores y Services — auto-corregido, 100 pts',
+        icon: '☸️',
+        color: 'from-blue-500 to-indigo-700',
+        href: '/assessments/clase5-kubernetes',
+        implementedDate: 'Ago 2026',
+      },
+      {
+        id: 'clase6-config-kubernetes',
+        name: 'Clase 6 — Configuración en Kubernetes',
+        description:
+          'Evaluación de la Clase 6 del bootcamp: inmutabilidad, ConfigMaps, Secrets, envFrom, Helm y CI/CD de configuración — auto-corregido, 100 pts',
+        icon: '🔐',
+        color: 'from-teal-500 to-cyan-700',
+        href: '/assessments/clase6-config-kubernetes',
+        implementedDate: 'Ago 2026',
+      },
+      {
+        id: 'clase7-8-seq-logging',
+        name: 'Clases 7 y 8 — SEQ Structured Logging',
+        description:
+          'Evaluación de las Clases 7 y 8 del bootcamp: logs estructurados, Serilog, sinks, severidad y Seq centralizado — auto-corregido, 100 pts',
+        icon: '📊',
+        color: 'from-emerald-500 to-green-700',
+        href: '/assessments/clase7-8-seq-logging',
+        implementedDate: 'Ago 2026',
+      },
+      {
+        id: 'clase9-cicd-github-actions',
+        name: 'Clase 9 — CI/CD con GitHub Actions',
+        description:
+          'Evaluación de la Clase 9 del bootcamp: pipeline CI/CD, Delivery vs Deployment, workflows de GitHub Actions y Secrets — auto-corregido, 100 pts',
+        icon: '🔁',
+        color: 'from-orange-500 to-amber-700',
+        href: '/assessments/clase9-cicd-github-actions',
+        implementedDate: 'Ago 2026',
+      },
+      {
+        id: 'dev-persistencia',
+        name: 'Clase 3 — Desarrollo: Persistencia con EF Core',
+        description:
+          'Construí una API .NET con EF Core, PostgreSQL, migraciones, DTOs y FluentValidation. Entregás el link del repo y un evaluador lo corrige sobre 100 pts',
+        icon: '🗃️',
+        color: 'from-violet-600 to-fuchsia-700',
+        href: '/labs/desarrollo/dev-persistencia',
+        implementedDate: 'Ago 2026',
+      },
+      {
+        id: 'dev-kubernetes',
+        name: 'Clase 5 — Desarrollo: Despliegue en Kubernetes',
+        description:
+          'Desplegá una API en Minikube con Deployment, Service y StatefulSet, y demostrá autorecuperación y escalado. Entrega por link de repo, corrección manual',
+        icon: '☸️',
+        color: 'from-blue-600 to-sky-700',
+        href: '/labs/desarrollo/dev-kubernetes',
+        implementedDate: 'Ago 2026',
+      },
+      {
+        id: 'dev-config-kubernetes',
+        name: 'Clase 6 — Desarrollo: ConfigMaps, Secrets y Helm',
+        description:
+          'Externalizá la configuración con ConfigMaps y Secrets, inyectala con envFrom y empaquetá todo en un chart de Helm. Entrega por link de repo, corrección manual',
+        icon: '🔐',
+        color: 'from-teal-600 to-cyan-700',
+        href: '/labs/desarrollo/dev-config-kubernetes',
+        implementedDate: 'Ago 2026',
+      },
+      {
+        id: 'dev-seq-logging',
+        name: 'Clases 7 y 8 — Desarrollo: Serilog y Seq',
+        description:
+          'Instrumentá una API con Serilog, centralizá los logs en Seq dentro del clúster y demostrá búsquedas por propiedad. Entrega por link de repo, corrección manual',
+        icon: '📊',
+        color: 'from-emerald-600 to-teal-700',
+        href: '/labs/desarrollo/dev-seq-logging',
+        implementedDate: 'Ago 2026',
+      },
+      {
+        id: 'dev-cicd-actions',
+        name: 'Clase 9 — Desarrollo: Pipeline con GitHub Actions',
+        description:
+          'Armá un pipeline de GitHub Actions con validación, empaquetado y separación Variables/Secrets. Entrega por link de repo, corrección manual sobre 100 pts',
+        icon: '🔁',
+        color: 'from-orange-600 to-red-700',
+        href: '/labs/desarrollo/dev-cicd-actions',
+        implementedDate: 'Ago 2026',
+      },
     ],
   },
   {

--- a/apps/frontend/src/lib/ranking-achievements.ts
+++ b/apps/frontend/src/lib/ranking-achievements.ts
@@ -56,6 +56,11 @@ const RANKED_EXAM_TYPES: ExamType[] = [
   'playwright-practico',
   'playwright-fundamentals',
   'gherkin-fundamentals',
+  'clase3-data-persistencia',
+  'clase5-kubernetes',
+  'clase6-config-kubernetes',
+  'clase7-8-seq-logging',
+  'clase9-cicd-github-actions',
 ];
 
 const ASSESSMENT_RANKING_TYPES = new Set<ExamType>([
@@ -70,6 +75,11 @@ const ASSESSMENT_RANKING_TYPES = new Set<ExamType>([
   'cicd-fundamentals',
   'playwright-fundamentals',
   'gherkin-fundamentals',
+  'clase3-data-persistencia',
+  'clase5-kubernetes',
+  'clase6-config-kubernetes',
+  'clase7-8-seq-logging',
+  'clase9-cicd-github-actions',
 ]);
 
 function isMissingAchievementsTableError(error: { code?: string } | null) {

--- a/supabase/migrations/20260821_000000_bootcamp_clases_y_desarrollo.sql
+++ b/supabase/migrations/20260821_000000_bootcamp_clases_y_desarrollo.sql
@@ -1,7 +1,7 @@
--- Habilita las 10 pruebas técnicas nuevas del bootcamp:
+-- Habilita las 6 pruebas técnicas nuevas del bootcamp:
 --   * 5 evaluaciones teóricas (una por clase), auto-corregidas.
---   * 5 pruebas de desarrollo con entrega por link de repositorio y
---     corrección manual del evaluador.
+--   * 1 proyecto final de desarrollo, integrador de las 5 clases, con
+--     entrega por link de repositorio y corrección manual del evaluador.
 --
 -- Incluye además dos correcciones de arrastre:
 --   1. El nuevo tipo de pregunta `multiple_select` (las evaluaciones traen una
@@ -68,12 +68,8 @@ ALTER TABLE public.exam_results
         'clase6-config-kubernetes'::text,
         'clase7-8-seq-logging'::text,
         'clase9-cicd-github-actions'::text,
-        -- Pruebas de desarrollo (entrega por repositorio, corrección manual)
-        'dev-persistencia'::text,
-        'dev-kubernetes'::text,
-        'dev-config-kubernetes'::text,
-        'dev-seq-logging'::text,
-        'dev-cicd-actions'::text
+        -- Proyecto final de desarrollo (entrega por repositorio, corrección manual)
+        'dev-proyecto-final'::text
       ]
     )
   );

--- a/supabase/migrations/20260821_000000_bootcamp_clases_y_desarrollo.sql
+++ b/supabase/migrations/20260821_000000_bootcamp_clases_y_desarrollo.sql
@@ -1,0 +1,130 @@
+-- Habilita las 10 pruebas técnicas nuevas del bootcamp:
+--   * 5 evaluaciones teóricas (una por clase), auto-corregidas.
+--   * 5 pruebas de desarrollo con entrega por link de repositorio y
+--     corrección manual del evaluador.
+--
+-- Incluye además dos correcciones de arrastre:
+--   1. El nuevo tipo de pregunta `multiple_select` (las evaluaciones traen una
+--      pregunta de varias respuestas cada una).
+--   2. Los 5 assessments del PR #306 (api-dotnet, docker, kubernetes-helm,
+--      observability, cicd) nunca se agregaron al CHECK de
+--      exam_results.exam_type, así que sus inserts venían fallando en silencio
+--      (actions/assessments.ts sólo loguea un warning). Se re-declara el CHECK
+--      con el array completo.
+
+-- 1. assessment_questions.question_type — agrega 'multiple_select'
+ALTER TABLE public.assessment_questions
+  DROP CONSTRAINT IF EXISTS assessment_questions_question_type_check;
+
+ALTER TABLE public.assessment_questions
+  ADD CONSTRAINT assessment_questions_question_type_check
+  CHECK (
+    question_type IN (
+      'multiple_choice',
+      'multiple_select',
+      'true_false',
+      'short_text',
+      'doc_analysis',
+      'test_case_matrix',
+      'response_analysis',
+      'bug_report'
+    )
+  );
+
+-- 2. exam_results.exam_type — array completo (existentes + faltantes + nuevos)
+ALTER TABLE public.exam_results
+  DROP CONSTRAINT IF EXISTS exam_results_exam_type_check;
+
+ALTER TABLE public.exam_results
+  ADD CONSTRAINT exam_results_exam_type_check
+  CHECK (
+    exam_type = ANY (
+      ARRAY[
+        -- Labs y exámenes legacy
+        'git'::text,
+        'git-practico'::text,
+        'istqb'::text,
+        'performance'::text,
+        'test-app'::text,
+        'playwright-practico'::text,
+        -- Assessments existentes
+        'api-testing-fundamentals'::text,
+        'api-banking'::text,
+        'database-fundamentals'::text,
+        'database-practice'::text,
+        'infrastructure-fundamentals'::text,
+        'api-developer-fundamentals'::text,
+        'playwright-fundamentals'::text,
+        'gherkin-fundamentals'::text,
+        -- Assessments del PR #306 que faltaban en el CHECK
+        'api-dotnet-fundamentals'::text,
+        'docker-fundamentals'::text,
+        'kubernetes-helm-fundamentals'::text,
+        'observability-fundamentals'::text,
+        'cicd-fundamentals'::text,
+        -- Evaluaciones teóricas del bootcamp (una por clase)
+        'clase3-data-persistencia'::text,
+        'clase5-kubernetes'::text,
+        'clase6-config-kubernetes'::text,
+        'clase7-8-seq-logging'::text,
+        'clase9-cicd-github-actions'::text,
+        -- Pruebas de desarrollo (entrega por repositorio, corrección manual)
+        'dev-persistencia'::text,
+        'dev-kubernetes'::text,
+        'dev-config-kubernetes'::text,
+        'dev-seq-logging'::text,
+        'dev-cicd-actions'::text
+      ]
+    )
+  );
+
+-- 3. Reglas XP de las 5 evaluaciones teóricas.
+-- Las pruebas de desarrollo no otorgan XP: su puntaje lo carga una persona.
+INSERT INTO public.xp_rules (event_type, xp_amount, description, daily_limit, is_active)
+VALUES
+  ('CLASE3_DATA_PERSISTENCIA_COMPLETED',  70,  'Completar la evaluación Clase 3 Data Persistencia', 3, true),
+  ('CLASE3_DATA_PERSISTENCIA_PASSED',     120, 'Aprobar la evaluación Clase 3 Data Persistencia (score >= 70)', 3, true),
+  ('CLASE3_DATA_PERSISTENCIA_HIGH_SCORE', 160, 'Score sobresaliente en Clase 3 Data Persistencia (>= 90)', 3, true),
+
+  ('CLASE5_KUBERNETES_COMPLETED',  70,  'Completar la evaluación Clase 5 Kubernetes', 3, true),
+  ('CLASE5_KUBERNETES_PASSED',     120, 'Aprobar la evaluación Clase 5 Kubernetes (score >= 70)', 3, true),
+  ('CLASE5_KUBERNETES_HIGH_SCORE', 160, 'Score sobresaliente en Clase 5 Kubernetes (>= 90)', 3, true),
+
+  ('CLASE6_CONFIG_KUBERNETES_COMPLETED',  70,  'Completar la evaluación Clase 6 Configuración en Kubernetes', 3, true),
+  ('CLASE6_CONFIG_KUBERNETES_PASSED',     120, 'Aprobar la evaluación Clase 6 Configuración en Kubernetes (score >= 70)', 3, true),
+  ('CLASE6_CONFIG_KUBERNETES_HIGH_SCORE', 160, 'Score sobresaliente en Clase 6 Configuración en Kubernetes (>= 90)', 3, true),
+
+  ('CLASE7_8_SEQ_LOGGING_COMPLETED',  70,  'Completar la evaluación Clases 7 y 8 SEQ Structured Logging', 3, true),
+  ('CLASE7_8_SEQ_LOGGING_PASSED',     120, 'Aprobar la evaluación Clases 7 y 8 SEQ Structured Logging (score >= 70)', 3, true),
+  ('CLASE7_8_SEQ_LOGGING_HIGH_SCORE', 160, 'Score sobresaliente en Clases 7 y 8 SEQ Structured Logging (>= 90)', 3, true),
+
+  ('CLASE9_CICD_GITHUB_ACTIONS_COMPLETED',  70,  'Completar la evaluación Clase 9 CI/CD con GitHub Actions', 3, true),
+  ('CLASE9_CICD_GITHUB_ACTIONS_PASSED',     120, 'Aprobar la evaluación Clase 9 CI/CD con GitHub Actions (score >= 70)', 3, true),
+  ('CLASE9_CICD_GITHUB_ACTIONS_HIGH_SCORE', 160, 'Score sobresaliente en Clase 9 CI/CD con GitHub Actions (>= 90)', 3, true),
+
+  -- Assessments del PR #306, que tampoco tuvieron migración de xp_rules
+  ('API_DOTNET_FUNDAMENTALS_COMPLETED',  70,  'Completar el assessment API .NET Fundamentals', 3, true),
+  ('API_DOTNET_FUNDAMENTALS_PASSED',     120, 'Aprobar el assessment API .NET Fundamentals (score >= 70)', 3, true),
+  ('API_DOTNET_FUNDAMENTALS_HIGH_SCORE', 160, 'Score sobresaliente en API .NET Fundamentals (>= 90)', 3, true),
+
+  ('DOCKER_FUNDAMENTALS_COMPLETED',  70,  'Completar el assessment Docker Fundamentals', 3, true),
+  ('DOCKER_FUNDAMENTALS_PASSED',     120, 'Aprobar el assessment Docker Fundamentals (score >= 70)', 3, true),
+  ('DOCKER_FUNDAMENTALS_HIGH_SCORE', 160, 'Score sobresaliente en Docker Fundamentals (>= 90)', 3, true),
+
+  ('KUBERNETES_HELM_FUNDAMENTALS_COMPLETED',  70,  'Completar el assessment Kubernetes + Helm Fundamentals', 3, true),
+  ('KUBERNETES_HELM_FUNDAMENTALS_PASSED',     120, 'Aprobar el assessment Kubernetes + Helm Fundamentals (score >= 70)', 3, true),
+  ('KUBERNETES_HELM_FUNDAMENTALS_HIGH_SCORE', 160, 'Score sobresaliente en Kubernetes + Helm Fundamentals (>= 90)', 3, true),
+
+  ('OBSERVABILITY_FUNDAMENTALS_COMPLETED',  70,  'Completar el assessment Observability Fundamentals', 3, true),
+  ('OBSERVABILITY_FUNDAMENTALS_PASSED',     120, 'Aprobar el assessment Observability Fundamentals (score >= 70)', 3, true),
+  ('OBSERVABILITY_FUNDAMENTALS_HIGH_SCORE', 160, 'Score sobresaliente en Observability Fundamentals (>= 90)', 3, true),
+
+  ('CICD_FUNDAMENTALS_COMPLETED',  70,  'Completar el assessment CI/CD Fundamentals', 3, true),
+  ('CICD_FUNDAMENTALS_PASSED',     120, 'Aprobar el assessment CI/CD Fundamentals (score >= 70)', 3, true),
+  ('CICD_FUNDAMENTALS_HIGH_SCORE', 160, 'Score sobresaliente en CI/CD Fundamentals (>= 90)', 3, true)
+ON CONFLICT (event_type) DO UPDATE SET
+  xp_amount   = EXCLUDED.xp_amount,
+  description = EXCLUDED.description,
+  daily_limit = EXCLUDED.daily_limit,
+  is_active   = EXCLUDED.is_active,
+  updated_at  = now();


### PR DESCRIPTION
## Summary

- Suma **5 evaluaciones teóricas** nuevas (`clase3-data-persistencia`, `clase5-kubernetes`, `clase6-config-kubernetes`, `clase7-8-seq-logging`, `clase9-cicd-github-actions`), auto-corregidas, con las preguntas y claves de respuesta transcritas literalmente de los bancos de preguntas del bootcamp (5 Excel, 10 preguntas c/u).
- Suma **5 pruebas de desarrollo** equivalentes (una por clase) en `/labs/desarrollo/<id>`: el candidato entrega el link de un repositorio de GitHub y un evaluador carga un puntaje global (0–100) desde la nueva pantalla `/empresa/evaluar-desarrollo/[resultId]`.
- Las 10 pruebas quedan seleccionables al generar el código de proceso desde `/empresa/procesos/nuevo`, siguiendo el mismo patrón usado en PRs anteriores (#306, #307).
- Agrega el tipo de pregunta **`multiple_select`** (con crédito parcial) al motor de assessments compartido, porque cada banco de preguntas trae una pregunta de "varias respuestas" que el motor no podía puntuar antes.
- **Corrige un bug preexistente**: los 5 assessments de `api-dotnet-fundamentals`, `docker-fundamentals`, `kubernetes-helm-fundamentals`, `observability-fundamentals` y `cicd-fundamentals` (PR #306) nunca se agregaron al `CHECK` de `exam_results.exam_type`, así que sus resultados probablemente nunca llegaban a esa tabla en producción (el fallo se silenciaba con un `console.warn`). La nueva migración re-declara el `CHECK` con el array completo.

## Test plan

- [x] `pnpm --filter @aiquaa/frontend exec vitest run` — 120 tests pasan (33 nuevos: scoring de `multiple_select`, consistencia de las 5 definiciones nuevas, catálogo de pruebas de desarrollo). Las 15 suites que fallan (`window.matchMedia`) son preexistentes en una rama limpia, no relacionadas con este cambio.
- [x] `tsc --noEmit` — sin errores nuevos (los 24 errores de `@aiquaa/allpairs-core` son preexistentes por el paquete sin compilar en el worktree).
- [x] `eslint` sobre todos los archivos tocados — 0 errores, sólo warnings preexistentes.
- [x] `next build` — compila completo, incluyendo las 25 rutas de assessments nuevas y las 5 rutas estáticas de `/labs/desarrollo/*`.
- [ ] Manual: `/empresa/procesos/nuevo` → generar código con una prueba teórica y una de desarrollo → completar el assessment teórico end-to-end → entregar un repo en la prueba de desarrollo → corregirla desde `/empresa/evaluar-desarrollo/[resultId]` y confirmar que el puntaje se refleja en `/empresa/candidatos` y el perfil del candidato.

🤖 Generated with [Claude Code](https://claude.com/claude-code)