### PR TITLE
feat(assessments): destaca las pruebas nuevas y oculta las duplicadas

### DIFF
--- a/apps/frontend/src/app/assessments/page.tsx
+++ b/apps/frontend/src/app/assessments/page.tsx
@@ -1,15 +1,12 @@
 import Link from 'next/link';
 import { apiDeveloperFundamentalsDefinition } from './api-developer-fundamentals/data/assessment-definition';
 import { apiDotnetFundamentalsDefinition } from './api-dotnet-fundamentals/data/assessment-definition';
-import { cicdFundamentalsDefinition } from './cicd-fundamentals/data/assessment-definition';
 import { apiTestingFundamentalsDefinition } from './api-testing-fundamentals/data/assessment-definition';
 import { databaseFundamentalsDefinition } from './database-fundamentals/data/assessment-definition';
 import { dockerFundamentalsDefinition } from './docker-fundamentals/data/assessment-definition';
 import { databasePracticeDefinition } from './database-practice/data/assessment-definition';
 import { gherkinFundamentalsDefinition } from './gherkin-fundamentals/data/assessment-definition';
 import { infrastructureFundamentalsDefinition } from './infrastructure-fundamentals/data/assessment-definition';
-import { kubernetesHelmFundamentalsDefinition } from './kubernetes-helm-fundamentals/data/assessment-definition';
-import { observabilityFundamentalsDefinition } from './observability-fundamentals/data/assessment-definition';
 import { playwrightFundamentalsDefinition } from './playwright-fundamentals/data/assessment-definition';
 import { clase3DataPersistenciaDefinition } from './clase3-data-persistencia/data/assessment-definition';
 import { clase5KubernetesDefinition } from './clase5-kubernetes/data/assessment-definition';
@@ -96,27 +93,6 @@ export default function AssessmentsIndexPage() {
       badgeColor: 'text-amber-300',
       accentColor: 'text-blue-200',
       buttonClass: 'bg-blue-500 hover:bg-blue-400',
-    },
-    {
-      definition: kubernetesHelmFundamentalsDefinition,
-      badge: 'Examen teórico · Auto-corregido · Kubernetes',
-      badgeColor: 'text-amber-300',
-      accentColor: 'text-sky-200',
-      buttonClass: 'bg-sky-500 hover:bg-sky-400',
-    },
-    {
-      definition: observabilityFundamentalsDefinition,
-      badge: 'Examen teórico · Auto-corregido · Observabilidad',
-      badgeColor: 'text-amber-300',
-      accentColor: 'text-teal-200',
-      buttonClass: 'bg-teal-500 hover:bg-teal-400',
-    },
-    {
-      definition: cicdFundamentalsDefinition,
-      badge: 'Examen teórico · Auto-corregido · CI/CD',
-      badgeColor: 'text-amber-300',
-      accentColor: 'text-orange-200',
-      buttonClass: 'bg-orange-500 hover:bg-orange-400',
     },
     {
       definition: playwrightFundamentalsDefinition,

--- a/apps/frontend/src/app/empresa/procesos/nuevo/page.tsx
+++ b/apps/frontend/src/app/empresa/procesos/nuevo/page.tsx
@@ -12,6 +12,42 @@ import {
 
 const EXAM_OPTIONS = [
   {
+    id: 'clase3-data-persistencia',
+    label: 'Clase 3 — Data Persistencia (Examen teórico)',
+    description:
+      'Persistencia, ADO.NET vs Entity Framework Core, migraciones, PostgreSQL/Npgsql, DTOs y FluentValidation — auto-corregido, 10 preguntas, 100 pts',
+  },
+  {
+    id: 'clase5-kubernetes',
+    label: 'Clase 5 — Kubernetes (Examen teórico)',
+    description:
+      'Pilares de la orquestación, arquitectura del clúster, Pods, Deployment/ReplicaSet, StatefulSet y Services — auto-corregido, 10 preguntas, 100 pts',
+  },
+  {
+    id: 'clase6-config-kubernetes',
+    label: 'Clase 6 — Configuración en Kubernetes (Examen teórico)',
+    description:
+      'Inmutabilidad de la imagen, ConfigMaps, Secrets y Base64, inyección con envFrom, Helm y CI/CD de configuración — auto-corregido, 10 preguntas, 100 pts',
+  },
+  {
+    id: 'clase7-8-seq-logging',
+    label: 'Clases 7 y 8 — SEQ Structured Logging (Examen teórico)',
+    description:
+      'Límites de kubectl logs, logs estructurados, Serilog y sus sinks, niveles de severidad y Seq en Kubernetes — auto-corregido, 10 preguntas, 100 pts',
+  },
+  {
+    id: 'clase9-cicd-github-actions',
+    label: 'Clase 9 — CI/CD con GitHub Actions (Examen teórico)',
+    description:
+      'Delivery vs Deployment, etapas del pipeline, Jobs/Steps/Triggers/Runners, workflows y separación Variables/Secrets — auto-corregido, 10 preguntas, 100 pts',
+  },
+  {
+    id: 'dev-proyecto-final',
+    label: 'Proyecto final: API + Kubernetes + CI/CD (Prueba de desarrollo)',
+    description:
+      'Integra las 5 clases en un solo repo: API .NET con EF Core/PostgreSQL, despliegue en Kubernetes, configuración con ConfigMaps/Secrets/Helm, logging con Serilog/Seq y pipeline de GitHub Actions — entrega por link de repositorio, corrección manual del evaluador sobre 100 pts',
+  },
+  {
     id: 'istqb',
     label: 'ISTQB CTFL — Fundamentos de QA',
     description:
@@ -90,64 +126,10 @@ const EXAM_OPTIONS = [
       'Dockerfiles multistage e imágenes livianas, variables de entorno sin hardcode y ejecución/reproducibilidad local — auto-corregido, 3 secciones',
   },
   {
-    id: 'kubernetes-helm-fundamentals',
-    label: 'Kubernetes + Helm — Fundamentos (Examen teórico)',
-    description:
-      'Manifiestos Deployment/Service, ConfigMaps y Secrets, charts de Helm y despliegue funcional en Minikube — auto-corregido, 4 secciones',
-  },
-  {
-    id: 'observability-fundamentals',
-    label: 'Observabilidad — Fundamentos (Examen teórico)',
-    description:
-      'Logging estructurado con Serilog, centralización en Seq, niveles de log y visualización — auto-corregido, 4 secciones',
-  },
-  {
-    id: 'cicd-fundamentals',
-    label: 'CI/CD — Fundamentos (Examen teórico)',
-    description:
-      'Pipelines de integración continua, despliegue continuo automatizado y buenas prácticas de versionado — auto-corregido, 3 secciones',
-  },
-  {
     id: 'gherkin-fundamentals',
     label: 'Gherkin y BDD — Fundamentos (Examen teórico)',
     description:
       'Fundamentos de BDD, sintaxis Gherkin (Given/When/Then) y escenarios avanzados aplicados a testing — auto-corregido, 3 niveles',
-  },
-  {
-    id: 'clase3-data-persistencia',
-    label: 'Clase 3 — Data Persistencia (Examen teórico)',
-    description:
-      'Persistencia, ADO.NET vs Entity Framework Core, migraciones, PostgreSQL/Npgsql, DTOs y FluentValidation — auto-corregido, 10 preguntas, 100 pts',
-  },
-  {
-    id: 'clase5-kubernetes',
-    label: 'Clase 5 — Kubernetes (Examen teórico)',
-    description:
-      'Pilares de la orquestación, arquitectura del clúster, Pods, Deployment/ReplicaSet, StatefulSet y Services — auto-corregido, 10 preguntas, 100 pts',
-  },
-  {
-    id: 'clase6-config-kubernetes',
-    label: 'Clase 6 — Configuración en Kubernetes (Examen teórico)',
-    description:
-      'Inmutabilidad de la imagen, ConfigMaps, Secrets y Base64, inyección con envFrom, Helm y CI/CD de configuración — auto-corregido, 10 preguntas, 100 pts',
-  },
-  {
-    id: 'clase7-8-seq-logging',
-    label: 'Clases 7 y 8 — SEQ Structured Logging (Examen teórico)',
-    description:
-      'Límites de kubectl logs, logs estructurados, Serilog y sus sinks, niveles de severidad y Seq en Kubernetes — auto-corregido, 10 preguntas, 100 pts',
-  },
-  {
-    id: 'clase9-cicd-github-actions',
-    label: 'Clase 9 — CI/CD con GitHub Actions (Examen teórico)',
-    description:
-      'Delivery vs Deployment, etapas del pipeline, Jobs/Steps/Triggers/Runners, workflows y separación Variables/Secrets — auto-corregido, 10 preguntas, 100 pts',
-  },
-  {
-    id: 'dev-proyecto-final',
-    label: 'Proyecto final: API + Kubernetes + CI/CD (Prueba de desarrollo)',
-    description:
-      'Integra las 5 clases en un solo repo: API .NET con EF Core/PostgreSQL, despliegue en Kubernetes, configuración con ConfigMaps/Secrets/Helm, logging con Serilog/Seq y pipeline de GitHub Actions — entrega por link de repositorio, corrección manual del evaluador sobre 100 pts',
   },
   {
     id: 'test-app',

--- a/apps/frontend/src/lib/labsCatalog.ts
+++ b/apps/frontend/src/lib/labsCatalog.ts
@@ -174,6 +174,72 @@ export const toolCategories: LabCategory[] = [
       'Pruebas técnicas para desarrolladores: evaluá fundamentos y criterio de diseño',
     tools: [
       {
+        id: 'clase3-data-persistencia',
+        name: 'Clase 3 — Data Persistencia',
+        description:
+          'Evaluación de la Clase 3 del bootcamp: persistencia, ADO.NET vs EF Core, migraciones, PostgreSQL/Npgsql, DTOs y FluentValidation — auto-corregido, 100 pts',
+        icon: '🗃️',
+        color: 'from-violet-500 to-purple-700',
+        href: '/assessments/clase3-data-persistencia',
+        featured: true,
+        implementedDate: 'Ago 2026',
+      },
+      {
+        id: 'clase5-kubernetes',
+        name: 'Clase 5 — Kubernetes',
+        description:
+          'Evaluación de la Clase 5 del bootcamp: orquestación, arquitectura del clúster, Pods, controladores y Services — auto-corregido, 100 pts',
+        icon: '☸️',
+        color: 'from-blue-500 to-indigo-700',
+        href: '/assessments/clase5-kubernetes',
+        featured: true,
+        implementedDate: 'Ago 2026',
+      },
+      {
+        id: 'clase6-config-kubernetes',
+        name: 'Clase 6 — Configuración en Kubernetes',
+        description:
+          'Evaluación de la Clase 6 del bootcamp: inmutabilidad, ConfigMaps, Secrets, envFrom, Helm y CI/CD de configuración — auto-corregido, 100 pts',
+        icon: '🔐',
+        color: 'from-teal-500 to-cyan-700',
+        href: '/assessments/clase6-config-kubernetes',
+        featured: true,
+        implementedDate: 'Ago 2026',
+      },
+      {
+        id: 'clase7-8-seq-logging',
+        name: 'Clases 7 y 8 — SEQ Structured Logging',
+        description:
+          'Evaluación de las Clases 7 y 8 del bootcamp: logs estructurados, Serilog, sinks, severidad y Seq centralizado — auto-corregido, 100 pts',
+        icon: '📊',
+        color: 'from-emerald-500 to-green-700',
+        href: '/assessments/clase7-8-seq-logging',
+        featured: true,
+        implementedDate: 'Ago 2026',
+      },
+      {
+        id: 'clase9-cicd-github-actions',
+        name: 'Clase 9 — CI/CD con GitHub Actions',
+        description:
+          'Evaluación de la Clase 9 del bootcamp: pipeline CI/CD, Delivery vs Deployment, workflows de GitHub Actions y Secrets — auto-corregido, 100 pts',
+        icon: '🔁',
+        color: 'from-orange-500 to-amber-700',
+        href: '/assessments/clase9-cicd-github-actions',
+        featured: true,
+        implementedDate: 'Ago 2026',
+      },
+      {
+        id: 'dev-proyecto-final',
+        name: 'Proyecto final: API + Kubernetes + CI/CD',
+        description:
+          'Integrá las 5 clases en un solo repo: API .NET con EF Core/PostgreSQL, despliegue en Kubernetes, ConfigMaps/Secrets/Helm, Serilog/Seq y un pipeline de GitHub Actions. Entregás el link del repo y un evaluador lo corrige sobre 100 pts',
+        icon: '🏆',
+        color: 'from-violet-600 to-fuchsia-700',
+        href: '/labs/desarrollo/dev-proyecto-final',
+        featured: true,
+        implementedDate: 'Ago 2026',
+      },
+      {
         id: 'api-developer-fundamentals',
         name: 'APIs para Desarrolladores — Fundamentos',
         description:
@@ -204,99 +270,6 @@ export const toolCategories: LabCategory[] = [
         color: 'from-blue-500 to-cyan-600',
         href: '/assessments/docker-fundamentals',
         featured: true,
-        implementedDate: 'Ago 2026',
-      },
-      {
-        id: 'kubernetes-helm-fundamentals',
-        name: 'Kubernetes + Helm — Fundamentos',
-        description:
-          'Prueba técnica para bootcamp de desarrollo: manifiestos Deployment/Service, ConfigMaps y Secrets, charts de Helm y despliegue funcional en Minikube — auto-corregido, 100 pts',
-        icon: '☸️',
-        color: 'from-sky-500 to-blue-700',
-        href: '/assessments/kubernetes-helm-fundamentals',
-        featured: true,
-        implementedDate: 'Ago 2026',
-      },
-      {
-        id: 'observability-fundamentals',
-        name: 'Observabilidad — Fundamentos',
-        description:
-          'Prueba técnica para bootcamp de desarrollo: logging estructurado con Serilog, centralización en Seq, niveles de log y visualización — auto-corregido, 100 pts',
-        icon: '📈',
-        color: 'from-teal-500 to-emerald-600',
-        href: '/assessments/observability-fundamentals',
-        featured: true,
-        implementedDate: 'Ago 2026',
-      },
-      {
-        id: 'cicd-fundamentals',
-        name: 'CI/CD — Fundamentos',
-        description:
-          'Prueba técnica para bootcamp de desarrollo: pipelines de integración continua, despliegue continuo automatizado y buenas prácticas de versionado — auto-corregido, 100 pts',
-        icon: '🔁',
-        color: 'from-orange-500 to-red-600',
-        href: '/assessments/cicd-fundamentals',
-        featured: true,
-        implementedDate: 'Ago 2026',
-      },
-      {
-        id: 'clase3-data-persistencia',
-        name: 'Clase 3 — Data Persistencia',
-        description:
-          'Evaluación de la Clase 3 del bootcamp: persistencia, ADO.NET vs EF Core, migraciones, PostgreSQL/Npgsql, DTOs y FluentValidation — auto-corregido, 100 pts',
-        icon: '🗃️',
-        color: 'from-violet-500 to-purple-700',
-        href: '/assessments/clase3-data-persistencia',
-        implementedDate: 'Ago 2026',
-      },
-      {
-        id: 'clase5-kubernetes',
-        name: 'Clase 5 — Kubernetes',
-        description:
-          'Evaluación de la Clase 5 del bootcamp: orquestación, arquitectura del clúster, Pods, controladores y Services — auto-corregido, 100 pts',
-        icon: '☸️',
-        color: 'from-blue-500 to-indigo-700',
-        href: '/assessments/clase5-kubernetes',
-        implementedDate: 'Ago 2026',
-      },
-      {
-        id: 'clase6-config-kubernetes',
-        name: 'Clase 6 — Configuración en Kubernetes',
-        description:
-          'Evaluación de la Clase 6 del bootcamp: inmutabilidad, ConfigMaps, Secrets, envFrom, Helm y CI/CD de configuración — auto-corregido, 100 pts',
-        icon: '🔐',
-        color: 'from-teal-500 to-cyan-700',
-        href: '/assessments/clase6-config-kubernetes',
-        implementedDate: 'Ago 2026',
-      },
-      {
-        id: 'clase7-8-seq-logging',
-        name: 'Clases 7 y 8 — SEQ Structured Logging',
-        description:
-          'Evaluación de las Clases 7 y 8 del bootcamp: logs estructurados, Serilog, sinks, severidad y Seq centralizado — auto-corregido, 100 pts',
-        icon: '📊',
-        color: 'from-emerald-500 to-green-700',
-        href: '/assessments/clase7-8-seq-logging',
-        implementedDate: 'Ago 2026',
-      },
-      {
-        id: 'clase9-cicd-github-actions',
-        name: 'Clase 9 — CI/CD con GitHub Actions',
-        description:
-          'Evaluación de la Clase 9 del bootcamp: pipeline CI/CD, Delivery vs Deployment, workflows de GitHub Actions y Secrets — auto-corregido, 100 pts',
-        icon: '🔁',
-        color: 'from-orange-500 to-amber-700',
-        href: '/assessments/clase9-cicd-github-actions',
-        implementedDate: 'Ago 2026',
-      },
-      {
-        id: 'dev-proyecto-final',
-        name: 'Proyecto final: API + Kubernetes + CI/CD',
-        description:
-          'Integrá las 5 clases en un solo repo: API .NET con EF Core/PostgreSQL, despliegue en Kubernetes, ConfigMaps/Secrets/Helm, Serilog/Seq y un pipeline de GitHub Actions. Entregás el link del repo y un evaluador lo corrige sobre 100 pts',
-        icon: '🏆',
-        color: 'from-violet-600 to-fuchsia-700',
-        href: '/labs/desarrollo/dev-proyecto-final',
         implementedDate: 'Ago 2026',
       },
     ],


### PR DESCRIPTION
## Summary

Sigue a #323 (ya mergeado). Ajusta cómo se descubren las pruebas técnicas del bootcamp:

- **Mueve al tope** las 5 evaluaciones teóricas de Clase X (`clase3-data-persistencia`, `clase5-kubernetes`, `clase6-config-kubernetes`, `clase7-8-seq-logging`, `clase9-cicd-github-actions`) y el proyecto final de desarrollo (`dev-proyecto-final`) en:
  - el selector de `/empresa/procesos/nuevo`
  - la categoría "💻 Desarrollo" de `/labs`
- **Oculta** `kubernetes-helm-fundamentals`, `observability-fundamentals` y `cicd-fundamentals` de `/labs`, `/assessments` y del selector de `/empresa/procesos/nuevo`, porque su contenido quedó duplicado por las nuevas pruebas de Clase 5+6, Clase 7-8 y Clase 9 respectivamente.
  - No se borran: las rutas `/assessments/<slug>` siguen accesibles, los resultados existentes en `exam_results` siguen renderizando normal, y los procesos que ya las tenían seleccionadas no se ven afectados. Sólo dejan de ofrecerse para procesos **nuevos**.
  - `docker-fundamentals` e `infrastructure-fundamentals` quedan visibles: no tienen un equivalente exacto entre las pruebas nuevas (no se generó una prueba de la Clase 4).

## Test plan

- [x] `pnpm --filter @aiquaa/frontend exec vitest run` sobre `src/app/assessments` y `src/lib/labs` — 111 tests pasan (las pruebas ocultadas siguen teniendo su propia suite de definición intacta, sólo se les quitó la entrada de catálogo).
- [x] `tsc --noEmit` — sin errores.
- [x] `eslint` sobre los 3 archivos tocados — sin errores.
- [ ] Manual: abrir `/labs` y `/assessments` y confirmar que las 5 Clase X + proyecto final aparecen primero y que Kubernetes+Helm/Observabilidad/CI/CD ya no aparecen; abrir `/empresa/procesos/nuevo` y confirmar el mismo orden en el selector.

🤖 Generated with [Claude Code](https://claude.com/claude-code)