### PR TITLE
fix(test): forward passwordRef/confirmPasswordRef in RegisterForm real-flow test mock

### DIFF
--- a/apps/frontend/test/components/auth/RegisterForm.real.test.tsx
+++ b/apps/frontend/test/components/auth/RegisterForm.real.test.tsx
@@ -1,5 +1,11 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import RegisterForm from '@/components/auth/RegisterForm';
 
@@ -25,8 +31,11 @@ vi.mock('@/components/auth/AuthForm', () => ({
     errors,
     formData,
     onFieldChange,
+    onPasswordChange,
     showAlert,
     alertMessage,
+    passwordRef,
+    confirmPasswordRef,
   }: any) => (
     <form onSubmit={onSubmit}>
       <input
@@ -47,15 +56,17 @@ vi.mock('@/components/auth/AuthForm', () => ({
         aria-label="Contraseña"
         name="password"
         placeholder="Contraseña"
-        value={formData.password || ''}
-        onChange={onFieldChange}
+        ref={passwordRef}
+        defaultValue={formData.password || ''}
+        onChange={onPasswordChange}
       />
       <input
         aria-label="Confirmar contraseña"
         name="confirmPassword"
         placeholder="Confirmar contraseña"
-        value={formData.confirmPassword || ''}
-        onChange={onFieldChange}
+        ref={confirmPasswordRef}
+        defaultValue={formData.confirmPassword || ''}
+        onChange={onPasswordChange}
       />
       <button type="submit">Crear cuenta</button>
       {errors.name && <p>{errors.name}</p>}
@@ -89,7 +100,9 @@ describe('RegisterForm real flow', () => {
     expect(await screen.findByText('Nombre obligatorio')).toBeInTheDocument();
     expect(screen.getByText('Correo obligatorio')).toBeInTheDocument();
     expect(screen.getByText('Contraseña obligatoria')).toBeInTheDocument();
-    expect(screen.getByText('Confirmar contraseña obligatorio')).toBeInTheDocument();
+    expect(
+      screen.getByText('Confirmar contraseña obligatorio')
+    ).toBeInTheDocument();
     expect(mockRegister).not.toHaveBeenCalled();
   });
 
@@ -97,13 +110,21 @@ describe('RegisterForm real flow', () => {
     const user = userEvent.setup();
     render(<RegisterForm />);
 
-    await user.type(screen.getByPlaceholderText('Nombre completo'), 'QA Aiquaa');
+    await user.type(
+      screen.getByPlaceholderText('Nombre completo'),
+      'QA Aiquaa'
+    );
     await user.type(screen.getByPlaceholderText('Email'), 'qa@aiquaa.com');
     await user.type(screen.getByPlaceholderText('Contraseña'), 'Password123');
-    await user.type(screen.getByPlaceholderText('Confirmar contraseña'), 'Password456');
+    await user.type(
+      screen.getByPlaceholderText('Confirmar contraseña'),
+      'Password456'
+    );
     await user.click(getSubmitButton());
 
-    expect(await screen.findByText('Las contraseñas no coinciden')).toBeInTheDocument();
+    expect(
+      await screen.findByText('Las contraseñas no coinciden')
+    ).toBeInTheDocument();
     expect(mockRegister).not.toHaveBeenCalled();
   });
 
@@ -116,10 +137,16 @@ describe('RegisterForm real flow', () => {
 
     render(<RegisterForm />);
 
-    await user.type(screen.getByPlaceholderText('Nombre completo'), 'QA Aiquaa');
+    await user.type(
+      screen.getByPlaceholderText('Nombre completo'),
+      'QA Aiquaa'
+    );
     await user.type(screen.getByPlaceholderText('Email'), 'qa@aiquaa.com');
     await user.type(screen.getByPlaceholderText('Contraseña'), 'Password123');
-    await user.type(screen.getByPlaceholderText('Confirmar contraseña'), 'Password123');
+    await user.type(
+      screen.getByPlaceholderText('Confirmar contraseña'),
+      'Password123'
+    );
     await user.click(getSubmitButton());
 
     await waitFor(() => {
@@ -132,7 +159,9 @@ describe('RegisterForm real flow', () => {
     });
 
     expect(
-      await screen.findByText('Este email ya está registrado. Intenta iniciar sesión o usa otro email.')
+      await screen.findByText(
+        'Este email ya está registrado. Intenta iniciar sesión o usa otro email.'
+      )
     ).toBeInTheDocument();
   });
 
@@ -171,7 +200,9 @@ describe('RegisterForm real flow', () => {
       confirmPassword: 'Password123',
     });
     expect(
-      screen.getByText('Registro exitoso. Revisa tu email para verificar tu cuenta.')
+      screen.getByText(
+        'Registro exitoso. Revisa tu email para verificar tu cuenta.'
+      )
     ).toBeInTheDocument();
     expect(setTimeoutSpy).toHaveBeenCalledOnce();
     expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), 2000);


### PR DESCRIPTION
## Summary

- `RegisterForm.tsx` reads `password`/`confirmPassword` at submit time via `passwordRef.current?.value` / `confirmPasswordRef.current?.value` — these are refs forwarded down to `AuthForm`, which attaches them (`ref={passwordRef}`, `ref={confirmPasswordRef}`) to its uncontrolled password inputs.
- The `AuthForm` mock in `test/components/auth/RegisterForm.real.test.tsx` never accepted or attached those refs, so `passwordRef.current` was always `null` at submit time regardless of what the test typed — `validateForm()` always saw `password: '', confirmPassword: ''`, produced "Contraseña obligatoria"/"Confirmar contraseña obligatorio" errors, and `handleSubmit` short-circuited (`if (!validateForm()) return;`) before ever calling the registration action.
- This is one of the 14 pre-existing failures tracked in #314 ("Required check 'Lint & Unit Tests' is permanently red on main"). Fixes 2 of the 3 previously-failing tests in this file (verified locally: `pnpm --filter @aiquaa/frontend test -- RegisterForm.real` goes from 1 passed/3 failed to 3 passed/1 failed).

## Remaining failure in this file (not fixed here, out of scope)

The 4th test ("muestra éxito y programa la redirección al login tras registrarse") still fails for an unrelated, deeper reason: this test file mocks a `useNextAuth().register()` call, but `RegisterForm.tsx` no longer uses that hook — it now calls the `registerAction` server action directly (imported from `@/actions/auth`). Since `registerAction` isn't mocked in this file, the real server action executes in the test environment. Fixing this properly means mocking `registerAction` (like `RegisterForm.test.tsx` already does) and rewriting the assertions around it, which is a larger change than this scoped ref-forwarding fix and risks masking other behavior — left as a follow-up.

## Verification

- `pnpm --filter @aiquaa/frontend test -- RegisterForm.real` — 3/4 passing (was 1/4).
- Full `pnpm --filter @aiquaa/frontend test` — 32 failing (was 33 on `main`, per #314), no new failures introduced; same 15 pre-existing failing files as documented in #314.
- `pnpm exec eslint` on the changed file — clean.
- `pnpm --filter @aiquaa/frontend type-check` — clean.

## Context

Found and fixed during an automated, unattended QA-cycle session (no live human watching) while investigating the pre-existing test failures tracked in #314, which itself blocks the required CI check for #309 (SEC-HIGH, exam answer key exposed client-side) and other pending PRs.


---
_Generated by [Claude Code](https://claude.ai/code/session_019LR8tZwguN8hRiKHzThGD1)_