### PR TITLE
fix(db): stop handle_new_user() from writing empty display_name (#319)

### DIFF
--- a/supabase/migrations/20260827000000_fix_empty_display_name_fallback.sql
+++ b/supabase/migrations/20260827000000_fix_empty_display_name_fallback.sql
@@ -1,0 +1,69 @@
+-- Fix #319: handle_new_user() fell back to an empty string ('') for
+-- display_name whenever raw_user_meta_data had no 'full_name' (email/password
+-- signups with no name field, some OAuth providers). An empty string is not
+-- NULL, so it silently reached profiles/ranking_candidatos and rendered as a
+-- blank name on the public leaderboard. Confirmed in production: 8 profiles
+-- affected since 2026-05-09, still occurring on new signups as of 2026-08-19.
+--
+-- This migration only changes the fallback for *future* signups (derive a
+-- name from the email local-part instead of ''). It intentionally does not
+-- backfill the 8 existing empty rows in public.profiles /
+-- public.ranking_candidatos — that's a data change on production and should
+-- go through human review separately, not ship inside a trigger fix.
+CREATE OR REPLACE FUNCTION public.handle_new_user()
+ RETURNS trigger
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_audience     audience_type;
+  v_empresa_id   UUID;
+  v_display_name TEXT;
+BEGIN
+  v_audience := coalesce(
+    (new.raw_user_meta_data ->> 'audience')::audience_type,
+    'candidato'
+  );
+
+  -- Prefer full_name from auth metadata; fall back to the email local-part
+  -- (never an empty string) so the leaderboard/profile never render blank.
+  v_display_name := nullif(trim(coalesce(new.raw_user_meta_data ->> 'full_name', '')), '');
+  IF v_display_name IS NULL THEN
+    v_display_name := nullif(split_part(coalesce(new.email, ''), '@', 1), '');
+  END IF;
+
+  INSERT INTO public.profiles (id, display_name, email, audience, company_name)
+  VALUES (
+    new.id,
+    v_display_name,
+    new.email,
+    v_audience,
+    new.raw_user_meta_data ->> 'company_name'
+  )
+  ON CONFLICT (id) DO UPDATE SET
+    display_name = excluded.display_name,
+    email        = excluded.email,
+    audience     = excluded.audience,
+    company_name = excluded.company_name;
+
+  IF v_audience = 'empresa' THEN
+    INSERT INTO public.empresas (ruc, razon_social, nombre_comercial)
+    VALUES (
+      NULLIF(trim(coalesce(new.raw_user_meta_data ->> 'ruc', '')), ''),
+      coalesce(new.raw_user_meta_data ->> 'company_name', 'Empresa sin nombre'),
+      new.raw_user_meta_data ->> 'company_name'
+    )
+    RETURNING id INTO v_empresa_id;
+
+    UPDATE public.profiles
+    SET empresa_id = v_empresa_id
+    WHERE id = new.id;
+
+    INSERT INTO public.empresa_miembros (empresa_id, user_id, role, status, joined_at)
+    VALUES (v_empresa_id, new.id, 'owner', 'active', now());
+  END IF;
+
+  RETURN new;
+END;
+$function$;


### PR DESCRIPTION
## Summary

Closes the root cause identified in #319: `handle_new_user()` (the trigger that populates `public.profiles` on signup) fell back to `display_name = ''` whenever `raw_user_meta_data` had no `full_name` — email/password signups with no name field, and some OAuth providers. An empty string isn't NULL, so nothing downstream corrects it, and the row renders with a blank name on the public ranking/leaderboard.

**Verified in production (Supabase MCP) this cycle:** 8 profiles affected (`display_name = ''`), oldest from 2026-05-09, count unchanged since 2026-08-19/20/21 (167 total profiles now vs. 147 then — 20 new signups in that window, none newly affected, so the fallback isn't firing on *every* signup, just ones without `full_name`, but it's still live).

## Fix

`supabase/migrations/20260827000000_fix_empty_display_name_fallback.sql` — `CREATE OR REPLACE FUNCTION public.handle_new_user()`, same logic as the current production function, except the `display_name` fallback: when `full_name` is missing/blank, derive it from the email local-part (`split_part(email, '@', 1)`) instead of `''`. Everything else (audience handling, empresa creation) is byte-for-byte the same as the live function (confirmed via `pg_get_functiondef` against production before writing this).

## Explicitly out of scope

- **Backfill of the 8 existing empty rows** in `public.profiles` / `public.ranking_candidatos` — that's a production data change, not a trigger fix, and #319 itself flags it as needing human review before writing over real user rows. Left as a follow-up.
- Checked `apps/frontend/src/actions/profile.ts` (the profile-edit path): it already does `display_name: fullName || username || null` (never writes `''`), so no separate app-layer fix is needed there.

## Why this needs human review before merge

DDL change to a `SECURITY DEFINER` trigger function that runs on every signup (`auth.users` insert), applied to a repo whose migrations are the source of truth for a live production Supabase project. This PR was authored by an unattended scheduled QA-cycle session with no live human watching, and the migration has not been applied/tested against a branch or staging Supabase project from this environment (only the equivalence with the current prod function was verified by reading its definition via SQL). Please review the diff against the current live function and apply via the project's normal migration path.

## Test plan

- [x] Read live `handle_new_user()` via `pg_get_functiondef` in production (Supabase MCP) and confirmed the migration changes only the `display_name` fallback line, nothing else.
- [x] Confirmed current empty-name count (8/167 profiles) via read-only SQL.
- [x] Confirmed `apps/frontend/src/actions/profile.ts`'s profile-edit path already avoids writing `''` for `display_name`.
- [ ] Apply migration to a Supabase branch/staging project and verify a signup with no `full_name` gets a non-empty `display_name`. Not done here — no staging project available from this environment.

---
*Hallado y corregido en ciclo de mejora continua automatizado (QA-CYCLE), 2026-08-27. Sesión sin humano viendo en vivo (rutina programada).*

---
_Generated by [Claude Code](https://claude.ai/code/session_016CriNezL39ZRcZhRP2ujYE)_